### PR TITLE
Fix setup_dev_env.sh on Windows (Scripts/ layout, python -m pip, rela… Closes #9

### DIFF
--- a/packaging/setup_dev_env.sh
+++ b/packaging/setup_dev_env.sh
@@ -11,12 +11,19 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VENV="$ROOT/.venv"
 
 python3 -m venv "$VENV"
+# venv puts executables in Scripts/ on Windows (Git Bash) and bin/ on Unix/WSL.
+if [ -d "$VENV/Scripts" ]; then BIN="$VENV/Scripts"; else BIN="$VENV/bin"; fi
+
 # The coworker package (server, engine, connectors) + inbound-messaging extras.
 # aisuite comes in as a regular dependency (git-pinned in pyproject.toml until
 # the next PyPI release).
-"$VENV/bin/pip" install --quiet --upgrade pip
-"$VENV/bin/pip" install --quiet -e "$ROOT[messaging,dev]"
+# Use `python -m pip` (not the pip launcher) so pip can upgrade itself on
+# Windows, where the running pip.exe is locked against modification.
+"$BIN/python" -m pip install --quiet --upgrade pip
+# Install from "." inside $ROOT rather than an absolute path: under Git Bash the
+# MSYS-style $ROOT (/h/...) is not resolvable by the native Windows pip.
+(cd "$ROOT" && "$BIN/python" -m pip install --quiet -e ".[messaging,dev]")
 
-"$VENV/bin/python" -c 'import aisuite, coworker' # fail loudly if the wiring broke
+"$BIN/python" -c 'import aisuite, coworker' # fail loudly if the wiring broke
 echo "Ready: $VENV"
-echo "  server: $VENV/bin/openworker-server --cwd /path/to/your/project --port 8765"
+echo "  server: $BIN/openworker-server --cwd /path/to/your/project --port 8765"


### PR DESCRIPTION
## What

This PR fixes `packaging/setup_dev_env.sh` so it works correctly on **Windows via Git Bash**, as documented in the README.

### Changes

1. **Support Windows virtual environment layout**

   * Detects whether the virtual environment uses `.venv/Scripts/` (Windows) or `.venv/bin/` (Linux/macOS/WSL).
   * Uses the correct executable path accordingly.

2. **Use `python -m pip` instead of invoking `pip` directly**

   * Replaces direct `pip` execution with `python -m pip`, which is the recommended and more reliable approach across platforms.
   * Avoids issues where `pip.exe` cannot update itself on Windows.

3. **Install local packages using the project directory**

   * Installs editable packages from the project root instead of relying on MSYS path conversion.
   * Prevents Windows Git Bash from passing invalid paths to native Python.

These changes are backward compatible with Linux/macOS/WSL and require no changes to existing Unix workflows.

---

## Testing

**Environment**

* Windows 11
* Git Bash
* Python 3.12

### Before

```text
packaging/setup_dev_env.sh: line 17: .venv/bin/pip: No such file or directory
```

The virtual environment was created successfully, but the bootstrap script failed because it expected a Unix-style `.venv/bin` layout.

### After

*  `packaging/setup_dev_env.sh` completes successfully in Git Bash.
*  All dependencies are installed.
*  The development environment is set up without requiring WSL.
*  Verified that the changes remain compatible with Linux/macOS by preserving the existing `.venv/bin` behavior.
