### PR TITLE
Stabilize curated Ollama model test

### DIFF
--- a/tests/test_provider_router.py
+++ b/tests/test_provider_router.py
@@ -332,7 +332,9 @@ def test_manager_curated_models(tmp_path, monkeypatch):
     assert "anthropic:claude-opus-4-8" in models
     assert "gpt-4o" not in models  # no OpenAI seed anywhere
 
-    added = mgr.add_model("ollama:qwen2.5-coder:32b")  # keyless provider → selectable
+    # Custom Ollama models are shown only while the local service is reachable.
+    monkeypatch.setattr(SessionManager, "_ollama_alive", lambda self: True)
+    added = mgr.add_model("ollama:qwen2.5-coder:32b")
     assert added["ok"] and "ollama:qwen2.5-coder:32b" in added["models"]
 
     n = len(mgr.get_settings()["models"])


### PR DESCRIPTION
This fixes the failing curated-model test.

The application intentionally shows custom Ollama models only when the local service is reachable, but this test relied on whatever happened to be running in the environment. CI has no Ollama service, so the assertion failed even though the behavior was correct.

The test now explicitly marks Ollama as reachable before checking that a custom Ollama model appears in the picker.

Checks run:
- `.venv/bin/pytest tests/test_provider_router.py::test_manager_curated_models tests/test_settings.py::test_ollama_models_gated_on_liveness -q`
- `.venv/bin/pytest tests -q`