### PR TITLE
Prevent duplicate overlapping scheduler runs

### DIFF
--- a/coworker/automation/scheduler.py
+++ b/coworker/automation/scheduler.py
@@ -75,11 +75,18 @@ class Scheduler:
 
     async def _tick(self, *, trigger: str) -> None:
         for task in self.store.due():
+            # Claim synchronously before create_task: under event-loop starvation,
+            # another tick can otherwise enqueue the same overdue task before the
+            # first spawned coroutine gets a chance to update _running_ids.
+            if task.id in self._running_ids:
+                logger.info("skipping %s — previous run still going", task.id)
+                continue
+            self._running_ids.add(task.id)
             # Spawn, don't await: a run can suspend on a parked approval (standing
             # scoped approvals, §25) and one blocked automation must never stall the
             # scheduler loop, other due tasks, or self-wake resumption. Overlap is
-            # still guarded inside run_task via _running_ids.
-            spawned = asyncio.create_task(self.run_task(task, trigger=trigger))
+            # claimed above before yielding control.
+            spawned = asyncio.create_task(self._run_claimed(task, trigger=trigger))
             self._spawned.add(spawned)
             spawned.add_done_callback(self._spawned.discard)
         if self.extra_tick is not None:
@@ -93,21 +100,28 @@ class Scheduler:
             logger.info("skipping %s — previous run still going", task.id)
             return None
         self._running_ids.add(task.id)
+        return await self._run_claimed(task, trigger=trigger)
+
+    async def _run_claimed(
+        self, task: ScheduledTask, *, trigger: str
+    ) -> Optional[TaskRun]:
         try:
-            run = await self.runner(task, trigger)
-        except Exception as exc:
-            logger.exception("task %s run failed", task.id)
-            run = TaskRun(
-                task_id=task.id, status="error", error=str(exc), trigger=trigger
-            )
-            self.store.add_run(run)
+            try:
+                run = await self.runner(task, trigger)
+            except Exception as exc:
+                logger.exception("task %s run failed", task.id)
+                run = TaskRun(
+                    task_id=task.id, status="error", error=str(exc), trigger=trigger
+                )
+                self.store.add_run(run)
+            # Advance before releasing the claim. Otherwise a tick can see the
+            # stale due row between completion and save and immediately rerun it.
+            fresh = self.store.get(task.id)
+            if fresh is not None:
+                fresh.run_count += 1
+                fresh.last_run = run.started_at if run else None
+                fresh.last_status = run.status if run else "error"
+                self.store.save(fresh)
+            return run
         finally:
             self._running_ids.discard(task.id)
-        # advance the task (run_count/last_run) → save recomputes next_run.
-        fresh = self.store.get(task.id)
-        if fresh is not None:
-            fresh.run_count += 1
-            fresh.last_run = run.started_at if run else None
-            fresh.last_status = run.status if run else "error"
-            self.store.save(fresh)
-        return run

--- a/tests/test_standing_approvals.py
+++ b/tests/test_standing_approvals.py
@@ -394,6 +394,29 @@ def test_create_automation_grants_and_revoke(tmp_path, monkeypatch):
 # -- scheduler: a suspended run must not stall the loop ---------------------------
 
 
+async def test_scheduler_claims_due_task_before_spawn_yields(tmp_path):
+    store = TaskStore(tmp_path / "auto.db")
+    task = _task(title="overlap")
+    store.save(task)
+    store._conn.execute(
+        "UPDATE scheduled_tasks SET next_run=1.0 WHERE id=?", (task.id,)
+    )
+    store._conn.commit()
+    gate = asyncio.Event()
+
+    async def runner(task, trigger):
+        await gate.wait()
+        return TaskRun(task_id=task.id, status="ok", trigger=trigger)
+
+    sched = Scheduler(store, runner)
+    # Neither await yields inside _tick, so the first spawned coroutine has not
+    # started when the second tick inspects the same overdue database row.
+    await sched._tick(trigger="catchup")
+    await sched._tick(trigger="schedule")
+    assert len(sched._spawned) == 1
+    await sched.stop()
+
+
 async def test_blocked_run_does_not_stall_other_tasks(tmp_path):
     store = TaskStore(tmp_path / "auto.db")
     blocked = _task(title="blocked")


### PR DESCRIPTION
The scheduler documents skip-on-overlap behavior, but `_tick()` previously added a task ID only inside the spawned coroutine. If another tick arrived before that coroutine began, the same overdue task could be queued twice; both runs would then execute and increment `run_count`.

This claims the task synchronously before `create_task()` and keeps that claim until the completed run advances `next_run`. Direct `run_task()` calls continue to use the same guard.

The regression test invokes two ticks without yielding to the first spawned coroutine and asserts that only one run is queued.

Checks run:

- `.venv/bin/pytest tests/test_standing_approvals.py -q` — 17 passed
- [Fork CI](https://github.com/tonimelisma/openworker/actions/runs/30057764211) GUI unit and E2E jobs passed
- Fork CI Python job — 853 passed, 1 skipped, plus the same pre-existing `test_manager_curated_models` failure present on [upstream `main`](https://github.com/andrewyng/openworker/actions/runs/30038166658)

Screenshots: Not applicable — this is a backend scheduler race with no UI change.