### PR TITLE
Confine browser_screenshot destination to the session's writable roots

### DIFF
--- a/coworker/connectors/browser_automation.py
+++ b/coworker/connectors/browser_automation.py
@@ -324,8 +324,27 @@ def _snapshot(page, max_chars: int) -> dict[str, Any]:
     }
 
 
-def make_browser_automation_tools() -> list[Callable[..., Any]]:
+def make_browser_automation_tools(
+    roots: Optional[list[Any]] = None,
+) -> list[Callable[..., Any]]:
     tools: list[Callable[..., Any]] = []
+
+    def _confine_screenshot_path(raw: str) -> tuple[Optional[Path], Optional[dict]]:
+        """Resolve a caller-supplied screenshot path inside a WRITABLE granted root.
+        browser_screenshot is registered read-kind so it never hits the approval prompt;
+        without this, a model-controlled `path` writes PNG bytes over ANY file (e.g. a
+        secrets store under $HOME). Mirrors the confinement every other write tool uses
+        (github_clone, email downloads). Relative paths resolve against the primary root."""
+        writable = [Path(r.path) for r in (roots or []) if getattr(r, "writable", False)]
+        if not writable:
+            return None, {"error": "no writable session directory for the screenshot"}
+        p = Path(raw).expanduser()
+        cand = (p if p.is_absolute() else writable[0] / p).resolve()
+        if not any(cand.is_relative_to(root.resolve()) for root in writable):
+            return None, {
+                "error": f"{cand} is outside the session's writable directories"
+            }
+        return cand, None
 
     def browser_open_url(
         url: str, wait_until: str = "domcontentloaded"
@@ -530,16 +549,21 @@ def make_browser_automation_tools() -> list[Callable[..., Any]]:
     )
 
     def browser_screenshot(path: str = "") -> dict[str, Any]:
+        # Confine an explicit destination to the session's writable roots BEFORE opening the
+        # browser (fail fast, and keep it testable without Playwright). No path → the fixed
+        # temp scratch file, which the model can't point anywhere.
+        if path:
+            out, err = _confine_screenshot_path(path)
+            if err:
+                return err
+        else:
+            out = Path(tempfile.gettempdir()) / "coworker-browser-screenshot.png"
+
         def run(page):
-            out = (
-                Path(path).expanduser()
-                if path
-                else Path(tempfile.gettempdir()) / "coworker-browser-screenshot.png"
-            )
-            out = out.resolve()
-            out.parent.mkdir(parents=True, exist_ok=True)
-            page.screenshot(path=str(out), full_page=True)
-            return {"ok": True, "path": str(out), "url": page.url}
+            dest = out.resolve()
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            page.screenshot(path=str(dest), full_page=True)
+            return {"ok": True, "path": str(dest), "url": page.url}
 
         return _BROWSER.call("screenshot", run)
 

--- a/coworker/connectors/integration_tools.py
+++ b/coworker/connectors/integration_tools.py
@@ -525,7 +525,9 @@ def make_integration_tools(
     enabled_tools: Optional[set[str]] = None,
     roots: Optional[list[Any]] = None,
 ) -> list[Callable[..., Any]]:
-    tools: list[Callable[..., Any]] = make_browser_automation_tools()
+    # Browser tools need the session roots too: a screenshot's destination must resolve
+    # inside a granted writable directory, never an arbitrary model-supplied path.
+    tools: list[Callable[..., Any]] = make_browser_automation_tools(roots=roots)
     # Email needs the session roots: attachment downloads land in the primary scratch
     # and outgoing attachments must resolve inside a granted directory.
     tools.extend(make_email_tools(secrets, roots=roots))

--- a/tests/test_browser_screenshot.py
+++ b/tests/test_browser_screenshot.py
@@ -1,0 +1,56 @@
+"""browser_screenshot must confine a caller-supplied destination to the session's writable
+roots. The tool is registered read-kind (never approval-gated), so an unconfined path let a
+model-controlled `path` overwrite any file on disk with PNG bytes. Confinement happens before
+the browser is opened, so these cases assert without Playwright installed."""
+
+from __future__ import annotations
+
+from coworker.connectors.browser_automation import make_browser_automation_tools
+from coworker.roots import RootDir
+
+
+def _screenshot_tool(roots):
+    tools = make_browser_automation_tools(roots=roots)
+    tool = next(t for t in tools if t.__name__ == "browser_screenshot")
+    return tool
+
+
+def test_screenshot_rejects_path_outside_writable_roots(tmp_path):
+    workspace = tmp_path / "scratch"
+    workspace.mkdir()
+    tool = _screenshot_tool([RootDir(path=workspace, writable=True)])
+
+    # An absolute path outside every granted root is refused (would have overwritten it).
+    outside = tmp_path / "secrets.json"
+    outside.write_text("keep me")
+    res = tool(path=str(outside))
+    assert "error" in res and "outside" in res["error"]
+    assert outside.read_text() == "keep me"  # untouched
+
+
+def test_screenshot_rejects_traversal_escape(tmp_path):
+    workspace = tmp_path / "scratch"
+    workspace.mkdir()
+    tool = _screenshot_tool([RootDir(path=workspace, writable=True)])
+    res = tool(path="../escape.png")
+    assert "error" in res and "outside" in res["error"]
+
+
+def test_screenshot_rejects_when_no_writable_root(tmp_path):
+    ro = tmp_path / "ro"
+    ro.mkdir()
+    tool = _screenshot_tool([RootDir(path=ro, writable=False)])
+    res = tool(path=str(ro / "shot.png"))
+    assert "error" in res and "no writable" in res["error"]
+
+
+def test_screenshot_accepts_path_inside_writable_root_then_reaches_browser(tmp_path):
+    """A path inside a granted writable root passes confinement; it then proceeds to the
+    browser call (which returns a Playwright setup error here — the point is it was NOT
+    rejected by confinement, i.e. no 'outside'/'no writable' error)."""
+    workspace = tmp_path / "scratch"
+    workspace.mkdir()
+    tool = _screenshot_tool([RootDir(path=workspace, writable=True)])
+    res = tool(path=str(workspace / "shot.png"))
+    assert "outside" not in str(res.get("error", ""))
+    assert "no writable" not in str(res.get("error", ""))


### PR DESCRIPTION
## Summary

`browser_screenshot` writes a PNG to a **caller-supplied path with no confinement**, and the tool is registered `kind="read"` in `TOOL_DEFS`, so `approval_for_tool` returns `False` (reads never gate) and it is **not approval-prompted**. Together that lets a model-controlled path overwrite any file the process can write.

`coworker/connectors/browser_automation.py`:

```python
def browser_screenshot(path: str = "") -> dict[str, Any]:
    def run(page):
        out = (Path(path).expanduser() if path
               else Path(tempfile.gettempdir()) / "coworker-browser-screenshot.png")
        out = out.resolve()
        out.parent.mkdir(parents=True, exist_ok=True)   # creates missing dirs
        page.screenshot(path=str(out), full_page=True)  # overwrites the target
```

### Impact

A misled or prompt-injected agent calls:

```
browser_screenshot(path="~/.config/coworker/secrets.json")
browser_screenshot(path="~/.ssh/authorized_keys")
```

and the tool overwrites that file with image bytes, unapproved. Every other write path in the connectors (`github_clone`, `github_pull`, email attachment downloads, `send_file`) already confines writes to granted roots via `is_relative_to` - the screenshot tool was the lone outlier.

## Fix

Thread the session `roots` into `make_browser_automation_tools` (exactly as `make_email_tools` already receives them) and resolve an explicit screenshot path **inside a writable granted root**, rejecting:

- absolute paths outside every granted root,
- `../` traversal escapes,
- the no-writable-root case.

A relative path resolves against the primary root. No path still writes the fixed temp scratch file, which the model cannot redirect. Confinement runs **before** the browser opens, so it fails fast and stays unit-testable without Playwright.

This matches the codebase's existing model: writes land only in directories the user has shared read-write with the session.

## Validation

New `tests/test_browser_screenshot.py`:
- rejects an absolute path outside the writable roots (and asserts the pre-existing file is untouched),
- rejects a `../` traversal escape,
- rejects when no writable root is granted,
- accepts a path inside a writable root (passes confinement, then proceeds to the browser call).

Full suite: `856 passed, 1 skipped`. The single unrelated failure (`test_provider_router.py::test_manager_curated_models`) fails identically on `main` - it requires a live local Ollama.