### PR TITLE
feat(providers): add Groq and OpenRouter as first-class resellers

### DIFF
--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -11,9 +11,8 @@ falls back to the conservative heuristics in ``capabilities.py`` at their own ri
 degraded results. Ids verified against vendor/reseller catalogs on 2026-07-04; refresh the
 reseller rows when catalogs rotate (they rename on every model generation).
 
-Resellers: Together + Fireworks for now. TODO: add Groq and OpenRouter entries here AND their
-descriptors in ``registry.py`` once the current provider surface is tested — deliberately
-deferred to bound how much needs verifying at once.
+Resellers: Together, Fireworks, Groq, and OpenRouter. Each uses their own model namespaces;
+descriptors live in ``registry.py``.
 """
 
 from __future__ import annotations
@@ -102,6 +101,25 @@ MATRIX: dict[str, ModelEntry] = {
     ),
     "fireworks:accounts/fireworks/models/llama4-maverick-instruct-basic": ModelEntry(
         "Llama 4 Maverick · via Fireworks"
+    ),
+    # -- Groq (LPU inference) ---------------------------------------------------
+    "groq:llama-4-maverick-17b-128e-instruct": ModelEntry(
+        "Llama 4 Maverick · via Groq"
+    ),
+    "groq:deepseek-r1-distill-llama-70b": ModelEntry(
+        "DeepSeek R1 Distill 70B · via Groq"
+    ),
+    "groq:qwen-qwq-32b": ModelEntry("Qwen QwQ 32B · via Groq"),
+    # -- OpenRouter (multi-provider gateway) ------------------------------------
+    "openrouter:anthropic/claude-sonnet-4-6": ModelEntry(
+        "Claude Sonnet 4.6 · via OpenRouter", _AGENTIC_VISION
+    ),
+    "openrouter:google/gemini-2.5-flash": ModelEntry(
+        "Gemini 2.5 Flash · via OpenRouter", _AGENTIC_VISION
+    ),
+    "openrouter:deepseek/deepseek-r1": ModelEntry("DeepSeek R1 · via OpenRouter"),
+    "openrouter:meta-llama/llama-4-maverick": ModelEntry(
+        "Llama 4 Maverick · via OpenRouter"
     ),
 }
 

--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -308,9 +308,7 @@ DESCRIPTORS: list[ProviderDescriptor] = [
         env_key="MISTRAL_API_KEY",
     ),
     # Resellers: many labs' models behind one key, using THEIR model namespaces (the curated
-    # ids + display labels live in providers/matrix.py). TODO: add Groq and OpenRouter here
-    # (+ their matrix rows) once the current provider surface is tested — deliberately
-    # deferred to bound how much needs verifying at once (owner call, 2026-07-04).
+    # ids + display labels live in providers/matrix.py).
     _compat(
         "together",
         "Together AI",
@@ -324,6 +322,21 @@ DESCRIPTORS: list[ProviderDescriptor] = [
         base_url="https://api.fireworks.ai/inference/v1",
         recommended_model="accounts/fireworks/models/glm-5p2",
         env_key="FIREWORKS_API_KEY",
+    ),
+    _compat(
+        "groq",
+        "Groq",
+        base_url="https://api.groq.com/openai/v1",
+        recommended_model="llama-4-maverick-17b-128e-instruct",
+        env_key="GROQ_API_KEY",
+    ),
+    _compat(
+        "openrouter",
+        "OpenRouter",
+        base_url="https://openrouter.ai/api/v1",
+        recommended_model="anthropic/claude-sonnet-4-6",
+        env_key="OPENROUTER_API_KEY",
+        endpoint_help="Prefilled with OpenRouter's official endpoint. Supports 300+ models from all major providers behind one key.",
     ),
     ProviderDescriptor(
         name="ollama",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -381,6 +381,8 @@ def test_matrix_answers_capabilities_for_reseller_ids():
         "together:zai-org/GLM-5.2",
         "together:meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
         "fireworks:accounts/fireworks/models/kimi-k2p6",
+        "groq:llama-4-maverick-17b-128e-instruct",
+        "openrouter:anthropic/claude-sonnet-4-6",
     ):
         caps = capabilities_for(mid)
         assert caps.tools and caps.parallel_tool_calls and caps.streaming
@@ -407,7 +409,7 @@ def test_reseller_descriptors_and_matrix_stay_in_lockstep():
     from coworker.providers.matrix import models_for_provider
     from coworker.providers.registry import get_descriptor
 
-    for name in ("together", "fireworks"):
+    for name in ("together", "fireworks", "groq", "openrouter"):
         d = get_descriptor(name)
         assert d is not None and d.needs_key
         curated = models_for_provider(name)


### PR DESCRIPTION
## Summary

- Adds **Groq** and **OpenRouter** as first-class reseller providers, resolving the TODO in `matrix.py` and `registry.py` (deferred since 2026-07-04)
- Both use the existing `_compat` helper — zero new abstractions
- Curated matrix entries: 3 Groq models (Llama 4 Maverick, DeepSeek R1 Distill 70B, Qwen QwQ 32B) + 4 OpenRouter models (Claude Sonnet 4.6, Gemini 2.5 Flash, DeepSeek R1, Llama 4 Maverick)

## Details

| Provider | Base URL | Env key | Recommended model |
|----------|----------|---------|-------------------|
| Groq | `https://api.groq.com/openai/v1` | `GROQ_API_KEY` | `llama-4-maverick-17b-128e-instruct` |
| OpenRouter | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` | `anthropic/claude-sonnet-4-6` |

## Test plan

- [x] Matrix stays under 40 entries (37 total)
- [x] All matrix entries have `tools` capability
- [x] Reseller lockstep test extended — `recommended_model` in curated list for both
- [x] Capability assertions pass for new reseller model ids
- [x] Labels render correctly (`"Llama 4 Maverick · via Groq"`, etc.)

Re-raised after upstream force-push (per maintainer request on #6).

Closes #93