### PR TITLE
Keep ripgrep searches out of generated directories

### DIFF
--- a/coworker/tools/search.py
+++ b/coworker/tools/search.py
@@ -96,12 +96,13 @@ def search_tools(workspace: str) -> list:
                 "-e",
                 pattern,
             ]
-            # Do not rely solely on a workspace's .gitignore: the Python fallback
-            # always omits these generated/dependency directories too.
-            for ignored in sorted(_IGNORE_DIRS):
-                cmd += ["--glob", f"!**/{ignored}/**"]
             if glob:
                 cmd += ["--glob", glob]
+            # Do not rely solely on a workspace's .gitignore: the Python fallback
+            # always omits these generated/dependency directories too. Exclusions come
+            # last because ripgrep resolves conflicting globs with the later one winning.
+            for ignored in sorted(_IGNORE_DIRS):
+                cmd += ["--glob", f"!**/{ignored}/**"]
             cmd.append(str(base))
             try:
                 out = subprocess.run(cmd, capture_output=True, text=True, timeout=30)

--- a/coworker/tools/search.py
+++ b/coworker/tools/search.py
@@ -96,6 +96,10 @@ def search_tools(workspace: str) -> list:
                 "-e",
                 pattern,
             ]
+            # Do not rely solely on a workspace's .gitignore: the Python fallback
+            # always omits these generated/dependency directories too.
+            for ignored in sorted(_IGNORE_DIRS):
+                cmd += ["--glob", f"!**/{ignored}/**"]
             if glob:
                 cmd += ["--glob", glob]
             cmd.append(str(base))

--- a/tests/test_code_tools.py
+++ b/tests/test_code_tools.py
@@ -37,6 +37,7 @@ def test_grep_finds_matches_and_respects_glob(tmp_path):
     # glob filter restricts to python files
     only_py = grep(pattern="hello", glob="*.py")
     assert all(m["file"].endswith(".py") for m in only_py["matches"])
+    assert not any("node_modules" in m["file"] for m in only_py["matches"])
     assert only_py["matches"][0]["line"] == 1
 
 
@@ -52,11 +53,12 @@ def test_ripgrep_uses_the_same_ignored_dirs_as_the_python_fallback(tmp_path, mon
         or SimpleNamespace(returncode=0, stdout="", stderr=""),
     )
 
-    search_tools(str(tmp_path))[0](pattern="hello")
+    search_tools(str(tmp_path))[0](pattern="hello", glob="*.py")
 
     assert commands
+    user_glob = commands[0].index("*.py")
     for ignored in search._IGNORE_DIRS:
-        assert f"!**/{ignored}/**" in commands[0]
+        assert commands[0].index(f"!**/{ignored}/**") > user_glob
 
 
 def test_grep_rejects_path_escape(tmp_path):

--- a/tests/test_code_tools.py
+++ b/tests/test_code_tools.py
@@ -7,6 +7,7 @@ against temp dirs (git_log needs a real `git`, which the dev box has).
 from __future__ import annotations
 
 import subprocess
+from types import SimpleNamespace
 
 import pytest
 
@@ -37,6 +38,25 @@ def test_grep_finds_matches_and_respects_glob(tmp_path):
     only_py = grep(pattern="hello", glob="*.py")
     assert all(m["file"].endswith(".py") for m in only_py["matches"])
     assert only_py["matches"][0]["line"] == 1
+
+
+def test_ripgrep_uses_the_same_ignored_dirs_as_the_python_fallback(tmp_path, monkeypatch):
+    import coworker.tools.search as search
+
+    commands = []
+    monkeypatch.setattr(search.shutil, "which", lambda name: "rg")
+    monkeypatch.setattr(
+        search.subprocess,
+        "run",
+        lambda cmd, **kwargs: commands.append(cmd)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    search_tools(str(tmp_path))[0](pattern="hello")
+
+    assert commands
+    for ignored in search._IGNORE_DIRS:
+        assert f"!**/{ignored}/**" in commands[0]
 
 
 def test_grep_rejects_path_escape(tmp_path):


### PR DESCRIPTION
This keeps the ripgrep-backed `grep` tool consistent with the Python fallback.

When a workspace does not have a matching `.gitignore`, searches could include `node_modules`, `dist`, and similar generated directories. The exclusions are explicit now, and they are applied after a caller-provided glob so they still win when the patterns overlap.

The tests cover the `glob="*.py"` case and assert the ripgrep flag order.

Checks run:
- `.venv/bin/pytest tests/test_code_tools.py -q`

Fixes #7