### PR TITLE
fix(automation): align cron day-of-week labels with standard cron (0=Sunday)

### DIFF
--- a/coworker/automation/models.py
+++ b/coworker/automation/models.py
@@ -10,7 +10,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-_DOW = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+_DOW = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
 
 def _now() -> float:

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -34,7 +34,8 @@ def _task(**kw) -> ScheduledTask:
 # -- model / schedule ----------------------------------------------------------
 def test_schedule_human():
     assert Schedule("cron", cron="10 19 * * *").human() == "Every day at ~7:10 PM"
-    assert "Monday" in Schedule("cron", cron="0 9 * * 0").human()
+    assert "Sunday" in Schedule("cron", cron="0 9 * * 0").human()
+    assert "Monday" in Schedule("cron", cron="0 9 * * 1").human()
     assert Schedule("cron", cron="0 9 5 * *").human() == "Monthly on day 5 at ~9:00 AM"
     assert Schedule("once", fire_at="2026-07-01T09:00:00").human().startswith("Once at")
 


### PR DESCRIPTION
Closes #18

Standard cron treats the day-of-week field as Sunday-indexed (`0` = Sunday, `1` = Monday, ... `6` = Saturday, `7` = Sunday), and the scheduler resolves fire times with croniter, which follows that convention. `_DOW` in `coworker/automation/models.py` started on Monday, so every weekly automation label was shifted by one day: a task scheduled with `0 9 * * 0` fires on **Sunday** but was rendered as "Every Monday at ~9:00 AM".

**Change**
- Reorder `_DOW` to start on Sunday. The existing `% 7` keeps `7` → Sunday working.
- Update the test assertion that codified the shifted label, and add a `dow=1` → Monday case.

**Testing**
- `pytest tests/test_automation.py` — fails before the fix (`assert 'Sunday' in 'Every Monday at ~9:00 AM'`), 17 passed after.
- Full suite: everything passes except the pre-existing `test_manager_curated_models` failure on machines without a local Ollama service, already addressed by #15 (unrelated to this change).
