### PR TITLE
Normalize provider API keys on read

### DIFF
--- a/coworker/providers/anthropic_provider.py
+++ b/coworker/providers/anthropic_provider.py
@@ -131,12 +131,12 @@ def resolve_api_key(secrets: Any = None) -> Optional[str]:
     """
     import os
 
-    key = os.environ.get("ANTHROPIC_API_KEY")
+    key = (os.environ.get("ANTHROPIC_API_KEY") or "").strip()
     if key:
         return key
     if secrets is not None:
         profile = secrets.get("provider:anthropic") or {}
-        return profile.get("api_key") or None
+        return str(profile.get("api_key") or "").strip() or None
     return None
 
 

--- a/coworker/providers/gemini_provider.py
+++ b/coworker/providers/gemini_provider.py
@@ -90,12 +90,13 @@ def resolve_api_key(secrets: Any = None) -> Optional[str]:
     convention) first, else the SecretStore `provider:gemini` profile (`{api_key}`)."""
     import os
 
-    key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
-    if key:
-        return key
+    for env_name in ("GEMINI_API_KEY", "GOOGLE_API_KEY"):
+        key = (os.environ.get(env_name) or "").strip()
+        if key:
+            return key
     if secrets is not None:
         profile = secrets.get("provider:gemini") or {}
-        return profile.get("api_key") or None
+        return str(profile.get("api_key") or "").strip() or None
     return None
 
 

--- a/coworker/providers/openai_provider.py
+++ b/coworker/providers/openai_provider.py
@@ -28,12 +28,12 @@ def resolve_api_key(secrets: Any = None) -> Optional[str]:
     """
     import os
 
-    key = os.environ.get("OPENAI_API_KEY")
+    key = (os.environ.get("OPENAI_API_KEY") or "").strip()
     if key:
         return key
     if secrets is not None:
         profile = secrets.get("provider:openai") or {}
-        return profile.get("api_key") or None
+        return str(profile.get("api_key") or "").strip() or None
     return None
 
 

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1323,8 +1323,8 @@ class SessionManager:
         for d in provider_descriptors():
             profile = self.secrets.get(f"provider:{d.name}") or {}
             if d.needs_key:
-                configured = bool(profile.get("api_key")) or bool(
-                    d.env_key and os.environ.get(d.env_key)
+                configured = bool(str(profile.get("api_key") or "").strip()) or bool(
+                    d.env_key and (os.environ.get(d.env_key) or "").strip()
                 )
             else:
                 configured = True  # keyless (Ollama) — usable out of the box
@@ -1524,8 +1524,8 @@ class SessionManager:
         if not d.needs_key:
             return True  # keyless (Ollama)
         profile = self.secrets.get(f"provider:{name}") or {}
-        return bool(profile.get("api_key")) or bool(
-            d.env_key and os.environ.get(d.env_key)
+        return bool(str(profile.get("api_key") or "").strip()) or bool(
+            d.env_key and (os.environ.get(d.env_key) or "").strip()
         )
 
     # -- settings / prefs (model API key, default model, onboarding) -------------
@@ -1661,8 +1661,9 @@ class SessionManager:
         """Model-access + UI status. Never returns the key; `source` says where it comes from."""
         import os
 
-        env_key = bool(os.environ.get("OPENAI_API_KEY"))
-        stored = bool((self.secrets.get("provider:openai") or {}).get("api_key"))
+        env_key = bool((os.environ.get("OPENAI_API_KEY") or "").strip())
+        stored_key = (self.secrets.get("provider:openai") or {}).get("api_key")
+        stored = bool(str(stored_key or "").strip())
         # Only surface models whose provider is actually configured — the composer picker
         # reflects exactly what's connected. The active default is always kept selectable
         # (it's hidden behind the "No model" state until a provider is connected anyway).

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -465,14 +465,14 @@ def test_registry_builds_native_anthropic_provider():
 def test_resolve_api_key_env_then_secrets(monkeypatch):
     from coworker.providers.anthropic_provider import resolve_api_key
 
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", " \tsk-ant-env\n")
     assert resolve_api_key() == "sk-ant-env"
     monkeypatch.delenv("ANTHROPIC_API_KEY")
 
     class _Secrets:
         def get(self, name):
             return (
-                {"api_key": "sk-ant-stored"} if name == "provider:anthropic" else None
+                {"api_key": "\nsk-ant-stored "} if name == "provider:anthropic" else None
             )
 
     assert resolve_api_key(_Secrets()) == "sk-ant-stored"

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -460,16 +460,18 @@ def test_registry_builds_native_gemini_provider():
 def test_resolve_api_key_env_then_secrets(monkeypatch):
     from coworker.providers.gemini_provider import resolve_api_key
 
-    monkeypatch.setenv("GEMINI_API_KEY", "AIza-env")
+    monkeypatch.setenv("GEMINI_API_KEY", " \tAIza-env\n")
     assert resolve_api_key() == "AIza-env"
-    monkeypatch.delenv("GEMINI_API_KEY")
-    monkeypatch.setenv("GOOGLE_API_KEY", "AIza-google")  # the SDK's own env convention
+    # A blank primary env var must not shadow the SDK's fallback convention.
+    monkeypatch.setenv("GEMINI_API_KEY", " \t")
+    monkeypatch.setenv("GOOGLE_API_KEY", "\nAIza-google ")  # the SDK's own env convention
     assert resolve_api_key() == "AIza-google"
+    monkeypatch.delenv("GEMINI_API_KEY")
     monkeypatch.delenv("GOOGLE_API_KEY")
 
     class _Secrets:
         def get(self, name):
-            return {"api_key": "AIza-stored"} if name == "provider:gemini" else None
+            return {"api_key": " AIza-stored\n"} if name == "provider:gemini" else None
 
     assert resolve_api_key(_Secrets()) == "AIza-stored"
     assert resolve_api_key(None) is None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,7 +14,7 @@ from coworker.secrets import SecretStore
 
 
 def test_resolve_api_key_prefers_env(monkeypatch, tmp_path):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-123")
+    monkeypatch.setenv("OPENAI_API_KEY", " \tsk-env-123\n")
     secrets = SecretStore(path=tmp_path / "secrets.json")
     secrets.put("provider:openai", {"type": "api_key", "api_key": "sk-store-999"})
     assert resolve_api_key(secrets) == "sk-env-123"
@@ -24,8 +24,23 @@ def test_resolve_api_key_falls_back_to_store(monkeypatch, tmp_path):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     secrets = SecretStore(path=tmp_path / "secrets.json")
     assert resolve_api_key(secrets) is None
-    secrets.put("provider:openai", {"type": "api_key", "api_key": "sk-store-999"})
+    secrets.put("provider:openai", {"type": "api_key", "api_key": "\nsk-store-999 "})
     assert resolve_api_key(secrets) == "sk-store-999"
+
+
+def test_whitespace_only_env_key_is_not_configured(tmp_path, monkeypatch):
+    from coworker.server.manager import SessionManager
+
+    monkeypatch.setenv("OPENAI_API_KEY", " \t\n")
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    manager = SessionManager(data_dir=tmp_path / "data")
+
+    settings = manager.get_settings()
+    openai = next(p for p in manager.get_providers() if p["name"] == "openai")
+
+    assert settings["has_key"] is False
+    assert settings["source"] is None
+    assert openai["configured"] is False
 
 
 def test_settings_rest_roundtrip(tmp_path, monkeypatch):


### PR DESCRIPTION
Provider keys entered through the current settings paths are normalized before
storage, but keys can also come from environment variables or older/manually
populated secret profiles. Those read paths returned raw values, so surrounding
whitespace could reach SDK clients, and a whitespace-only variable could make a
provider appear configured or shadow a valid fallback key.

This normalizes native OpenAI, Anthropic, and Gemini keys when they are resolved
and keeps provider/settings status checks consistent. Gemini now skips a blank
`GEMINI_API_KEY` and continues to `GOOGLE_API_KEY`.

Checks:

- `python -m pytest -q tests/test_settings.py tests/test_anthropic_provider.py tests/test_gemini_provider.py` (79 passed)
- Broader backend regression: 841 passed, 1 skipped, 4 deselected
