### PR TITLE
Add "GLM (Z AI · coding plan)" provider (Z AI Anthropic endpoint)

### DIFF
--- a/coworker/providers/anthropic_provider.py
+++ b/coworker/providers/anthropic_provider.py
@@ -347,6 +347,7 @@ class AnthropicProvider(ProviderClient):
         api_key: Optional[str] = None,
         secrets: Any = None,
         thinking_budget: Optional[int] = None,
+        base_url: Optional[str] = None,
     ):
         # Mirrors OpenAIProvider: the SDK client is built lazily so engines can be assembled
         # before any key exists; the key resolves at call time (explicit → env → SecretStore).
@@ -355,6 +356,9 @@ class AnthropicProvider(ProviderClient):
         self._client = client
         self._api_key = api_key
         self._secrets = secrets
+        # Optional Anthropic-compatible endpoint (e.g. Z AI's /api/anthropic). None → the SDK
+        # default (api.anthropic.com).
+        self._base_url = base_url
         self.default_model = default_model
         self.thinking_budget = thinking_budget or 0
 
@@ -369,7 +373,7 @@ class AnthropicProvider(ProviderClient):
                     "No Anthropic API key configured. Set ANTHROPIC_API_KEY in the environment, "
                     "or add your key in Manage → Configure Models."
                 )
-            self._client = Anthropic(api_key=key)
+            self._client = Anthropic(api_key=key, base_url=self._base_url)
         return self._client
 
     def _request_kwargs(

--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -72,6 +72,8 @@ MATRIX: dict[str, ModelEntry] = {
     "gemini:gemini-2.5-flash": ModelEntry("Gemini 2.5 Flash · Google", _AGENTIC_VISION),
     # -- direct OpenAI-compatible vendors ----------------------------------------
     "zai:glm-5.2": ModelEntry("GLM-5.2 · Z AI"),
+    "zai-coding:glm-4.6": ModelEntry("GLM-4.6 · Z AI (coding plan)"),
+    "zai-coding:glm-4.5": ModelEntry("GLM-4.5 · Z AI (coding plan)"),
     "deepseek:deepseek-v4-flash": ModelEntry("DeepSeek V4 Flash · DeepSeek"),
     "deepseek:deepseek-v4-pro": ModelEntry("DeepSeek V4 Pro · DeepSeek"),
     "kimi:kimi-k2.6": ModelEntry("Kimi K2.6 · Moonshot"),

--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -120,6 +120,18 @@ def _build_anthropic(profile: dict[str, Any], secrets: Any) -> ProviderClient:
     )
 
 
+def _build_zai_anthropic(profile: dict[str, Any], secrets: Any) -> ProviderClient:
+    # Z AI's coding-plan key is billed ONLY on its Anthropic-compatible endpoint; the OpenAI-style
+    # /paas API (the `zai` provider) returns 429 code 1113 "insufficient balance" for it. So reach
+    # GLM through AnthropicProvider pointed at /api/anthropic, keyed from THIS provider's own
+    # profile (never the shared Anthropic env/SecretStore key — a different vendor's endpoint).
+    api_key = ((profile or {}).get("api_key") or "").strip() or None
+    base_url = ((profile or {}).get("base_url") or "").strip() or "https://api.z.ai/api/anthropic"
+    if not api_key:
+        raise RuntimeError("No Z AI API key configured — add it in Settings ▸ Models.")
+    return AnthropicProvider(api_key=api_key, base_url=base_url, secrets=secrets)
+
+
 def _build_gemini(profile: dict[str, Any], secrets: Any) -> ProviderClient:
     # Same deferred-key contract as anthropic (GeminiProvider/resolve_api_key).
     api_key = ((profile or {}).get("api_key") or "").strip() or None
@@ -262,6 +274,29 @@ DESCRIPTORS: list[ProviderDescriptor] = [
         recommended_model="glm-5.2",
         env_key="ZAI_API_KEY",
         endpoint_help="Prefilled with Z AI's international endpoint. China mainland: https://open.bigmodel.cn/api/paas/v4",
+    ),
+    # Z AI coding-plan keys are billed on Z AI's ANTHROPIC-compatible endpoint, not the OpenAI-style
+    # /paas API the `zai` provider above uses (that returns 1113 "insufficient balance" for them).
+    # This provider reuses the native Anthropic engine pointed at /api/anthropic. Separate from
+    # `anthropic` so real Claude and GLM can be configured side by side.
+    ProviderDescriptor(
+        name="zai-coding",
+        title="GLM (Z AI · coding plan)",
+        needs_key=True,
+        fields=[
+            ProviderField("api_key", "Z AI API key", secret=True),
+            ProviderField(
+                "base_url",
+                "Endpoint",
+                required=False,
+                default="https://api.z.ai/api/anthropic",
+                placeholder="https://api.z.ai/api/anthropic",
+                help="Z AI's Anthropic-compatible endpoint, where coding-plan keys are billed. China mainland: https://open.bigmodel.cn/api/anthropic",
+            ),
+        ],
+        build=_build_zai_anthropic,
+        recommended_model="glm-4.6",
+        blurb="Spends your Z AI coding-plan allowance via Z AI's Anthropic-compatible API (not the pay-as-you-go /paas endpoint).",
     ),
     _compat(
         "deepseek",

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1409,6 +1409,7 @@ class SessionManager:
     # 2026-07-04; refresh alongside `recommended_model` in providers/registry.py).
     COMPAT_MODELS = {
         "zai": ["glm-5.2", "glm-4.6"],
+        "zai-coding": ["glm-4.6", "glm-4.5"],
         "deepseek": ["deepseek-v4-flash", "deepseek-v4-pro"],
         "kimi": ["kimi-k2.6", "kimi-k2.5"],
         "minimax": ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M3"],


### PR DESCRIPTION
## Problem

Z AI's **coding-plan** keys are billed only on Z AI's Anthropic-compatible endpoint (`https://api.z.ai/api/anthropic`), not the OpenAI-style `/paas/v4` API that the built-in `zai` provider targets. With a coding-plan key, every GLM request through `zai` fails with:

```
Error code: 429 - {'error': {'code': '1113',
  'message': 'Insufficient balance or no resource package. Please recharge.'}}
```

The key is valid and funded — it's just the wrong endpoint. Confirmed directly with the same key: `200` on `/api/anthropic`, `429/1113` on `/paas/v4`.

## Fix

A dedicated **"GLM (Z AI · coding plan)"** provider that reuses the existing native Anthropic engine, pointed at Z AI's Anthropic-compatible endpoint. Kept separate from the `anthropic` provider so real Claude and GLM can be configured side by side.

- **`coworker/providers/anthropic_provider.py`** — `AnthropicProvider` gains an optional `base_url`, so the native Anthropic engine can target any Anthropic-compatible endpoint (not just `api.anthropic.com`). `None` keeps the SDK default, so existing behaviour is unchanged.
- **`coworker/providers/registry.py`** — new first-class `zai-coding` provider; endpoint is prefilled + editable, key comes from its own profile (never the shared Anthropic key).
- **`coworker/server/manager.py` / `coworker/providers/matrix.py`** — `glm-4.6` / `glm-4.5` suggestions + display labels so the composer picker shows them with human names.

Routing works via the existing `provider:` prefix mechanism (`zai-coding:glm-4.6`), and GLM's capabilities already key off the `glm` model-name heuristic, so no changes were needed there.

## Verification

`glm-4.6` answers end-to-end through `/v1/chat/completions` — including extended thinking (`thinking` block returned) — against Z AI's Anthropic endpoint with a real coding-plan key. `x-api-key` auth (what the Anthropic SDK sends) is accepted by the endpoint.

Happy to rename/relocate if this overlaps something already on your internal roadmap. I can also add before/after screenshots of the Settings ▸ Models flow if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALh6rqcKaAuyp8emiP2eb5
