### PR TITLE
Raise Python floor to 3.11 in docs and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ OpenWorker is local-first. Everything lives on your machine: the agent loop, you
 
 ## Run from source
 
-Prerequisites: Python 3.10+, Node 20+, and (for the desktop shell) the Rust toolchain via [rustup](https://rustup.rs/).
+Prerequisites: Python 3.11+, Node 20+, and (for the desktop shell) the Rust toolchain via [rustup](https://rustup.rs/).
 
 ```shell
 git clone https://github.com/andrewyng/openworker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "coworker"
 version = "0.0.0"
 description = "Agent coworker platform — provider-agnostic agentic coworker runtime"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "openai>=1.0",
     "anthropic>=0.40",  # native Claude Messages API provider


### PR DESCRIPTION
Closes #13.

`pyproject.toml` declared `requires-python = ">=3.10"` and the README listed Python 3.10+ as a prerequisite, but `coworker/config.py` imports `tomllib`, which is stdlib only in 3.11+. On a fresh clone where `python3` is 3.10, `packaging/setup_dev_env.sh` succeeds and pytest then fails at collection with `ModuleNotFoundError: No module named 'tomllib'`.

Two one-line changes: `>=3.10` to `>=3.11` in `pyproject.toml`, and Python 3.10+ to 3.11+ in the README prerequisites. No `tomli` backport, since CI and the release workflow already pin 3.12 and 3.10 reaches EOL in October 2026.

Verified with a clean python3.12 venv: `pip install -e ".[messaging,dev]"` then `pytest tests -q` gives 3 failed, 849 passed, 1 skipped. The 3 failures (`test_grep_finds_matches_and_respects_glob`, `test_manager_curated_models`, `test_provider_set_and_remove_roundtrip`) are pre-existing on main and unrelated.

Possible follow-ups, not in this PR: a fail-fast version check in `packaging/setup_dev_env.sh`, and a `tomli` conditional dependency if 3.10 support is ever actually wanted.