### PR TITLE
Parse inbox reply intent from the leading word, not substrings

### DIFF
--- a/coworker/inbox_routing.py
+++ b/coworker/inbox_routing.py
@@ -23,9 +23,6 @@ DEFAULT_INBOX = "default"
 # to OpenWorker (2026-07-22); the legacy [ocw:…] spelling stays parseable so replies to
 # messages sent before the rename still resolve.
 _ID_TOKEN = re.compile(r"\[o(?:c)?w:([0-9a-f]{6,})\]")
-# Whole words only — substring matching resolved "disallow" as allow and "note" as deny.
-_ALLOW_WORDS = re.compile(r"\b(?:approve|approved|allow|allowed|yes)\b")
-_DENY_WORDS = re.compile(r"\b(?:deny|denied|reject|rejected|no)\b")
 
 
 @dataclass
@@ -120,23 +117,48 @@ def deliver(item, binding: InboxBinding, sender: Optional[Sender]) -> bool:
     return True
 
 
+# Decision keywords for a channel reply. Matched against the reply's LEADING word/emoji
+# only (see _reply_intent). Substring matching turned "disallow" into allow and "note"
+# into deny; whole-word matching anywhere (the interim fix) still inverted negated
+# replies — "I cannot approve this yet" matched \bapprove\b and, with allow checked
+# first, executed the declined action. Leading-word intent keeps "Yes, go ahead" /
+# "No." / "👍" working; everything else is a free-text answer, which the approval path
+# already maps to deny — the safe default for an approval gate.
+_ALLOW_WORDS = frozenset({"approve", "approved", "allow", "allowed", "yes"})
+_DENY_WORDS = frozenset({"deny", "denied", "reject", "rejected", "no"})
+_ALLOW_EMOJI = ("👍", "✅")
+_DENY_EMOJI = ("👎", "❌")
+_TOKEN_TRIM = ".,!?:;'\"()"
+
+
+def _reply_intent(text: str) -> Optional[str]:
+    """Allow/deny intent from the first word (or emoji) of a reply, else None."""
+    first = text.split()[0] if text.split() else ""
+    if first.startswith(_ALLOW_EMOJI):  # startswith: tolerate skin-tone modifiers
+        return "allow"
+    if first.startswith(_DENY_EMOJI):
+        return "deny"
+    word = first.strip(_TOKEN_TRIM).lower()
+    if word in _ALLOW_WORDS:
+        return "allow"
+    if word in _DENY_WORDS:
+        return "deny"
+    return None
+
+
 def resolve_from_reply(
     reply: str, resolve: Callable[[str, str], bool]
 ) -> Optional[bool]:
     """Correlate an inbound channel reply to its item (by the embedded id) and resolve it.
 
-    Looks for the ``[ow:<id>]`` token (or legacy ``[ocw:…]``) and an allow/deny intent; falls back to treating the whole
-    message as a free-text answer. ``resolve(item_id, resolution)`` is the InboxStore.resolve.
+    Looks for the ``[ow:<id>]`` token (or legacy ``[ocw:…]``) and an allow/deny intent in the
+    reply's leading word; falls back to treating the whole message as a free-text answer.
+    ``resolve(item_id, resolution)`` is the InboxStore.resolve.
     Returns the resolve() result, or None if no item id was found."""
     m = _ID_TOKEN.search(reply or "")
     if not m:
         return None
     item_id = m.group(1)
-    lowered = reply.lower()
-    if _ALLOW_WORDS.search(lowered) or "👍" in reply or "✅" in reply:
-        resolution = "allow"
-    elif _DENY_WORDS.search(lowered) or "👎" in reply or "❌" in reply:
-        resolution = "deny"
-    else:
-        resolution = _ID_TOKEN.sub("", reply).strip()  # free-text answer to a question
+    text = _ID_TOKEN.sub("", reply).strip()
+    resolution = _reply_intent(text) or text  # free-text answer to a question
     return resolve(item_id, resolution)

--- a/tests/test_inbox_routing.py
+++ b/tests/test_inbox_routing.py
@@ -77,6 +77,53 @@ def test_inbound_freetext_answer_to_question(tmp_path):
     assert res is True and store.get(q.id).resolution == "us-east-1"
 
 
+def test_freetext_answer_containing_decision_substrings_stays_freetext(tmp_path):
+    """Decision intent comes from the LEADING word only — a free-text answer that merely
+    contains "no"/"yes" as a substring or mid-sentence word must not flip to deny/allow."""
+    store = InboxStore(tmp_path / "inbox.json")
+    for answer in (
+        "I have no preference — use us-east-1",
+        "yesterday's numbers look fine",
+        "the northern region",
+    ):
+        q = store.add_question("s1", "Which region?")
+        assert resolve_from_reply(f"{answer} [ow:{q.id}]", store.resolve) is True
+        assert store.get(q.id).resolution == answer
+
+
+def test_negated_approval_reply_does_not_allow(tmp_path):
+    """"I cannot approve this yet" used to resolve as ALLOW (substring match, allow words
+    checked first). It must fall through to free text, which the approver maps to deny."""
+    store = InboxStore(tmp_path / "inbox.json")
+    item = store.add_approval("s1", "Deploy?", inbox="ops")
+    assert resolve_from_reply(f"I cannot approve this yet [ow:{item.id}]", store.resolve)
+    assert store.get(item.id).resolution == "I cannot approve this yet"
+
+
+def test_leading_decision_word_and_emoji_still_resolve(tmp_path):
+    store = InboxStore(tmp_path / "inbox.json")
+    for reply, expected in (
+        ("Yes, go ahead", "allow"),
+        ("No.", "deny"),
+        ("👍", "allow"),
+        ("❌ too risky", "deny"),
+        ("allow", "allow"),
+        ("reject", "deny"),
+    ):
+        item = store.add_approval("s1", "Deploy?", inbox="ops")
+        assert resolve_from_reply(f"{reply} [ow:{item.id}]", store.resolve) is True
+        assert store.get(item.id).resolution == expected
+
+
+def test_decision_word_after_token_still_resolves(tmp_path):
+    """The [ow:…] token may lead the reply (e.g. a quoted redelivery) — intent is parsed
+    from the text with the token stripped, wherever it sits."""
+    store = InboxStore(tmp_path / "inbox.json")
+    item = store.add_approval("s1", "Deploy?", inbox="ops")
+    assert resolve_from_reply(f"[ow:{item.id}] approve", store.resolve) is True
+    assert store.get(item.id).resolution == "allow"
+
+
 def test_reply_without_token_is_ignored(tmp_path):
     store = InboxStore(tmp_path / "inbox.json")
     assert resolve_from_reply("random chatter", store.resolve) is None


### PR DESCRIPTION
## The bug

`resolve_from_reply` in `coworker/inbox_routing.py` decides whether an inbound Slack/Telegram reply is an allow, a deny, or a free-text answer by checking decision words as **substrings anywhere** in the message, with the allow words checked first:

```python
lowered = reply.lower()
if any(w in lowered for w in ("approve", "allow", "yes", "👍", "✅")):
    resolution = "allow"
elif any(w in lowered for w in ("deny", "reject", "no", "👎", "❌")):
    resolution = "deny"
```

Two failure modes, both reachable from any bound channel:

1. **Free-text answers get hijacked.** Replying `I have no preference — use us-east-1 [ow:…]` to an `ask_user` question resolves the item as `deny` (contains "no") instead of delivering the answer. `yesterday's numbers look fine` resolves as `allow` (contains "yes"). The suspended agent receives `allow`/`deny` as its "answer" and the user's actual text is lost.

2. **Negated approvals flip to allows.** `I cannot approve this yet [ow:…]` contains "approve", and allow words are checked first — so the pending action is **approved**. Since replies-from-channel is exactly the unattended flow where approval gating matters most, this one can execute an action the user explicitly declined.

## The fix

Intent is now parsed from the reply's **leading word or emoji** after the `[ow:…]`/`[ocw:…]` token is stripped. `Yes, go ahead`, `No.`, `deny`, `👍` (including skin-tone variants), `❌ too risky` all resolve exactly as before. Anything else falls through to the existing free-text path — which `inbox_approver` already maps to deny, the safe default for an approval gate.

No API or call-site changes; the keyword sets are unchanged.

## Tests

Added four tests to `tests/test_inbox_routing.py`: free-text answers containing decision substrings stay free text, the negated-approval reply no longer allows, leading decision words/emoji still resolve, and intent still parses when the token leads the reply. Full suite: 850 passed; the 7 pre-existing failures on `main` (FakeSlack socket tests + `test_ui_refresh_e2e`, absent the `messaging` extras) are unchanged.
