### PR TITLE
Add a self-hosted (GPU) OpenAI-compatible model provider

### DIFF
--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -133,6 +133,26 @@ def _build_ollama(profile: dict[str, Any], secrets: Any) -> ProviderClient:
     return OpenAIProvider(api_key="ollama", base_url=base_url)
 
 
+def _build_self_hosted(profile: dict[str, Any], secrets: Any) -> ProviderClient:
+    # A user-run, OpenAI-compatible model server (vLLM, TGI, SGLang, LMDeploy, llama.cpp, …),
+    # typically GPU-backed. Both the endpoint and the key are deployment-specific, so BOTH come
+    # from this provider's own profile — never the OpenAI env/SecretStore fallback, so an OpenAI
+    # key is never sent to a self-hosted host. Built on demand (only when a `selfhosted:` model is
+    # selected), so we fail fast with a clear, named error. The base URL is used verbatim (like
+    # the OpenAI custom-endpoint field): include the `/v1` path yourself.
+    base_url = ((profile or {}).get("base_url") or "").strip()
+    api_key = ((profile or {}).get("api_key") or "").strip()
+    if not base_url:
+        raise RuntimeError(
+            "No endpoint configured for the self-hosted provider — add its URL in Settings ▸ Models."
+        )
+    if not api_key:
+        raise RuntimeError(
+            "No self-hosted API key configured — add it in Settings ▸ Models."
+        )
+    return OpenAIProvider(api_key=api_key, base_url=base_url)
+
+
 def _openai_compat(vendor: str, default_base_url: str, env_key: Optional[str] = None):
     """Builder factory for vendors reached through their OpenAI-compatible API (Z AI, DeepSeek,
     Kimi, MiniMax, Qwen, xAI, Mistral). The key is resolved from the vendor's OWN profile (or its
@@ -344,6 +364,38 @@ DESCRIPTORS: list[ProviderDescriptor] = [
         # `ollama pull qwen3-coder:30b`.
         recommended_model="qwen3-coder:30b",
     ),
+    # A self-hosted, OpenAI-compatible model server (vLLM, TGI, SGLang, LMDeploy, …), usually
+    # GPU-backed. Unlike the direct vendors above, both the endpoint and the key are
+    # deployment-specific, so BOTH are required, user-entered fields with no prefilled default.
+    # Models are user-specific (not in the curated matrix), so they carry the conservative
+    # capability defaults — add them as `selfhosted:<your-model-id>`.
+    ProviderDescriptor(
+        name="selfhosted",
+        title="Self-hosted (GPU)",
+        needs_key=True,
+        fields=[
+            ProviderField(
+                "base_url",
+                "Endpoint URL",
+                secret=False,
+                required=True,
+                placeholder="https://my-gpu-host:8000/v1",
+                help="Your server's OpenAI-compatible base URL — include the /v1 path "
+                "(vLLM, TGI, SGLang, LMDeploy, llama.cpp server, …).",
+            ),
+            ProviderField(
+                "api_key",
+                "API key",
+                secret=True,
+                required=True,
+                help="Sent as an Authorization: Bearer token. If your server doesn't check "
+                "keys, enter any non-empty value.",
+            ),
+        ],
+        build=_build_self_hosted,
+        blurb="Point OpenWorker at your own OpenAI-compatible model server — typically GPU-backed. "
+        "Add its URL and a key, then add models as selfhosted:<model-id>.",
+    ),
 ]
 
 _BY_NAME = {d.name: d for d in DESCRIPTORS}
@@ -400,6 +452,14 @@ def verify_provider_key(
 
     d = _BY_NAME.get(name) or _BY_NAME["openai"]
     key = (api_key or "").strip()
+    # A provider whose endpoint is a required field with no prefilled default (self-hosted) has
+    # no sane fallback URL — probing api.openai.com with its key would be wrong (and leak the
+    # key to the wrong host), so require the URL up front.
+    requires_endpoint = any(
+        f.key == "base_url" and f.required and not f.default for f in d.fields
+    )
+    if requires_endpoint and not (base_url or "").strip():
+        return {"ok": False, "error": f"Enter the endpoint URL to test {d.title}."}
     try:
         if name == "anthropic":
             resp = httpx.get(

--- a/surfaces/gui/src/providers/logos.ts
+++ b/surfaces/gui/src/providers/logos.ts
@@ -40,6 +40,7 @@ export const PROVIDER_ORDER = [
   "openai",
   "gemini",
   "ollama",
+  "selfhosted",
   "fireworks",
   "together",
   "zai",

--- a/tests/test_provider_router.py
+++ b/tests/test_provider_router.py
@@ -71,6 +71,37 @@ def test_build_ollama_client_uses_base_url(monkeypatch):
     assert captured["api_key"] == "ollama"  # placeholder, Ollama ignores it
 
 
+def test_build_self_hosted_passes_url_and_key_verbatim(monkeypatch):
+    captured: dict = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", FakeOpenAI)
+    client = build_provider_client(
+        "selfhosted",
+        {"base_url": "https://gpu-host:8000/v1", "api_key": "sk-local"},
+        secrets=None,
+    )
+    client._ensure_client()  # type: ignore[attr-defined]
+    # Both are deployment-specific and passed through as-is (no /v1 auto-append, no fallback).
+    assert captured["base_url"] == "https://gpu-host:8000/v1"
+    assert captured["api_key"] == "sk-local"
+
+
+def test_build_self_hosted_requires_url_and_key():
+    import pytest
+
+    # Missing endpoint or key fails fast with a named error, never a silent openai.com fallback.
+    with pytest.raises(RuntimeError, match="endpoint"):
+        build_provider_client("selfhosted", {"api_key": "sk-local"}, None)
+    with pytest.raises(RuntimeError, match="self-hosted API key"):
+        build_provider_client(
+            "selfhosted", {"base_url": "https://gpu-host:8000/v1"}, None
+        )
+
+
 # -- router routing -------------------------------------------------------------
 class _Recorder(ProviderClient):
     def __init__(self, name: str):
@@ -137,6 +168,9 @@ def test_router_bare_only_strips_known_provider():
         r._bare("ollama:qwen2.5-coder:32b") == "qwen2.5-coder:32b"
     )  # strip provider, keep tag
     assert r._bare("gpt-5.5") == "gpt-5.5"
+    # self-hosted is a known provider, so its prefix routes and is stripped
+    assert r._provider_name("selfhosted:llama-3.1-70b") == "selfhosted"
+    assert r._bare("selfhosted:llama-3.1-70b") == "llama-3.1-70b"
     # a colon that isn't a provider (version tag) must NOT be split — else OpenAI gets "32b"
     assert r._bare("qwen2.5-coder:32b") == "qwen2.5-coder:32b"
     assert r._provider_name("qwen2.5-coder:32b") == "openai"  # unknown prefix → default

--- a/tests/test_provider_verify.py
+++ b/tests/test_provider_verify.py
@@ -90,6 +90,24 @@ def test_verify_ollama_uses_v1_models_no_key(monkeypatch):
     assert "headers" not in cap  # keyless
 
 
+def test_verify_self_hosted_hits_custom_endpoint(monkeypatch):
+    cap: dict = {}
+    _patch_get(monkeypatch, status=200, capture=cap)
+    verify_provider_key(
+        "selfhosted", api_key="sk-local", base_url="https://gpu-host:8000/v1"
+    )
+    assert cap["url"] == "https://gpu-host:8000/v1/models"
+    assert cap["headers"]["Authorization"] == "Bearer sk-local"
+
+
+def test_verify_self_hosted_requires_endpoint(monkeypatch):
+    # No URL and no default endpoint → clear error, and NO probe (so the key can't leak to
+    # api.openai.com). httpx.get is left unpatched: if it were called the test would error out.
+    res = verify_provider_key("selfhosted", api_key="sk-local", base_url="")
+    assert res["ok"] is False
+    assert "endpoint URL" in res["error"]
+
+
 def test_verify_network_error_is_clean(monkeypatch):
     _patch_get(monkeypatch, raise_exc=ConnectionError("boom"))
     res = verify_provider_key("openai", api_key="sk-x")


### PR DESCRIPTION
## What & why

OpenWorker can already reach a self-hosted server by repurposing the OpenAI provider's *Custom endpoint* field, but that requires knowing the trick and leaves GPU-backed model servers as a second-class citizen. This adds a dedicated **Self-hosted (GPU)** provider so a user-run, OpenAI-compatible model server (vLLM, TGI, SGLang, LMDeploy, llama.cpp server, …) is a first-class choice in **Settings ▸ Models**.

## How it works

- New `ProviderDescriptor` (`name="selfhosted"`, title *"Self-hosted (GPU)"*) in `coworker/providers/registry.py`, alongside the existing vendor/Ollama entries.
- Both the **Endpoint URL** and **API key** are required, user-entered fields with **no prefilled default** — unlike the fixed-endpoint vendors, both are deployment-specific.
- The key is resolved **only** from this provider's own profile — never the OpenAI env/SecretStore fallback — so an OpenAI key is never sent to a self-hosted host. Missing URL/key fails fast with a clear, named error.
- Models are entered as `selfhosted:<model-id>` and route through the existing OpenAI-compatible client (`ProviderRouter` strips the prefix). Un-matrixed ids fall back to the conservative capability defaults in `capabilities.py`.
- The base URL is used verbatim (like the OpenAI custom-endpoint field) — include the `/v1` path.

Everything else is descriptor-driven, so the Settings pane, composer, and routing pick it up with no further changes. One frontend line adds `selfhosted` to the provider-gallery order (`logos.ts`); with no brand logo it uses the existing neutral-monogram fallback.

## Hardening

`verify_provider_key` now requires a URL before the read-only *Test* call for any provider whose endpoint is a required field with no default. Previously such a provider would fall back to probing `api.openai.com` — wrong, and it would send the self-hosted key to the wrong host.

## Tests

Added coverage in `tests/test_provider_router.py` and `tests/test_provider_verify.py`:
- build passes URL + key through verbatim (no `/v1` auto-append, no fallback)
- missing URL or key raises a named error
- `selfhosted:` prefix routes and is stripped
- verify hits the custom endpoint; verify without a URL errors and makes no probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)