### PR TITLE
grep tool: parse ripgrep output correctly on Windows drive paths

### DIFF
--- a/coworker/tools/search.py
+++ b/coworker/tools/search.py
@@ -134,17 +134,22 @@ def _rel(path: str, root: Path) -> str:
         return path
 
 
+# One `path:line:text` match line. The path part must tolerate a Windows drive prefix:
+# a naive split(":", 2) on `C:\ws\a.py:12:text` yields file="C", line="\ws\a.py" — every
+# match garbled on Windows, where rg (invoked with an absolute base) echoes absolute paths.
+_RG_LINE = re.compile(r"^(?P<file>(?:[A-Za-z]:)?[^:]*):(?P<line>\d+):(?P<text>.*)$")
+
+
 def _parse_rg(stdout: str, root: Path, n: int) -> dict[str, Any]:
     matches: list[dict[str, Any]] = []
     for line in stdout.splitlines():
-        parts = line.split(":", 2)
-        if len(parts) == 3:
-            f, ln, txt = parts
+        m = _RG_LINE.match(line)
+        if m:
             matches.append(
                 {
-                    "file": _rel(f, root),
-                    "line": int(ln) if ln.isdigit() else 0,
-                    "text": txt[:300],
+                    "file": _rel(m["file"], root),
+                    "line": int(m["line"]),
+                    "text": m["text"][:300],
                 }
             )
         if len(matches) >= n:

--- a/tests/test_code_tools.py
+++ b/tests/test_code_tools.py
@@ -13,7 +13,7 @@ import pytest
 
 from coworker.tools.files import file_tools
 from coworker.tools.git import git_tools
-from coworker.tools.search import _py_grep, search_tools
+from coworker.tools.search import _parse_rg, _py_grep, search_tools
 from coworker.web.fetch import _html_to_text, make_web_fetch_tool
 
 
@@ -64,6 +64,29 @@ def test_ripgrep_uses_the_same_ignored_dirs_as_the_python_fallback(tmp_path, mon
 def test_grep_rejects_path_escape(tmp_path):
     grep = search_tools(str(tmp_path))[0]
     assert "escapes" in grep(pattern="x", path="../..")["error"]
+
+
+def test_parse_rg_posix_paths_and_colons_in_text(tmp_path):
+    root = tmp_path.resolve()
+    out = f"{root}/src/a.py:12:url = 'http://x:8080'\n"
+    res = _parse_rg(out, root, 100)
+    assert res["count"] == 1
+    m = res["matches"][0]
+    assert m["file"] == "src/a.py"
+    assert m["line"] == 12
+    assert m["text"] == "url = 'http://x:8080'"
+
+
+def test_parse_rg_windows_drive_paths(tmp_path):
+    """rg on Windows echoes absolute paths (`C:\\ws\\a.py:12:text`); a naive
+    split(':', 2) turned the drive letter into the filename and lost the line number."""
+    out = "C:\\ws\\src\\a.py:12:def hello():\n"
+    res = _parse_rg(out, tmp_path.resolve(), 100)
+    assert res["count"] == 1
+    m = res["matches"][0]
+    assert m["file"] == "C:\\ws\\src\\a.py"  # not 'C'
+    assert m["line"] == 12
+    assert m["text"] == "def hello():"
 
 
 def test_py_grep_fallback_skips_ignored_dirs(tmp_path):


### PR DESCRIPTION
## The bug

The `grep` tool invokes ripgrep with an **absolute** search base (`cmd.append(str(base))` in `coworker/tools/search.py`), so rg echoes absolute paths in its `path:line:text` output. `_parse_rg` then splits each line with `line.split(":", 2)` — which on Windows breaks on the drive letter:

```text
C:\ws\src\a.py:12:def hello():
└── file="C", line="\ws\src\a.py" (→ 0), text="12:def hello():"
```

Every match the agent sees on Windows has a one-letter filename, line 0, and the real line number glued to the front of the text — the tool is effectively unusable there, and the model can't cite or re-read anything it "found". POSIX is unaffected, which is why the existing tests (and everyday macOS use) never caught it.

## The fix

Match lines are parsed with a regex whose path group tolerates an optional `[A-Za-z]:` drive prefix and whose line group requires digits:

```python
_RG_LINE = re.compile(r"^(?P<file>(?:[A-Za-z]:)?[^:]*):(?P<line>\d+):(?P<text>.*)$")
```

POSIX paths and match text containing colons (URLs, timestamps) parse exactly as before; non-match lines are now skipped instead of misparsed, since the line group must be numeric.

## Tests

Two new tests in `tests/test_code_tools.py` exercise `_parse_rg` directly (it's a pure function, so the Windows shape is testable from any OS): a POSIX line with colons in the match text, and a Windows drive-letter line asserting the file isn't truncated to `C` and the line number survives. `tests/test_code_tools.py`: 16 passed.

Made with [Cursor](https://cursor.com)