### PR TITLE
Add an opt-in macOS Keychain backend to the secret store

### DIFF
--- a/coworker/secrets.py
+++ b/coworker/secrets.py
@@ -1,18 +1,30 @@
-"""Secret store — one canonical, file-backed store for connector/MCP credentials.
+"""Secret store — one canonical store for connector/MCP credentials.
 
 Design (from OpenClaw): secrets **never enter the model's context, prompts, or traces**.
 The store holds profiles keyed by `connector[:account]`; values may be literals OR
 `${ENV_VAR}` references resolved at read time from the process env / `~/.config/coworker/.env`.
 
-v1 is a `0600` JSON file behind this interface; the interface is what callers depend on, so
-a Keychain / age-encrypted backend can swap in later without touching them.
+Two backends behind one interface (callers depend only on the interface):
+
+  - **file** (the default, unchanged v1 behavior): a `0600` JSON file at
+    `<state_dir>/secrets.json`.
+  - **keychain** (opt-in, macOS): the profile map lives as a single generic-password
+    item in the login Keychain instead of a plaintext file, so credentials are
+    encrypted at rest and gated by the OS. Select it with
+    `COWORKER_SECRETS_BACKEND=keychain`; on first use an existing `secrets.json`
+    is imported (the file itself is left untouched — delete it once satisfied).
+    On platforms without a keychain the store falls back to the file backend so
+    the server always boots.
 """
 
 from __future__ import annotations
 
+import base64
 import json
+import logging
 import os
 import re
+import shutil
 import subprocess
 import sys
 import threading
@@ -20,8 +32,11 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
+logger = logging.getLogger(__name__)
+
 _REF = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 _IS_WINDOWS = sys.platform == "win32"
+_BACKEND_ENV = "COWORKER_SECRETS_BACKEND"
 
 
 def state_dir() -> Path:
@@ -103,13 +118,184 @@ def write_private_text(path: str | Path, content: str) -> Path:
     return target
 
 
-class SecretStore:
-    """File-backed secret store. Reads resolve `${VAR}` refs; status never leaks values."""
+class _FileBackend:
+    """v1 storage: the profile map as a `0600` JSON file (atomic replace on write)."""
 
-    def __init__(self, path: Optional[str | Path] = None) -> None:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def read(self) -> dict[str, Any]:
+        if not self.path.is_file():
+            return {}
+        try:
+            return json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+
+    def write(self, store: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            _restrict_to_user(self.path.parent, is_dir=True)
+        except OSError:
+            pass
+        tmp = self.path.with_name(self.path.name + ".tmp")
+        tmp.write_text(json.dumps(store, indent=2), encoding="utf-8")
+        _restrict_to_user(tmp, is_dir=False)
+        os.replace(tmp, self.path)
+
+
+class _KeychainBackend:
+    """macOS storage: the profile map as ONE generic-password item in the login Keychain.
+
+    One item (not one per profile) keeps `status()`/listing a single read and mirrors the
+    file backend's whole-map read/write semantics exactly. The blob is base64-encoded
+    JSON — pure ASCII, so it survives `security`'s output conventions (which hex-mangle
+    non-printable passwords) and needs no shell quoting.
+
+    Writes go through `security -i` with the command on **stdin**, so the secret material
+    never appears in the process argv (visible to any local `ps`). The item's account is
+    the logical store path, so distinct state dirs (tests, sidecars, `$COWORKER_STATE_DIR`
+    overrides) get distinct items instead of sharing one.
+
+    On first read, if the keychain item doesn't exist yet but the v1 `secrets.json` does,
+    the file's contents are imported once. The file is left in place (not scrubbed) so
+    flipping the backend back is non-destructive; deleting it is the user's call.
+    """
+
+    SERVICE = "coworker-secrets"
+    LABEL = "OpenWorker secrets"
+    _NOT_FOUND = 44  # errSecItemNotFound
+
+    def __init__(self, path: Path) -> None:
+        self.path = path  # identity for the keychain account + import source
+        self._account = str(path)
+        self._cache: Optional[dict[str, Any]] = None
+        self._cache_lock = threading.Lock()
+
+    @staticmethod
+    def _quote(value: str) -> str:
+        """Quote one argument for `security -i`'s command parser."""
+        return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+    def _find(self) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                "security",
+                "find-generic-password",
+                "-s",
+                self.SERVICE,
+                "-a",
+                self._account,
+                "-w",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    def _store_blob(self, blob: str) -> None:
+        # `add-generic-password -U` updates in place; `-i` reads the command from stdin
+        # so the blob rides a pipe, not the argv.
+        command = (
+            f"add-generic-password -U -s {self._quote(self.SERVICE)} "
+            f"-a {self._quote(self._account)} -l {self._quote(self.LABEL)} "
+            f"-w {blob}\n"
+        )
+        done = subprocess.run(
+            ["security", "-i"], input=command, capture_output=True, text=True
+        )
+        if done.returncode != 0:
+            raise OSError(
+                f"keychain write failed (security exited {done.returncode}): "
+                f"{(done.stderr or '').strip()[:200]}"
+            )
+
+    def read(self) -> dict[str, Any]:
+        with self._cache_lock:
+            if self._cache is not None:
+                return dict(self._cache)
+            found = self._find()
+            if found.returncode == self._NOT_FOUND:
+                # First use: seed from the v1 file so existing setups keep working.
+                imported = _FileBackend(self.path).read()
+                if imported:
+                    try:
+                        self._store_blob(_encode(imported))
+                        logger.info(
+                            "secrets: imported %d profile(s) from %s into the keychain",
+                            len(imported),
+                            self.path,
+                        )
+                    except OSError:
+                        logger.warning(
+                            "secrets: keychain import failed; serving the file copy",
+                            exc_info=True,
+                        )
+                        return imported  # don't cache: retry the import next read
+                self._cache = imported
+                return dict(imported)
+            if found.returncode != 0:
+                # Locked/errored keychain: serve empty but DON'T cache, so recovery
+                # (unlocking) is picked up on the next read.
+                logger.warning(
+                    "secrets: keychain read failed (security exited %d): %s",
+                    found.returncode,
+                    (found.stderr or "").strip()[:200],
+                )
+                return {}
+            self._cache = _decode(found.stdout.strip())
+            return dict(self._cache)
+
+    def write(self, store: dict[str, Any]) -> None:
+        with self._cache_lock:
+            self._store_blob(_encode(store))
+            self._cache = dict(store)
+
+
+def _encode(store: dict[str, Any]) -> str:
+    return base64.b64encode(json.dumps(store).encode("utf-8")).decode("ascii")
+
+
+def _decode(blob: str) -> dict[str, Any]:
+    try:
+        data = json.loads(base64.b64decode(blob, validate=True).decode("utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (ValueError, json.JSONDecodeError):
+        return {}
+
+
+def _pick_backend(path: Path) -> _FileBackend | _KeychainBackend:
+    choice = (os.environ.get(_BACKEND_ENV) or "file").strip().lower()
+    if choice in ("", "file"):
+        return _FileBackend(path)
+    if choice == "keychain":
+        if sys.platform == "darwin" and shutil.which("security"):
+            return _KeychainBackend(path)
+        logger.warning(
+            "secrets: %s=keychain requires the macOS `security` tool; "
+            "falling back to the file backend",
+            _BACKEND_ENV,
+        )
+        return _FileBackend(path)
+    logger.warning(
+        "secrets: unknown %s=%r; falling back to the file backend", _BACKEND_ENV, choice
+    )
+    return _FileBackend(path)
+
+
+class SecretStore:
+    """Secret store over a swappable backend (file by default, macOS Keychain opt-in).
+    Reads resolve `${VAR}` refs; status never leaks values."""
+
+    def __init__(
+        self,
+        path: Optional[str | Path] = None,
+        *,
+        backend: Optional[Any] = None,
+    ) -> None:
         self.path = Path(path).expanduser() if path else state_dir() / "secrets.json"
         self._dotenv_path = self.path.parent / ".env"
         self._lock = threading.Lock()
+        self._backend = backend if backend is not None else _pick_backend(self.path)
 
     # -- reads ------------------------------------------------------------------
     def get(self, profile: str) -> Optional[dict[str, Any]]:
@@ -174,20 +360,7 @@ class SecretStore:
 
     # -- internals --------------------------------------------------------------
     def _read(self) -> dict[str, Any]:
-        if not self.path.is_file():
-            return {}
-        try:
-            return json.loads(self.path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            return {}
+        return self._backend.read()
 
     def _write(self, store: dict[str, Any]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            _restrict_to_user(self.path.parent, is_dir=True)
-        except OSError:
-            pass
-        tmp = self.path.with_name(self.path.name + ".tmp")
-        tmp.write_text(json.dumps(store, indent=2), encoding="utf-8")
-        _restrict_to_user(tmp, is_dir=False)
-        os.replace(tmp, self.path)
+        self._backend.write(store)

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -7,8 +7,12 @@ import stat
 import subprocess
 import sys
 import time
+import uuid
+from types import SimpleNamespace
 
-from coworker.secrets import SecretStore
+import pytest
+
+from coworker.secrets import SecretStore, _KeychainBackend, _pick_backend
 
 
 def test_put_get_round_trip(tmp_path):
@@ -85,3 +89,118 @@ def test_delete(tmp_path):
     assert store.delete("x") is True
     assert store.delete("x") is False
     assert store.get("x") is None
+
+
+# -- keychain backend ------------------------------------------------------------
+class _FakeKeychain(_KeychainBackend):
+    """The backend with the two `security` calls swapped for an in-memory item, so the
+    blob encoding, import-on-first-read, and caching logic run on every platform."""
+
+    def __init__(self, path):
+        super().__init__(path)
+        self.item = None  # the stored base64 blob, None = errSecItemNotFound
+        self.finds = 0
+
+    def _find(self):
+        self.finds += 1
+        if self.item is None:
+            return SimpleNamespace(returncode=self._NOT_FOUND, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout=self.item + "\n", stderr="")
+
+    def _store_blob(self, blob):
+        self.item = blob
+
+
+def test_keychain_round_trip_and_status(tmp_path):
+    store = SecretStore(
+        tmp_path / "secrets.json", backend=_FakeKeychain(tmp_path / "secrets.json")
+    )
+    store.put("slack:default", {"type": "token", "bot_token": "xoxb-123"})
+    assert store.get("slack:default") == {"type": "token", "bot_token": "xoxb-123"}
+    assert store.get("missing") is None
+    assert store.delete("slack:default") is True
+    assert store.get("slack:default") is None
+    # No plaintext file materializes when the keychain backend is active.
+    assert not (tmp_path / "secrets.json").exists()
+
+
+def test_keychain_env_refs_still_resolve(tmp_path, monkeypatch):
+    monkeypatch.setenv("KC_TOK", "from-env")
+    store = SecretStore(
+        tmp_path / "secrets.json", backend=_FakeKeychain(tmp_path / "secrets.json")
+    )
+    store.put("slack:default", {"bot_token": "${KC_TOK}"})
+    assert store.get("slack:default")["bot_token"] == "from-env"
+
+
+def test_keychain_imports_existing_file_once(tmp_path):
+    """First read with an empty keychain seeds it from the v1 secrets.json — an existing
+    setup keeps its credentials when the user flips the backend. The file is left
+    untouched (non-destructive; scrubbing it is the user's call)."""
+    path = tmp_path / "secrets.json"
+    SecretStore(path).put("gmail:default", {"type": "oauth", "access": "tok"})
+
+    kc = _FakeKeychain(path)
+    store = SecretStore(path, backend=kc)
+    assert store.get("gmail:default") == {"type": "oauth", "access": "tok"}
+    assert kc.item is not None  # imported into the keychain item
+    assert path.is_file()  # v1 file untouched
+
+    # A later write goes to the keychain only; the file stays at its old contents.
+    store.put("slack:default", {"bot_token": "xoxb"})
+    assert "xoxb" not in path.read_text(encoding="utf-8")
+
+
+def test_keychain_caches_reads(tmp_path):
+    kc = _FakeKeychain(tmp_path / "secrets.json")
+    store = SecretStore(tmp_path / "secrets.json", backend=kc)
+    store.put("x", {"a": 1})
+    store.get("x")
+    store.get("x")
+    store.status()
+    assert kc.finds <= 1  # write-through cache: at most the initial lookup
+
+
+def test_backend_selection_defaults_to_file(tmp_path, monkeypatch):
+    monkeypatch.delenv("COWORKER_SECRETS_BACKEND", raising=False)
+    assert type(_pick_backend(tmp_path / "s.json")).__name__ == "_FileBackend"
+    monkeypatch.setenv("COWORKER_SECRETS_BACKEND", "file")
+    assert type(_pick_backend(tmp_path / "s.json")).__name__ == "_FileBackend"
+    # Unknown values fall back to file (the server must always boot).
+    monkeypatch.setenv("COWORKER_SECRETS_BACKEND", "vault")
+    assert type(_pick_backend(tmp_path / "s.json")).__name__ == "_FileBackend"
+
+
+def test_backend_selection_keychain_on_macos_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("COWORKER_SECRETS_BACKEND", "keychain")
+    picked = _pick_backend(tmp_path / "s.json")
+    if sys.platform == "darwin":
+        assert type(picked).__name__ == "_KeychainBackend"
+    else:
+        assert type(picked).__name__ == "_FileBackend"  # graceful fallback
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="real Keychain is macOS-only")
+def test_keychain_real_round_trip(tmp_path):
+    """End-to-end against the actual login Keychain (unique per-run account, cleaned up)."""
+    path = tmp_path / f"secrets-{uuid.uuid4().hex}.json"
+    backend = _KeychainBackend(path)
+    try:
+        store = SecretStore(path, backend=backend)
+        store.put("slack:default", {"bot_token": "xoxb-real"})
+        # A fresh backend (no cache) must read it back from the OS keychain itself.
+        fresh = SecretStore(path, backend=_KeychainBackend(path))
+        assert fresh.get("slack:default") == {"bot_token": "xoxb-real"}
+        assert not path.exists()  # nothing plaintext on disk
+    finally:
+        subprocess.run(
+            [
+                "security",
+                "delete-generic-password",
+                "-s",
+                _KeychainBackend.SERVICE,
+                "-a",
+                str(path),
+            ],
+            capture_output=True,
+        )


### PR DESCRIPTION
Implements the OS-keychain backend tracked in #36, and the direction `secrets.py` already reserves for itself: *"v1 is a 0600 JSON file behind this interface; the interface is what callers depend on, so a Keychain / age-encrypted backend can swap in later without touching them."* This swaps one in without touching any of the nine call sites.

## Why

Connector tokens, OAuth grants, and model API keys all live in `secrets.json` — plaintext behind `0600`. Any process running as the user (no TCC prompt, no entitlement, no sudo) reads every credential in one `open()`. For a local-first app whose privacy story is the headline, at-rest encryption gated by the OS is the natural next step, and macOS ships everything needed: the login Keychain plus `security(1)`. **No new dependencies.**

## Design

- **One generic-password item holds the whole profile map** (service `coworker-secrets`), not one item per profile — `status()`/listing stays a single read, and the read/write semantics mirror the file backend exactly.
- **Blob is base64-encoded JSON** — pure ASCII, so it survives `security`'s output conventions (non-printable passwords get hex-mangled) and needs no quoting.
- **Writes go through `security -i` with the command on stdin**, so secret material never rides process argv, where any local `ps` could snapshot it.
- **The item's account is the logical store path**, so distinct state dirs (tests, sidecars, `$COWORKER_STATE_DIR` overrides) get distinct items instead of sharing one.
- **Migration:** first read with an empty keychain imports an existing `secrets.json` and logs it. The file is left untouched, so flipping the env var back is non-destructive; scrubbing the plaintext copy stays the user's explicit call.
- **Selection:** `COWORKER_SECRETS_BACKEND=keychain`. The default stays `file` — zero behavior change for every current install. Non-macOS platforms or a missing `security` binary fall back to the file backend with a warning, so the server always boots. A Windows Credential Manager / libsecret backend can follow behind the same seam.
- Reads are cached in-process with write-through (a `security` subprocess per hot-path `get()` would be wasteful); a locked/errored keychain serves empty but is deliberately **not** cached, so recovery is picked up on the next read.

## Tests

`tests/test_secrets.py` grows seven tests: round-trip/status/delete through a fake keychain (the two `security` calls stubbed, so the encoding/import/caching logic runs on every platform), `${VAR}` refs still resolving, one-time import from an existing v1 file, read caching, backend selection (default file, unknown value falls back, keychain only on darwin), and a **real end-to-end round trip against the actual login Keychain** (darwin-only, unique per-run account, cleaned up afterwards) — verified locally on macOS: a fresh backend with no cache reads the credentials back from the OS keychain and nothing plaintext touches disk.

Full suite: 853 passed; the 7 pre-existing failures on `main` (FakeSlack socket tests + `test_ui_refresh_e2e`, absent the `messaging` extras) are unchanged.
