### PR TITLE
Add Linux support: AppImage distribution + voice input & keep-awake

### DIFF
--- a/packaging/build_appimage.sh
+++ b/packaging/build_appimage.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Build the Linux desktop app as an AppImage.
+#
+#   1. PyInstaller-bundle the server into a standalone onedir folder (no venv at runtime).
+#   2. Stage it at binaries/sidecar/ for Tauri's `resources` slot.
+#   3. `tauri build --bundles appimage` → OpenWorker_<version>_<arch>.AppImage
+#      (+ updater artifacts OpenWorker_<version>_<arch>.AppImage.tar.gz + .sig when the
+#      updater signing key is available).
+#
+# Why AppImage: OpenWorker is a host-acting agent (shell, files, MCP subprocesses), so a
+# sandboxed format (Flatpak/Snap) would fight the app's nature. AppImage ships one portable
+# file with full host access — and it is the ONLY Linux bundle the Tauri updater supports,
+# so picking it keeps auto-update working (deb/rpm throw "Cannot run updater on this Linux
+# package" at install time).
+#
+# Prerequisites (mirrors build_dmg.sh's header):
+#   - Rust (rustup) + Node/npm, and the GUI deps installed (npm ci in surfaces/gui).
+#   - A Python venv at .venv (repo root) with this package installed editable, plus the
+#     build-only deps:
+#       python3.12 -m venv .venv
+#       .venv/bin/pip install -e . pyinstaller typer
+#     `typer` is needed only at BUILD time: PyInstaller walks the `mcp` package and
+#     `mcp.cli` calls sys.exit() at import if typer is absent, which aborts the freeze.
+#     (aisuite installs like any other dependency — git-pinned in pyproject.toml.)
+#   - Tauri's Linux build-time libs. Fedora:
+#       dnf install webkit2gtk4.1-devel gtk3-devel libappindicator-gtk3-devel \
+#                   librsvg2-devel libsoup3-devel patchelf alsa-lib-devel
+#     Debian/Ubuntu:
+#       apt install libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev \
+#                   librsvg2-dev libsoup-3.0-dev patchelf libasound2-dev
+#     `alsa-lib-devel` / `libasound2-dev` is required by cpal (the STT sidecar's audio
+#     backend) — without alsa.pc the `ocw-stt` crate fails to compile.
+#     Tauri downloads appimagetool + linuxdeploy itself on first build.
+#     (At runtime an AppImage needs webkit2gtk-4.1, gtk3, libsoup3-3.0, libasound2 on the
+#     host — standard on any modern distro.)
+#
+# AUTO-UPDATE (optional): set TAURI_SIGNING_PRIVATE_KEY to produce the .AppImage.tar.gz +
+# .sig artifacts the updater manifest (packaging/make_update_manifest.py) references.
+# From the env, or from `.ocw-updater.env` one directory above the repo (same convention
+# as build_dmg.sh). Keyless builds skip the overlay entirely so dev/fork builds still work;
+# a keyless RELEASE would strand every install without auto-update, hence the loud warning.
+#
+# Experimental (use-at-your-own-risk) connectors are EXCLUDED from this build by default —
+# the spec strips coworker.connectors.experimental. Self-builders can opt in with:
+#   COWORKER_EXPERIMENTAL=1 ./build_appimage.sh
+set -euo pipefail
+
+# NO_STRIP=1: linuxdeploy bundles its own `strip` (an old GNU binutils inside the
+# AppImage) that predates the `.relr.dyn` ELF section (type 0x13, SHT_RELR, added in
+# binutils 2.31). Libraries built on modern distros (Fedora 40+, recent Ubuntu) carry
+# that section, so the bundled strip rejects EVERY .so ("unknown type [0x13] section
+# `.relr.dyn'") and linuxdeploy aborts. NO_STRIP tells linuxdeploy-plugin-appimage to
+# skip the strip pass entirely — the libraries are already release builds, so the only
+# cost is keeping their (typically already-stripped) debug sections. Harmless on older
+# distros too, so set unconditionally.
+export NO_STRIP=1
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PLATFORM="$(cd "$HERE/.." && pwd)"
+GUI="$PLATFORM/surfaces/gui"
+APP="OpenWorker"
+# Single source of truth for the version: tauri.conf.json (also stamps the bundle).
+VERSION="$(node -p "require('$GUI/src-tauri/tauri.conf.json').version")"
+TRIPLE="$(rustc -vV | sed -n 's/host: //p')"   # e.g. x86_64-unknown-linux-gnu
+ARCH="${TRIPLE%%-*}"                            # x86_64 | aarch64
+# AppImage bundle naming (and Tauri's --target) uses the Debian arch convention,
+# not the GNU triple: x86_64 -> amd64, aarch64 -> arm64.
+case "$ARCH" in
+  x86_64) BUNDLE_ARCH="amd64";;
+  aarch64) BUNDLE_ARCH="arm64";;
+  *) BUNDLE_ARCH="$ARCH";;
+esac
+
+echo "==> [1/3] PyInstaller: bundling openworker-server ($TRIPLE)"
+"$PLATFORM/.venv/bin/pyinstaller" --noconfirm --clean \
+  --distpath "$HERE/dist" --workpath "$HERE/build" "$HERE/openworker-server.spec"
+
+echo "==> [2/3] staging sidecar resources"
+# Onedir bundle (exe + _internal/) ships via Tauri `resources` as usr/lib/<binary>/sidecar/
+# inside the AppImage (see server_bin()'s Linux candidate in src-tauri/src/lib.rs). rm -rf
+# first: cp writes through a symlink at the destination; also clears any stale onefile binary
+# from pre-onedir builds.
+mkdir -p "$GUI/src-tauri/binaries"
+rm -rf "$GUI/src-tauri/binaries/sidecar" "$GUI/src-tauri/binaries/openworker-server-$TRIPLE"
+# -RL (dereference): Tauri's resource bundler flattens symlinks into duplicate REAL files.
+# Dereferencing at staging makes what tauri COPIES deterministic; no framework layout is
+# produced on Linux (unlike macOS), but dereferencing keeps the two build scripts identical
+# and avoids any stray symlink surviving into the AppDir.
+cp -RL "$HERE/dist/openworker-server" "$GUI/src-tauri/binaries/sidecar"
+if [ -n "$(find "$GUI/src-tauri/binaries/sidecar" -type l | head -1)" ]; then
+  echo "ERROR: symlinks survived sidecar staging — tauri would flatten them into duplicates" >&2
+  exit 1
+fi
+chmod +x "$GUI/src-tauri/binaries/sidecar/openworker-server"
+
+echo "==> [3/3] tauri build (AppImage)"
+# Auto-update artifacts (.AppImage.tar.gz + minisign .sig): produced only when the updater
+# signing key is available — from the env (CI secret TAURI_SIGNING_PRIVATE_KEY), or from
+# `.ocw-updater.env` one directory above the repo (same convention as the notary env on macOS).
+# Keyless builds skip the overlay entirely so dev/fork builds keep working; keyless RELEASES
+# would strand every install without auto-update, hence the loud warning.
+UPDATER_ENV="${OCW_UPDATER_ENV:-$PLATFORM/../.ocw-updater.env}"
+if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ] && [ -f "$UPDATER_ENV" ]; then
+  # shellcheck disable=SC1090
+  source "$UPDATER_ENV"
+fi
+UPDATER_OVERLAY=()
+if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+  UPDATER_OVERLAY=(--config '{"bundle":{"createUpdaterArtifacts":true}}')
+else
+  echo "    WARNING: no updater signing key — building WITHOUT auto-update artifacts (not releasable)."
+fi
+# ${arr[@]+…} guard: plain "${arr[@]}" on an EMPTY array is an "unbound variable" under set -u.
+# NO_STRIP=1 is exported at the top of this script (see comment there).
+( cd "$GUI" && npm run tauri build -- --bundles appimage ${UPDATER_OVERLAY[@]+"${UPDATER_OVERLAY[@]}"} )
+
+BUNDLE="$GUI/src-tauri/target/release/bundle/appimage"
+APPIMAGE="$BUNDLE/${APP}_${VERSION}_${BUNDLE_ARCH}.AppImage"
+
+if [ ! -f "$APPIMAGE" ]; then
+  echo "ERROR: expected AppImage not found at $APPIMAGE" >&2
+  echo "       (Tauri may have named it differently — check $BUNDLE/)" >&2
+  exit 1
+fi
+
+echo ""
+echo "Done → $APPIMAGE"
+echo "  run:      chmod +x \"$APPIMAGE\" && \"$APPIMAGE\""
+echo "  update:   (set TAURI_SIGNING_PRIVATE_KEY to also emit the .tar.gz + .sig for the updater manifest)"

--- a/packaging/make_update_manifest.py
+++ b/packaging/make_update_manifest.py
@@ -35,6 +35,7 @@ import sys
 ARTIFACTS = {
     "OpenWorker-macos-arm64.app.tar.gz": "darwin-aarch64",
     "OpenWorker-windows-setup.exe": "windows-x86_64",
+    "OpenWorker-linux-x86_64.AppImage.tar.gz": "linux-x86_64",
 }
 
 

--- a/stt/src/lib.rs
+++ b/stt/src/lib.rs
@@ -33,6 +33,24 @@ pub const DEFAULT_MODEL_SHA256: &str =
     "a03779c86df3323075f5e796cb2ce5029f00ec8869eee3fdfb897afe36c6d002";
 const WHISPER_SAMPLE_RATE: u32 = 16_000;
 
+/// Whether a microphone is reachable from the default CPAL host.
+///
+/// Hosts call this to decide whether to offer voice input at all. On Linux it is the only
+/// gate — the STT engine itself (cpal ALSA backend + whisper-rs on CPU) runs on any arch,
+/// so a missing or unreachable input device cleanly disables voice input instead of failing
+/// at record time. Wrapped in `catch_unwind` so a misbehaving audio stack can never crash the
+/// host: a panic here just reports "no microphone".
+///
+/// Cheap enough for a UI compatibility probe: it enumerates devices but opens no stream.
+pub fn input_device_available() -> bool {
+    std::panic::catch_unwind(|| {
+        cpal::default_host()
+            .default_input_device()
+            .is_some()
+    })
+    .unwrap_or(false)
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct DictationStatus {
     pub recording: bool,
@@ -459,7 +477,7 @@ fn start_recording() -> Result<Recording, String> {
     let host = cpal::default_host();
     let device = host
         .default_input_device()
-        .ok_or_else(|| "No microphone is available. Check your Mac sound settings.".to_owned())?;
+        .ok_or_else(|| "No microphone is available. Check your sound settings.".to_owned())?;
     let supported = device
         .default_input_config()
         .map_err(|e| format!("Could not open the microphone: {e}"))?;

--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -51,7 +51,7 @@ fn free_port() -> u16 {
 ///      builds used Tauri externalBin).
 ///   4. Dev fallback: the repo venv, relative to this crate (`src-tauri` → `platform/.venv`;
 ///      `bin/` on POSIX, `Scripts\` on Windows).
-fn server_bin() -> PathBuf {
+fn server_bin(product_name: Option<&str>) -> PathBuf {
     if let Ok(p) = std::env::var("COWORKER_SERVER_BIN") {
         return PathBuf::from(p);
     }
@@ -65,8 +65,20 @@ fn server_bin() -> PathBuf {
             // macOS: Contents/MacOS/<app> → Contents/Resources/sidecar/; Windows: resources
             // unpack next to the exe, so <install>/sidecar/.
             let mut candidates = vec![dir.join("sidecar").join(exe_name)];
-            if let Some(contents) = dir.parent() {
-                candidates.push(contents.join("Resources").join("sidecar").join(exe_name));
+            if let Some(parent) = dir.parent() {
+                // macOS: <bundle>/Contents/MacOS/<app> → Contents/Resources/sidecar/.
+                candidates.push(parent.join("Resources").join("sidecar").join(exe_name));
+                // Linux (AppImage / deb / rpm): the exe ships in usr/bin/ while Tauri
+                // unpacks `resources` to usr/lib/<productName>/ (NOT the cargo pkg name —
+                // verified in a built AppImage: usr/bin/openworker-desktop but
+                // usr/lib/OpenWorker/sidecar/). product_name comes from the Tauri config so
+                // this never desyncs from tauri.conf.json. Without this candidate the server
+                // is never found inside a bundled AppImage and the GUI stalls on "Starting
+                // coworker…".
+                #[cfg(target_os = "linux")]
+                if let Some(name) = product_name {
+                    candidates.push(parent.join("lib").join(name).join("sidecar").join(exe_name));
+                }
             }
             candidates.push(dir.join(exe_name)); // legacy onefile externalBin slot
             for c in candidates {
@@ -141,7 +153,8 @@ fn write_keep_awake_pref(enabled: bool) {
 // Cross-platform behind a uniform `start_keep_awake() -> Option<KeepAwakeGuard>`; dropping the
 // guard releases the hold. macOS uses the built-in `caffeinate`; Windows uses the
 // SetThreadExecutionState API (a dedicated thread holds ES_CONTINUOUS so the state survives
-// regardless of which Tauri worker thread toggled it); other platforms are a no-op.
+// regardless of which Tauri worker thread toggled it); Linux uses `systemd-inhibit` when
+// available, falling back to a no-op on systems without systemd (containers, some WSL setups).
 
 #[cfg(target_os = "macos")]
 struct KeepAwakeGuard(Child);
@@ -210,13 +223,43 @@ fn start_keep_awake() -> Option<KeepAwakeGuard> {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-struct KeepAwakeGuard;
+struct KeepAwakeGuard(Option<Child>);
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+impl Drop for KeepAwakeGuard {
+    fn drop(&mut self) {
+        // Killing the child (systemd-inhibit) releases the sleep hold, mirroring macOS's
+        // caffeinate kill. None on the no-op fallback path.
+        if let Some(mut child) = self.0.take() {
+            let _ = child.kill();
+        }
+    }
+}
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn start_keep_awake() -> Option<KeepAwakeGuard> {
-    // No portable built-in inhibitor on Linux; keep-awake is a no-op (the toggle still reflects
-    // state so the UI behaves, but the OS sleep policy is left to the user).
-    Some(KeepAwakeGuard)
+    // Try systemd-inhibit (present on virtually every modern Linux distro). `--mode=block`
+    // holds the inhibition for as long as the child (`sleep infinity`) is alive; killing the
+    // child here releases the hold, mirroring macOS's caffeinate.
+    // If systemd-inhibit is absent or spawn fails (containers, non-systemd distros, WSL without
+    // systemd), fall back to a no-op guard so the toggle still reflects state but the OS sleep
+    // policy is left to the user — same behaviour as before this change. Detection is runtime:
+    // there is no build-time guarantee systemd is present, so we probe instead of assuming.
+    Command::new("systemd-inhibit")
+        .args([
+            "--what=sleep",
+            "--why=OpenWorker is working",
+            "--mode=block",
+            "sleep",
+            "infinity",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()
+        .map(|child| KeepAwakeGuard(Some(child)))
+        .or_else(|| Some(KeepAwakeGuard(None)))
 }
 
 // -- native commands (invoked from the SPA via window.__TAURI__.core.invoke) -----------------
@@ -366,11 +409,32 @@ fn voice_input_compatibility() -> (bool, String, Option<String>) {
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn voice_input_compatibility() -> (bool, String, Option<String>) {
-    (
-        false,
-        format!("{} · {}", std::env::consts::OS, std::env::consts::ARCH),
-        Some("Voice Input is currently supported on macOS and Windows.".to_owned()),
-    )
+    // The STT engine (cpal ALSA backend + whisper-rs on CPU) builds and runs on Linux, so the
+    // only gate is whether a microphone is reachable. Probe cpal at runtime so voice input is
+    // offered on Linux desktops with audio input and cleanly disabled elsewhere (headless
+    // servers, containers without ALSA, WSL without an audio sink) — exactly the pattern the UI
+    // already handles via `supported` + `compatibility_reason`.
+    let arch = std::env::consts::ARCH;
+    let summary = format!("{} · {}", std::env::consts::OS, arch);
+    let (supported, reason) = if arch != "x86_64" && arch != "aarch64" {
+        (
+            false,
+            Some(format!(
+                "Voice Input is not built for the {arch} architecture on Linux."
+            )),
+        )
+    } else if !ocw_stt::input_device_available() {
+        (
+            false,
+            Some(
+                "No microphone is available. Connect an audio input device and check your sound settings."
+                    .to_owned(),
+            ),
+        )
+    } else {
+        (true, None)
+    };
+    (supported, summary, reason)
 }
 
 #[tauri::command]
@@ -620,7 +684,7 @@ pub fn run() {
         ])
         .setup(move |app| {
             // 1. Start the Python server sidecar on the chosen port (inherits our env).
-            let mut server_cmd = Command::new(server_bin());
+            let mut server_cmd = Command::new(server_bin(app.config().product_name.as_deref()));
             server_cmd
                 .args(["--host", "127.0.0.1", "--port", &port.to_string()])
                 // The sidecar self-exits if we die abruptly (dev-watcher restart, crash) —


### PR DESCRIPTION
## Summary

OpenWorker currently ships for macOS (DMG) and Windows (NSIS/MSI) only. This PR adds Linux as a first-class desktop target.

- **Distribution:** AppImage build pipeline (`packaging/build_appimage.sh`), parallel to the existing `build_dmg.sh` / `build_windows.ps1`.
- **Voice input (STT):** enabled on Linux where a microphone is reachable (runtime probe), cleanly disabled with a user-facing message otherwise.
- **Keep-awake:** implemented on Linux via `systemd-inhibit`, with a no-op fallback for non-systemd environments.
- **Auto-update:** the AppImage artifact is added to the updater manifest so Linux stays at parity with macOS/Windows.

## Why AppImage (not Flatpak/Snap)

OpenWorker is a host-acting agent — it runs shell commands, writes files, and spawns MCP subprocesses. A sandboxed bundle format would fight the app's core nature. AppImage ships one portable file with full host access, and it is the **only** Linux bundle the Tauri updater supports, so picking it keeps auto-update working.

## What's enabled on Linux (runtime detection, graceful fallback)

Both features probe dependencies at runtime instead of using static gates — enabled where supported, disabled cleanly with a message where not.

| Feature | Mechanism | Fallback when unavailable |
|---|---|---|
| Voice input | cpal ALSA backend + whisper-rs on CPU; `voice_input_compatibility()` probes arch (x86_64/aarch64) and microphone reachability | Disabled with "No microphone is available…" on headless / no-ALSA / containers |
| Keep-awake | `systemd-inhibit --what=sleep --mode=block sleep infinity` | No-op (containers, WSL, non-systemd) |

The STT engine (cpal + whisper-rs) was already platform-agnostic; only an artificial macOS-only gate blocked it on Linux. A new public `input_device_available()` in the `stt` crate probes cpal with `catch_unwind`, so a misbehaving audio stack can never crash the host.

## Sidecar resolution

Inside an AppImage, Tauri places `resources` under `usr/lib/<productName>/` (not next to the exe). A new Linux candidate in `server_bin()` mirrors the macOS `Resources/` candidate. `productName` is read from the Tauri config at runtime (new `product_name` parameter) so it can never desync from `tauri.conf.json`.

## Tested environment

Verified end-to-end on:

- **OS:** Fedora Linux 44 (Workstation Edition)
- **Kernel:** 7.1.4-204.fc44.x86_64
- **Arch:** x86_64
- **Desktop:** GNOME on Wayland
- **Audio:** PipeWire 1.6.8 (cpal talks to ALSA → PipeWire)
- **Toolchain:** Rust 1.97.1, Node 22.22.2, Python 3.11.15

The built AppImage launches, the Python sidecar is found at the correct path and serves the UI (all HTTP 200s), and voice input transcribes correctly (9.7s English dictation verified).

**Python version:** built and verified on **Python 3.11.15**. The true floor is 3.11 (not 3.12): `coworker/config.py` imports `tomllib`, which is stdlib only in 3.11+ — on 3.10 the server sidecar crashes at startup with `ModuleNotFoundError: No module named 'tomllib'` (verified empirically with a 3.10.20 interpreter). Nothing in the code or dependencies requires 3.12. This is consistent with PR #14, which raises the declared floor from `>=3.10` to `>=3.11` in `pyproject.toml` and the README to formalize this same requirement.

## Potential compatible distributions

**Expected to work** on any modern distro shipping **webkit2gtk-4.1** (the Tauri 2 hard requirement) — *not yet verified, only Fedora 44 was tested*:

| Distro | Notes |
|---|---|
| Fedora 38+ | webkit2gtk4.1 available |
| Ubuntu 24.04 LTS | `libwebkit2gtk-4.1-0` |
| Ubuntu 22.04 LTS | webkit2gtk-4.1 available |
| Debian 12 (bookworm) | `libwebkit2gtk-4.1-dev` |
| Arch Linux | rolling |
| openSUSE Tumbleweed | rolling |

Older distros with only webkit2gtk-4.0 are **not** compatible (Tauri 2 requires the 4.1 API).

## Requirements

### Runtime (to run the AppImage)
- `webkit2gtk-4.1`, `gtk3`, `libsoup3`, `libappindicator-gtk3`, `librsvg2`
- `libasound2` / `alsa-lib` — for voice input (cpal's audio backend)
- `systemd` — for keep-awake (optional; app degrades to no-op without it)
- Python is **not** a runtime requirement (the sidecar is PyInstaller-bundled into the AppImage)

### Build (to produce the AppImage)
- Rust (rustup) + Node/npm + Python **3.11+** with `pyinstaller` and `typer`
- Tauri Linux build-time libs (devel variants of the runtime libs above) + `patchelf`
- `alsa-lib-devel` / `libasound2-dev` — cpal needs `alsa.pc` to compile

Build with:
```bash
./packaging/build_appimage.sh
# → surfaces/gui/src-tauri/target/release/bundle/appimage/OpenWorker_<ver>_amd64.AppImage
```

> The script exports `NO_STRIP=1`: linuxdeploy bundles an old GNU `binutils` whose `strip` rejects the `.relr.dyn` ELF section (SHT_RELR) found in libraries built on modern distros (Fedora 40+, recent Ubuntu). Harmless on older distros.

## No impact on macOS / Windows

All Linux changes are `cfg(target_os = "linux")`-gated. The `server_bin()` signature change is source-compatible (`product_name` is ignored on macOS/Windows). `tauri.conf.json` is untouched. A CI `cargo check` for the macOS/Windows targets before merge would be prudent to confirm clean compilation, but no behavioral change is expected.

## Files changed

| File | Change |
|---|---|
| `packaging/build_appimage.sh` | **new** — AppImage build script |
| `surfaces/gui/src-tauri/src/lib.rs` | Linux sidecar candidate, keep-awake, voice-input gate |
| `stt/src/lib.rs` | `input_device_available()` + genericized error message |
| `packaging/make_update_manifest.py` | `linux-x86_64` updater artifact entry |