### PR TITLE
Retain oversized tool output for paged retrieval

### DIFF
--- a/coworker/agent.py
+++ b/coworker/agent.py
@@ -185,9 +185,6 @@ workspace_trusted = bool(ws and WorkspaceTrustStore().is_trusted(ws))
 
     registry = ToolRegistry()
     registry.register_all(agent.build_tools(context))
-    from .tool_outputs import read_tool_output_tool
-
-    registry.register(read_tool_output_tool(tool_output_store))
     # MCP / connector tools (supplied by the manager) carry their own metadata + schema.
     if extra_tools:
         registry.register_all(extra_tools)
@@ -311,6 +308,11 @@ workspace_trusted = bool(ws and WorkspaceTrustStore().is_trusted(ws))
     # plan mode via set_mode, and the registry is fixed at build); the engine rejects the
     # call whenever the session isn't actually in plan mode.
     registry.register(propose_plan_tool())
+    # Internal retrieval must be registered last and may not silently replace (or be
+    # replaced by) an agent, connector, MCP, memory, or skill tool with the same name.
+    from .tool_outputs import read_tool_output_tool
+
+    registry.register(read_tool_output_tool(tool_output_store), replace=False)
 
     # Per-turn ephemeral context, appended to the latest user message since mid-thread system
     # messages aren't reliable across providers. Two producers: the plan-mode reminder (mode can

--- a/coworker/agent.py
+++ b/coworker/agent.py
@@ -149,7 +149,7 @@ def build_engine(
     else:
         root_list = []
 
-workspace_trusted = bool(ws and WorkspaceTrustStore().is_trusted(ws))
+    workspace_trusted = bool(ws and WorkspaceTrustStore().is_trusted(ws))
     config = load_config(ws, workspace_trusted=workspace_trusted)
 
     # Every production surface gets a session-scoped output store. Manager passes one;

--- a/coworker/agent.py
+++ b/coworker/agent.py
@@ -173,8 +173,18 @@ def build_engine(
             )
 
     capture_dir = getattr(tool_output_store, "captures_dir", None)
+    capture_writer = getattr(tool_output_store, "append_capture", None)
+    capture_policy = getattr(tool_output_store, "policy", None)
+    max_capture_bytes = getattr(
+        capture_policy, "max_single_output_bytes", 64 * 1024 * 1024
+    )
     executor = (
-        LocalExecutor(cwd=ws, capture_dir=capture_dir)
+        LocalExecutor(
+            cwd=ws,
+            capture_dir=capture_dir,
+            capture_writer=capture_writer,
+            max_capture_bytes=max_capture_bytes,
+        )
         if (agent.needs_workspace and ws is not None)
         else None
     )

--- a/coworker/agent.py
+++ b/coworker/agent.py
@@ -133,6 +133,7 @@ def build_engine(
     channel_buffer: Optional[Any] = None,
     routing_targets: Optional[list[str]] = None,
     connector_filter: Optional[set[str]] = None,
+    tool_output_store: Optional[Any] = None,
 ) -> TurnEngine:
     ws = Path(workspace).expanduser().resolve() if workspace else None
     if agent.needs_workspace and ws is None:
@@ -148,10 +149,34 @@ def build_engine(
     else:
         root_list = []
 
-    workspace_trusted = bool(ws and WorkspaceTrustStore().is_trusted(ws))
+workspace_trusted = bool(ws and WorkspaceTrustStore().is_trusted(ws))
     config = load_config(ws, workspace_trusted=workspace_trusted)
+
+    # Every production surface gets a session-scoped output store. Manager passes one;
+    # direct callers get a durable store when session_id is known, otherwise an ephemeral
+    # TemporaryDirectory cleaned up with the engine.
+    ephemeral_output_dir = None
+    if tool_output_store is None:
+        import tempfile
+        import uuid as _uuid
+
+        from .tool_outputs import SessionToolOutputStore
+
+        if session_id:
+            tool_output_store = SessionToolOutputStore(state_dir(), session_id)
+        else:
+            ephemeral_output_dir = tempfile.TemporaryDirectory(
+                prefix="ow-tool-outputs-"
+            )
+            tool_output_store = SessionToolOutputStore(
+                ephemeral_output_dir.name, _uuid.uuid4().hex
+            )
+
+    capture_dir = getattr(tool_output_store, "captures_dir", None)
     executor = (
-        LocalExecutor(cwd=ws) if (agent.needs_workspace and ws is not None) else None
+        LocalExecutor(cwd=ws, capture_dir=capture_dir)
+        if (agent.needs_workspace and ws is not None)
+        else None
     )
     todo = TodoList()
     context = AgentContext(
@@ -160,6 +185,9 @@ def build_engine(
 
     registry = ToolRegistry()
     registry.register_all(agent.build_tools(context))
+    from .tool_outputs import read_tool_output_tool
+
+    registry.register(read_tool_output_tool(tool_output_store))
     # MCP / connector tools (supplied by the manager) carry their own metadata + schema.
     if extra_tools:
         registry.register_all(extra_tools)
@@ -325,6 +353,7 @@ def build_engine(
         directory_requester=directory_requester,
         plan_approver=plan_approver,
         question_asker=question_asker,
+        tool_output_store=tool_output_store,
     )
     engine.executor = executor  # type: ignore[attr-defined]
     engine.todo = todo  # type: ignore[attr-defined]
@@ -336,6 +365,8 @@ def build_engine(
         "workspace": str(ws) if ws else "",
     }
     engine.skill_loader = skill_loader  # type: ignore[attr-defined]
+    if ephemeral_output_dir is not None:
+        engine._ephemeral_output_dir = ephemeral_output_dir
     return engine
 
 

--- a/coworker/audit.py
+++ b/coworker/audit.py
@@ -53,7 +53,7 @@ class AuditStore:
         tool = str(event.get("tool") or event.get("tool_name") or "")
         connector = str(event.get("connector") or connector_for_tool(tool) or "")
         args = _sanitize_args(tool, event.get("arguments") or {})
-        resource = _resource(
+        resource = event.get("resource") or _resource(
             tool, event.get("arguments") or {}, event.get("result") or {}
         )
         with self._lock:

--- a/coworker/engine.py
+++ b/coworker/engine.py
@@ -709,6 +709,7 @@ class TurnEngine:
                 "output_ref": stored.ref,
                 "original_chars": stored.chars,
                 "truncated": True,
+                "content_complete": stored.content_complete,
             }
             if stored
             else {}

--- a/coworker/engine.py
+++ b/coworker/engine.py
@@ -73,6 +73,7 @@ class TurnEngine:
         question_asker: Optional[
             Callable[[dict[str, Any]], "Awaitable[dict[str, Any]]"]
         ] = None,
+        tool_output_store: Any = None,
         # Called (thread-safe, best-effort) when the user stops the turn — e.g. the
         # executor's kill for a running shell command.
         interrupt_hooks: Optional[list[Callable[[], None]]] = None,
@@ -103,6 +104,13 @@ class TurnEngine:
         # (answerable inline in a live session or from the Inbox when unattended). None on surfaces
         # that can't ask (the tool then no-ops).
         self.question_asker = question_asker
+        self.tool_output_store = tool_output_store
+        self._tool_projector = None
+        self._ephemeral_output_dir = None  # TemporaryDirectory when store is ephemeral
+        if tool_output_store is not None:
+            from .tool_outputs import ToolResultProjector
+
+            self._tool_projector = ToolResultProjector(tool_output_store)
         self.audit_context: dict[str, Any] = {}
         if instructions and not (
             self.messages and self.messages[0].get("role") == "system"
@@ -582,7 +590,9 @@ class TurnEngine:
             if outcome is ApprovalOutcome.DENY:
                 allowed, reason = (
                     False,
-                    "interrupted by user" if self._cancel.is_set() else "denied by user",
+                    "interrupted by user"
+                    if self._cancel.is_set()
+                    else "denied by user",
                 )
                 self._audit(
                     tool_call,
@@ -649,7 +659,33 @@ class TurnEngine:
         if isinstance(result, dict) and "_display" in result:
             display = result.get("_display") or None
             result = {k: v for k, v in result.items() if k != "_display"}
-        message = _tool_result_message(tool_call, result)
+        projected: Any = result
+        stored = None
+        try:
+            if self._tool_projector is not None:
+                outcome = self._tool_projector.project(
+                    tool_call.id, tool_call.name, result
+                )
+                projected, stored = outcome.model_value, outcome.stored
+        except Exception:
+            from .tool_outputs import serialize_tool_result
+
+            try:
+                original_chars: int | None = len(serialize_tool_result(result))
+            except Exception:
+                original_chars = None
+            projected = {
+                "error": "tool output could not be retained",
+                "recoverable": False,
+                **(
+                    {"original_chars": original_chars}
+                    if original_chars is not None
+                    else {}
+                ),
+            }
+            stored = None
+            status = "error"
+        message = _tool_result_message(tool_call, projected)
         if display:
             message["_display"] = display
         self.messages.append(message)
@@ -668,12 +704,28 @@ class TurnEngine:
                 status="hidden",
                 reason=" · ".join(parts) + " by privacy filters",
             )
+        spill_meta = (
+            {
+                "output_ref": stored.ref,
+                "original_chars": stored.chars,
+                "truncated": True,
+            }
+            if stored
+            else {}
+        )
         self._audit(
             tool_call,
             stage="finished",
             status=status,
-            result=result,
-            result_preview=_preview(result),
+            # Never audit the full raw result — only the (possibly projected) model value.
+            result_preview=_preview(projected),
+            projected_chars=len(_serialize_result(projected)),
+            resource=(
+                str(result["url"])
+                if isinstance(result, dict) and result.get("url")
+                else ""
+            ),
+            **spill_meta,
         )
         rule = self._standing_notes.pop(tool_call.id, "")
         return Event(
@@ -681,7 +733,8 @@ class TurnEngine:
             {
                 "name": tool_call.name,
                 "status": status,
-                "result_preview": _preview(result),
+                "result_preview": _preview(projected),
+                **spill_meta,
                 **({"display": display} if display else {}),
                 **({"standing_rule": rule} if rule else {}),
             },
@@ -1016,6 +1069,10 @@ def _tool_result_message(tool_call: ToolCall, result: Any) -> dict[str, Any]:
         "content": content,
         "ts": time.time(),
     }
+
+
+def _serialize_result(result: Any) -> str:
+    return result if isinstance(result, str) else json.dumps(result, default=str)
 
 
 def _tool_error_message(tool_call: ToolCall, reason: str) -> dict[str, Any]:

--- a/coworker/local_state.py
+++ b/coworker/local_state.py
@@ -1,0 +1,46 @@
+"""Shared helpers for local, user-scoped state directories and files.
+
+Extracted so secret storage and durable tool-output storage share one
+cross-platform ACL path without importing each other.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_IS_WINDOWS = sys.platform == "win32"
+
+
+def restrict_to_user(path: Path, *, is_dir: bool) -> None:
+    """Restrict a path so only the current user can access it.
+
+    POSIX expresses this with mode bits (0700 dir / 0600 file). Windows has no such bits —
+    `os.chmod` there only toggles the read-only flag, so a 0600 chmod is a silent no-op and
+    the file inherits broad ACLs (SYSTEM, Administrators, …). Use an ACL instead: strip
+    inherited entries and grant the current user alone. Best-effort on Windows so a transient
+    icacls failure never blocks saving state.
+    """
+    if _IS_WINDOWS:
+        user = os.environ.get("USERNAME")
+        if not user:
+            return
+        domain = os.environ.get("USERDOMAIN")
+        account = f"{domain}\\{user}" if domain else user
+        # A directory grant MUST be inheritable — (OI) object-inherit for files, (CI)
+        # container-inherit for subdirs — so everything created inside inherits the
+        # user's access. Without these flags, /inheritance:r leaves the directory with
+        # a non-inheritable ACE and any child file ends up with an empty DACL.
+        grant = f"{account}:(OI)(CI)F" if is_dir else f"{account}:F"
+        try:
+            subprocess.run(
+                ["icacls", str(path), "/inheritance:r", "/grant:r", grant],
+                capture_output=True,
+                check=False,
+            )
+        except OSError:
+            pass
+        return
+    os.chmod(path, 0o700 if is_dir else 0o600)

--- a/coworker/secrets.py
+++ b/coworker/secrets.py
@@ -13,15 +13,15 @@ from __future__ import annotations
 import json
 import os
 import re
-import subprocess
 import sys
 import threading
 import time
 from pathlib import Path
 from typing import Any, Optional
 
+from .local_state import restrict_to_user
+
 _REF = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
-_IS_WINDOWS = sys.platform == "win32"
 
 
 def state_dir() -> Path:
@@ -56,49 +56,17 @@ def _load_dotenv(path: Path) -> dict[str, str]:
     return env
 
 
-def _restrict_to_user(path: Path, *, is_dir: bool) -> None:
-    """Restrict a path so only the current user can access it.
-
-    POSIX expresses this with mode bits (0700 dir / 0600 file). Windows has no such bits —
-    `os.chmod` there only toggles the read-only flag, so a 0600 chmod is a silent no-op and
-    the file inherits broad ACLs (SYSTEM, Administrators, …). Use an ACL instead: strip
-    inherited entries and grant the current user alone. Best-effort on Windows so a transient
-    icacls failure never blocks saving a key."""
-    if _IS_WINDOWS:
-        user = os.environ.get("USERNAME")
-        if not user:
-            return
-        domain = os.environ.get("USERDOMAIN")
-        account = f"{domain}\\{user}" if domain else user
-        # A directory grant MUST be inheritable — (OI) object-inherit for files, (CI)
-        # container-inherit for subdirs — so everything created inside (the SQLite stores,
-        # conversations, …) inherits the user's access. Without these flags, /inheritance:r
-        # leaves the directory with a non-inheritable ACE and any child file ends up with an
-        # empty DACL → sqlite3 "unable to open database file", crashing the server on launch.
-        grant = f"{account}:(OI)(CI)F" if is_dir else f"{account}:F"
-        try:
-            subprocess.run(
-                ["icacls", str(path), "/inheritance:r", "/grant:r", grant],
-                capture_output=True,
-                check=False,
-            )
-        except OSError:
-            pass
-        return
-    os.chmod(path, 0o700 if is_dir else 0o600)
-
-
 def write_private_text(path: str | Path, content: str) -> Path:
     """Atomically write a user-only text file using the SecretStore's OS protections."""
     target = Path(path).expanduser()
     target.parent.mkdir(parents=True, exist_ok=True)
     try:
-        _restrict_to_user(target.parent, is_dir=True)
+        restrict_to_user(target.parent, is_dir=True)
     except OSError:
         pass
     tmp = target.with_name(target.name + ".tmp")
     tmp.write_text(content, encoding="utf-8")
-    _restrict_to_user(tmp, is_dir=False)
+    restrict_to_user(tmp, is_dir=False)
     os.replace(tmp, target)
     return target
 
@@ -184,10 +152,10 @@ class SecretStore:
     def _write(self, store: dict[str, Any]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         try:
-            _restrict_to_user(self.path.parent, is_dir=True)
+            restrict_to_user(self.path.parent, is_dir=True)
         except OSError:
             pass
         tmp = self.path.with_name(self.path.name + ".tmp")
         tmp.write_text(json.dumps(store, indent=2), encoding="utf-8")
-        _restrict_to_user(tmp, is_dir=False)
+        restrict_to_user(tmp, is_dir=False)
         os.replace(tmp, self.path)

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -165,6 +165,7 @@ from .manager import SessionManager
 def create_app(manager: SessionManager) -> FastAPI:
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
+        manager.collect_tool_output_orphans()
         try:
             live = (
                 await manager.start_gateway()
@@ -592,6 +593,34 @@ def create_app(manager: SessionManager) -> FastAPI:
     @app.get("/v1/sessions/{session_id}/messages")
     def session_messages(session_id: str) -> dict[str, Any]:
         return {"messages": manager.session_messages(session_id)}
+
+    @app.get("/v1/sessions/{session_id}/tool-outputs/{output_ref}")
+    def tool_output(
+        session_id: str,
+        output_ref: str,
+        offset_bytes: int = 0,
+        limit_bytes: int = 4000,
+    ) -> dict[str, Any]:
+        from fastapi import HTTPException
+
+        from ..tool_outputs import ToolOutputStoreError, is_valid_output_ref
+
+        if not is_valid_output_ref(output_ref):
+            raise HTTPException(status_code=400, detail="invalid output reference")
+        if manager.session_store.load(session_id) is None and session_id not in manager._engines:
+            raise HTTPException(status_code=404, detail="session not found")
+        try:
+            store = manager.tool_output_store(session_id, create=False)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail="tool output not found")
+        try:
+            return store.read(output_ref, offset_bytes, limit_bytes)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        except KeyError:
+            raise HTTPException(status_code=404, detail="tool output not found")
+        except ToolOutputStoreError as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
 
     @app.patch("/v1/sessions/{session_id}")
     def session_patch(session_id: str, body: dict) -> dict[str, Any]:

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -445,6 +445,7 @@ class SessionManager:
             routing_targets=self._routing_targets(session_id, agent),
             # Per-session connection hierarchy: expose only effective-enabled connectors' tools.
             connector_filter=self.effective_connectors(session_id, agent_name),
+            tool_output_store=self.tool_output_store(session_id),
         )
         # An automation run rebuilt here (manual "Run now" over WS, durable resume) still
         # carries its task's standing allowances — the rules live on the task record.
@@ -1737,6 +1738,7 @@ class SessionManager:
 
         env_key = bool(os.environ.get("OPENAI_API_KEY"))
         stored = bool((self.secrets.get("provider:openai") or {}).get("api_key"))
+
         # Only surface models whose provider is actually configured — the composer picker
         # reflects exactly what's connected. The active default is always kept selectable
         # (it's hidden behind the "No model" state until a provider is connected anyway).
@@ -2587,6 +2589,7 @@ class SessionManager:
             # Scheduled runs respect the same per-session connection hierarchy as live sessions:
             # expose only the persona's effective-enabled connectors' tools (§4.3).
             connector_filter=self.effective_connectors(session_id, task.agent),
+            tool_output_store=self.tool_output_store(session_id),
         )
         self._seed_task_permissions(engine, task)
         return engine
@@ -3557,6 +3560,19 @@ class SessionManager:
                 engine.request_interrupt()
             except Exception:
                 pass
+            try:
+                executor = getattr(engine, "executor", None)
+                if executor is not None:
+                    executor.close_background_tasks()
+            except Exception:
+                pass
+        try:
+            # Always attempt cleanup — even when the conversation record is already gone.
+            self.tool_output_store(session_id, create=False).delete_all()
+        except FileNotFoundError:
+            pass
+        except Exception:
+            pass
         record = self.session_store.load(session_id)
         ok = self.session_store.delete(session_id)
         # Deleting a session is the one implicit unsubscribe (otherwise subscriptions are permanent).
@@ -3584,6 +3600,45 @@ class SessionManager:
             except OSError:
                 pass  # a stale/foreign path must not fail the delete
         return {"ok": ok, "session_id": session_id}
+
+    def tool_output_store(self, session_id: str, *, create: bool = True):
+        from ..tool_outputs import SessionToolOutputStore
+
+        return SessionToolOutputStore(self._data_base, session_id, create=create)
+
+    def collect_tool_output_orphans(self, grace_seconds: float = 24 * 60 * 60) -> int:
+        """Delete hashed output dirs older than grace with no session record and no live engine.
+
+        Never evicts outputs for known or live sessions. Per-directory errors are swallowed
+        so one bad path cannot abort startup.
+        """
+        from ..tool_outputs import session_output_key
+
+        root = self._data_base / "tool-outputs"
+        if not root.is_dir():
+            return 0
+        known = {session_output_key(r.session_id) for r in self.session_store.list()}
+        live = {session_output_key(sid) for sid in self._engines}
+        preserve = known | live
+        removed = 0
+        now = time.time()
+        for child in root.iterdir():
+            try:
+                if (
+                    not child.is_dir()
+                    or len(child.name) != 64
+                    or any(char not in "0123456789abcdef" for char in child.name)
+                ):
+                    continue
+                if child.name in preserve:
+                    continue
+                if now - child.stat().st_mtime < grace_seconds:
+                    continue
+                shutil.rmtree(child)
+                removed += 1
+            except OSError:
+                pass
+        return removed
 
     # -- provider proxy ---------------------------------------------------------
     def provider_complete(self, model, messages, tools=None):

--- a/coworker/tool_outputs.py
+++ b/coworker/tool_outputs.py
@@ -51,6 +51,7 @@ class StoredToolOutput:
     bytes: int
     sha256: str
     created_at: float
+    content_complete: bool = True
     schema_version: int = _SCHEMA_VERSION
 
 
@@ -138,6 +139,7 @@ class SessionToolOutputStore:
     def _used_bytes(self) -> int:
         total = 0
         paths = list(self.directory.glob("out_*.txt"))
+        paths.extend(self.directory.glob("out_*.json"))
         if self.captures_dir.is_dir():
             paths.extend(self.captures_dir.glob("*.log"))
         for path in paths:
@@ -147,8 +149,9 @@ class SessionToolOutputStore:
                 pass
         return total
 
-    def _ensure_quota(self, nbytes: int) -> None:
-        if nbytes > self.policy.max_single_output_bytes:
+    def _ensure_quota(self, nbytes: int, *, content_bytes: int | None = None) -> None:
+        single_bytes = nbytes if content_bytes is None else content_bytes
+        if single_bytes > self.policy.max_single_output_bytes:
             raise ToolOutputStoreError("tool output exceeds per-result quota")
         if self._used_bytes() + nbytes > self.policy.max_session_output_bytes:
             raise ToolOutputStoreError("tool output exceeds session quota")
@@ -177,11 +180,15 @@ class SessionToolOutputStore:
             raise
 
     def put(
-        self, tool_call_id: str, tool_name: str, serialized: str
+        self,
+        tool_call_id: str,
+        tool_name: str,
+        serialized: str,
+        *,
+        content_complete: bool = True,
     ) -> StoredToolOutput:
         raw = serialized.encode("utf-8")
         with self._lock:
-            self._ensure_quota(len(raw))
             record = StoredToolOutput(
                 ref=f"out_{secrets.token_hex(16)}",
                 tool_call_id=str(tool_call_id),
@@ -190,14 +197,27 @@ class SessionToolOutputStore:
                 bytes=len(raw),
                 sha256=hashlib.sha256(raw).hexdigest(),
                 created_at=time.time(),
+                content_complete=content_complete,
             )
-            # Publish content first so a crash never leaves a metadata pointer without bytes.
-            self._atomic_write(self._path(record.ref, ".txt"), raw)
             meta = {**asdict(record), "schema_version": record.schema_version}
-            self._atomic_write(
-                self._path(record.ref, ".json"),
-                json.dumps(meta, sort_keys=True).encode("utf-8"),
+            meta_raw = json.dumps(meta, sort_keys=True).encode("utf-8")
+            self._ensure_quota(
+                len(raw) + len(meta_raw),
+                content_bytes=len(raw),
             )
+            content_path = self._path(record.ref, ".txt")
+            # Publish content first so a crash never leaves a metadata pointer without bytes.
+            self._atomic_write(content_path, raw)
+            try:
+                self._atomic_write(self._path(record.ref, ".json"), meta_raw)
+            except BaseException:
+                # A metadata failure must not leave an unreachable content blob consuming
+                # this known session's quota forever.
+                try:
+                    content_path.unlink()
+                except OSError:
+                    pass
+                raise
             return record
 
     def read(
@@ -313,6 +333,9 @@ class ToolResultProjector:
         self, tool_call_id: str, tool_name: str, result: Any
     ) -> ProjectedToolOutput:
         serialized = serialize_tool_result(result)
+        content_complete = not (
+            isinstance(result, dict) and result.get("retained_complete") is False
+        )
         # Retrieval must never spill recursively. The tool factory sizes pages to
         # the inline policy; this guard handles custom callers or corrupt results.
         if tool_name == "read_tool_output":
@@ -327,7 +350,12 @@ class ToolResultProjector:
             return ProjectedToolOutput(model_value=result, stored=None)
         if len(serialized) <= self.policy.inline_limit_chars:
             return ProjectedToolOutput(model_value=result, stored=None)
-        record = self.store.put(tool_call_id, tool_name, serialized)
+        record = self.store.put(
+            tool_call_id,
+            tool_name,
+            serialized,
+            content_complete=content_complete,
+        )
         preview_chars = self.policy.preview_chars
         while True:
             head = preview_chars // 2
@@ -345,10 +373,19 @@ class ToolResultProjector:
                 "original_chars": record.chars,
                 "original_bytes": record.bytes,
                 "sha256": record.sha256,
+                "content_complete": record.content_complete,
                 "preview": preview,
                 "instruction": (
-                    "Use read_tool_output with output_ref and offset_bytes to inspect "
-                    "the complete result."
+                    (
+                        "Use read_tool_output with output_ref and offset_bytes to inspect "
+                        "the complete result."
+                    )
+                    if record.content_complete
+                    else (
+                        "Use read_tool_output with output_ref and offset_bytes to inspect "
+                        "the retained portion. The source exceeded its capture quota, so "
+                        "the original output is not fully recoverable."
+                    )
                 ),
             }
             # JSON escaping can expand control characters and non-ASCII content.

--- a/coworker/tool_outputs.py
+++ b/coworker/tool_outputs.py
@@ -1,0 +1,437 @@
+"""Session-scoped durable storage for oversized tool results.
+
+Large tool outputs are written under a hashed session directory, projected into a
+bounded head/tail envelope for the model, and retrieved later via `read_tool_output`
+or the HTTP paging route. References are opaque (`out_…`) and never embed paths or
+provider-controlled IDs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import shutil
+import tempfile
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import aisuite as ai
+
+from .local_state import restrict_to_user
+
+_REF = re.compile(r"^out_[0-9a-f]{32}$")
+_SCHEMA_VERSION = 1
+# Leave this much free space on the volume before accepting a write.
+_MIN_DISK_HEADROOM_BYTES = 64 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ToolOutputPolicy:
+    inline_limit_chars: int = 8_000
+    preview_chars: int = 2_000
+    read_default_bytes: int = 4_000
+    read_max_bytes: int = 8_000
+    max_single_output_bytes: int = 64 * 1024 * 1024
+    max_session_output_bytes: int = 512 * 1024 * 1024
+    min_disk_headroom_bytes: int = _MIN_DISK_HEADROOM_BYTES
+
+
+@dataclass(frozen=True)
+class StoredToolOutput:
+    ref: str
+    tool_call_id: str
+    tool_name: str
+    chars: int
+    bytes: int
+    sha256: str
+    created_at: float
+    schema_version: int = _SCHEMA_VERSION
+
+
+@dataclass(frozen=True)
+class ProjectedToolOutput:
+    model_value: Any
+    stored: StoredToolOutput | None
+
+
+@dataclass(frozen=True)
+class ToolOutputPage:
+    output_ref: str
+    offset_bytes: int
+    content: str
+    next_offset_bytes: int | None
+    complete: bool
+    total_chars: int
+    total_bytes: int
+    sha256: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "output_ref": self.output_ref,
+            "offset_bytes": self.offset_bytes,
+            "content": self.content,
+            "next_offset_bytes": self.next_offset_bytes,
+            "complete": self.complete,
+            "total_chars": self.total_chars,
+            "total_bytes": self.total_bytes,
+            "sha256": self.sha256,
+        }
+
+
+class ToolOutputStoreError(RuntimeError):
+    """Raised when an oversized result cannot be retained (quota, disk, I/O)."""
+
+
+def serialize_tool_result(result: Any) -> str:
+    """Canonical serialization shared by projector, engine, and audit sizing."""
+    return result if isinstance(result, str) else json.dumps(result, default=str)
+
+
+def session_output_key(session_id: str) -> str:
+    """Stable hashed directory name for a session. Session id never appears on disk."""
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+
+
+def is_valid_output_ref(ref: str) -> bool:
+    return bool(isinstance(ref, str) and _REF.fullmatch(ref))
+
+
+class SessionToolOutputStore:
+    """Filesystem store scoped to one opaque session directory."""
+
+    def __init__(
+        self,
+        root: str | Path,
+        session_id: str,
+        policy: ToolOutputPolicy | None = None,
+        *,
+        create: bool = True,
+    ) -> None:
+        if not session_id:
+            raise ValueError("session_id is required")
+        self.policy = policy or ToolOutputPolicy()
+        self.session_id = session_id
+        self._lock = threading.Lock()
+        self.directory = Path(root) / "tool-outputs" / session_output_key(session_id)
+        if create:
+            self.directory.mkdir(parents=True, exist_ok=True)
+            restrict_to_user(self.directory, is_dir=True)
+            self.captures_dir = self.directory / "captures"
+            self.captures_dir.mkdir(exist_ok=True)
+            restrict_to_user(self.captures_dir, is_dir=True)
+        else:
+            if not self.directory.is_dir():
+                raise FileNotFoundError("session tool output store not found")
+            self.captures_dir = self.directory / "captures"
+
+    def _path(self, ref: str, suffix: str) -> Path:
+        if not is_valid_output_ref(ref):
+            raise ValueError("invalid output reference")
+        return self.directory / f"{ref}{suffix}"
+
+    def _used_bytes(self) -> int:
+        total = 0
+        paths = list(self.directory.glob("out_*.txt"))
+        if self.captures_dir.is_dir():
+            paths.extend(self.captures_dir.glob("*.log"))
+        for path in paths:
+            try:
+                total += path.stat().st_size
+            except OSError:
+                pass
+        return total
+
+    def _ensure_quota(self, nbytes: int) -> None:
+        if nbytes > self.policy.max_single_output_bytes:
+            raise ToolOutputStoreError("tool output exceeds per-result quota")
+        if self._used_bytes() + nbytes > self.policy.max_session_output_bytes:
+            raise ToolOutputStoreError("tool output exceeds session quota")
+        try:
+            usage = shutil.disk_usage(self.directory)
+            if usage.free < self.policy.min_disk_headroom_bytes + nbytes:
+                raise ToolOutputStoreError("insufficient disk headroom for tool output")
+        except FileNotFoundError:
+            pass
+
+    def _atomic_write(self, path: Path, data: bytes) -> None:
+        fd, tmp = tempfile.mkstemp(prefix=".pending-", dir=self.directory)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+            restrict_to_user(Path(tmp), is_dir=False)
+            os.replace(tmp, path)
+            restrict_to_user(path, is_dir=False)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    def put(
+        self, tool_call_id: str, tool_name: str, serialized: str
+    ) -> StoredToolOutput:
+        raw = serialized.encode("utf-8")
+        with self._lock:
+            self._ensure_quota(len(raw))
+            record = StoredToolOutput(
+                ref=f"out_{secrets.token_hex(16)}",
+                tool_call_id=str(tool_call_id),
+                tool_name=str(tool_name),
+                chars=len(serialized),
+                bytes=len(raw),
+                sha256=hashlib.sha256(raw).hexdigest(),
+                created_at=time.time(),
+            )
+            # Publish content first so a crash never leaves a metadata pointer without bytes.
+            self._atomic_write(self._path(record.ref, ".txt"), raw)
+            meta = {**asdict(record), "schema_version": record.schema_version}
+            self._atomic_write(
+                self._path(record.ref, ".json"),
+                json.dumps(meta, sort_keys=True).encode("utf-8"),
+            )
+            return record
+
+    def read(
+        self,
+        ref: str,
+        offset_bytes: int = 0,
+        limit_bytes: int | None = None,
+    ) -> dict[str, Any]:
+        if offset_bytes < 0:
+            raise ValueError("offset_bytes must be non-negative")
+        limit = self.policy.read_default_bytes if limit_bytes is None else limit_bytes
+        if (
+            not isinstance(limit, int)
+            or limit < 1
+            or limit > self.policy.read_max_bytes
+        ):
+            raise ValueError("invalid limit_bytes")
+        # Validate ref before touching the filesystem (traversal / malformed → 400).
+        meta_path = self._path(ref, ".json")
+        content_path = self._path(ref, ".txt")
+        if not meta_path.is_file() or not content_path.is_file():
+            raise KeyError("unknown output reference")
+        try:
+            info = json.loads(meta_path.read_text(encoding="utf-8"))
+            total_bytes = int(info["bytes"])
+            total_chars = int(info["chars"])
+            digest = str(info["sha256"])
+        except (OSError, ValueError, KeyError, TypeError) as exc:
+            raise ToolOutputStoreError("tool output metadata is corrupt") from exc
+        try:
+            actual_bytes = content_path.stat().st_size
+        except OSError as exc:
+            raise ToolOutputStoreError("tool output content is unavailable") from exc
+        if total_bytes != actual_bytes:
+            raise ToolOutputStoreError("tool output content is corrupt")
+        if offset_bytes > total_bytes:
+            raise ValueError("offset beyond output")
+        try:
+            with content_path.open("rb") as stream:
+                if 0 < offset_bytes < total_bytes:
+                    # Stored content is valid UTF-8. A byte offset is a boundary exactly
+                    # when the byte at that position is not a continuation byte. Inspect
+                    # one byte instead of decoding the entire prefix for every page.
+                    stream.seek(offset_bytes)
+                    current = stream.read(1)
+                    if current and current[0] & 0xC0 == 0x80:
+                        raise ValueError("offset_bytes is not on a UTF-8 boundary")
+                stream.seek(offset_bytes)
+                page = stream.read(limit)
+        except OSError as exc:
+            raise ToolOutputStoreError("tool output content is unavailable") from exc
+        complete = offset_bytes + len(page) >= total_bytes
+        if not complete:
+            while page:
+                try:
+                    text = page.decode("utf-8")
+                    break
+                except UnicodeDecodeError as exc:
+                    if exc.reason != "unexpected end of data":
+                        raise ValueError(
+                            "offset_bytes is not on a UTF-8 boundary"
+                        ) from exc
+                    page = page[: exc.start]
+            else:
+                raise ValueError(
+                    "limit_bytes is too small for the next UTF-8 character"
+                )
+        else:
+            try:
+                text = page.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ValueError("offset_bytes is not on a UTF-8 boundary") from exc
+        nxt = offset_bytes + len(page)
+        return ToolOutputPage(
+            output_ref=ref,
+            offset_bytes=offset_bytes,
+            content=text,
+            next_offset_bytes=None if complete else nxt,
+            complete=complete,
+            total_chars=total_chars,
+            total_bytes=total_bytes,
+            sha256=digest,
+        ).as_dict()
+
+    def list_references(self) -> set[str]:
+        refs: set[str] = set()
+        for path in self.directory.glob("out_*.json"):
+            ref = path.stem
+            if is_valid_output_ref(ref) and (self.directory / f"{ref}.txt").is_file():
+                refs.add(ref)
+        return refs
+
+    def delete_all(self) -> None:
+        shutil.rmtree(self.directory, ignore_errors=True)
+
+
+class ToolResultProjector:
+    """Serialize a tool result into either its inline form or a durable envelope."""
+
+    def __init__(
+        self,
+        store: SessionToolOutputStore,
+        policy: ToolOutputPolicy | None = None,
+    ) -> None:
+        self.store = store
+        self.policy = policy or store.policy
+        if self.policy.preview_chars < 2:
+            raise ValueError("preview_chars must be at least 2")
+        if self.policy.preview_chars >= self.policy.inline_limit_chars:
+            raise ValueError("preview_chars must be smaller than inline_limit_chars")
+
+    def project(
+        self, tool_call_id: str, tool_name: str, result: Any
+    ) -> ProjectedToolOutput:
+        serialized = serialize_tool_result(result)
+        # Retrieval must never spill recursively. The tool factory sizes pages to
+        # the inline policy; this guard handles custom callers or corrupt results.
+        if tool_name == "read_tool_output":
+            if len(serialized) > self.policy.inline_limit_chars:
+                return ProjectedToolOutput(
+                    model_value={
+                        "error": "retrieved page exceeds the inline output limit",
+                        "error_kind": "limit",
+                    },
+                    stored=None,
+                )
+            return ProjectedToolOutput(model_value=result, stored=None)
+        if len(serialized) <= self.policy.inline_limit_chars:
+            return ProjectedToolOutput(model_value=result, stored=None)
+        record = self.store.put(tool_call_id, tool_name, serialized)
+        preview_chars = self.policy.preview_chars
+        while True:
+            head = preview_chars // 2
+            tail = preview_chars - head
+            omitted = len(serialized) - preview_chars
+            preview = (
+                serialized[:head]
+                + f"\n\n[... {omitted} characters omitted ...]\n\n"
+                + serialized[-tail:]
+            )
+            envelope = {
+                "output_ref_version": 1,
+                "output_ref": record.ref,
+                "truncated": True,
+                "original_chars": record.chars,
+                "original_bytes": record.bytes,
+                "sha256": record.sha256,
+                "preview": preview,
+                "instruction": (
+                    "Use read_tool_output with output_ref and offset_bytes to inspect "
+                    "the complete result."
+                ),
+            }
+            # JSON escaping can expand control characters and non-ASCII content.
+            # Size the actual provider payload, not only the raw preview characters.
+            if (
+                len(serialize_tool_result(envelope))
+                <= self.policy.inline_limit_chars
+                or preview_chars <= 2
+            ):
+                break
+            preview_chars = max(2, preview_chars // 2)
+        return ProjectedToolOutput(model_value=envelope, stored=record)
+
+
+def read_tool_output_tool(store: SessionToolOutputStore):
+    """Low-risk tool factory closed over a session store."""
+
+    default_limit = store.policy.read_default_bytes
+
+    def read_tool_output(
+        output_ref: str,
+        offset_bytes: int = 0,
+        limit_bytes: int = default_limit,
+    ) -> dict[str, Any]:
+        try:
+            requested = limit_bytes
+            while requested >= 1:
+                page = store.read(output_ref, offset_bytes, requested)
+                if (
+                    len(serialize_tool_result(page))
+                    <= store.policy.inline_limit_chars
+                ):
+                    return page
+                requested //= 2
+            return {
+                "error": "retrieved page exceeds the inline output limit",
+                "error_kind": "limit",
+            }
+        except ValueError as exc:
+            return {"error": str(exc), "error_kind": "invalid"}
+        except KeyError as exc:
+            return {"error": str(exc), "error_kind": "missing"}
+        except ToolOutputStoreError as exc:
+            return {"error": str(exc), "error_kind": "corrupt"}
+
+    read_tool_output.__name__ = "read_tool_output"
+    read_tool_output.__coworker_schema__ = {
+        "type": "function",
+        "function": {
+            "name": "read_tool_output",
+            "description": (
+                "Read an exact bounded page of a retained tool output. Pass the "
+                "output_ref from a truncated tool result envelope, plus optional "
+                "offset_bytes / limit_bytes. Does not accept filesystem paths."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "output_ref": {
+                        "type": "string",
+                        "description": "Opaque reference from a truncated tool result.",
+                    },
+                    "offset_bytes": {
+                        "type": "integer",
+                        "description": "Byte offset into the retained UTF-8 output.",
+                    },
+                    "limit_bytes": {
+                        "type": "integer",
+                        "description": (
+                            f"Max bytes to return (default {default_limit}, "
+                            f"max {store.policy.read_max_bytes})."
+                        ),
+                    },
+                },
+                "required": ["output_ref"],
+            },
+        },
+    }
+    read_tool_output.__aisuite_tool_metadata__ = ai.ToolMetadata(
+        name="read_tool_output",
+        category="context",
+        risk_level="low",
+        capabilities=["read"],
+        requires_approval=False,
+    )
+    return read_tool_output

--- a/coworker/tool_outputs.py
+++ b/coworker/tool_outputs.py
@@ -119,6 +119,7 @@ class SessionToolOutputStore:
         self.policy = policy or ToolOutputPolicy()
         self.session_id = session_id
         self._lock = threading.Lock()
+        self._verified_content: dict[str, tuple[int, int, int, int, int, str]] = {}
         self.directory = Path(root) / "tool-outputs" / session_output_key(session_id)
         if create:
             self.directory.mkdir(parents=True, exist_ok=True)
@@ -179,6 +180,53 @@ class SessionToolOutputStore:
                 pass
             raise
 
+    @staticmethod
+    def _content_signature(stat: os.stat_result) -> tuple[int, int, int, int, int]:
+        """Filesystem identity used to cache a successful content digest check."""
+        return (
+            stat.st_dev,
+            stat.st_ino,
+            stat.st_size,
+            stat.st_mtime_ns,
+            stat.st_ctime_ns,
+        )
+
+    def append_capture(self, path: Path, data: bytes) -> int:
+        """Append as much capture data as the shared session quota permits.
+
+        Tool-output blobs and background captures use this same lock and byte
+        accounting, so neither writer can independently consume the full session
+        allowance.
+        """
+        target = Path(path)
+        if (
+            target.parent != self.captures_dir
+            or target.suffix != ".log"
+            or not target.name
+        ):
+            raise ValueError("capture path is outside the session output store")
+        if not data:
+            return 0
+        with self._lock:
+            session_remaining = max(
+                0, self.policy.max_session_output_bytes - self._used_bytes()
+            )
+            try:
+                usage = shutil.disk_usage(self.directory)
+                disk_remaining = max(
+                    0, usage.free - self.policy.min_disk_headroom_bytes
+                )
+            except FileNotFoundError:
+                disk_remaining = session_remaining
+            granted = min(len(data), session_remaining, disk_remaining)
+            if granted <= 0:
+                return 0
+            with target.open("ab") as handle:
+                handle.write(data[:granted])
+                handle.flush()
+            restrict_to_user(target, is_dir=False)
+            return granted
+
     def put(
         self,
         tool_call_id: str,
@@ -218,6 +266,11 @@ class SessionToolOutputStore:
                 except OSError:
                     pass
                 raise
+            stat = content_path.stat()
+            self._verified_content[record.ref] = (
+                *self._content_signature(stat),
+                record.sha256,
+            )
             return record
 
     def read(
@@ -247,16 +300,22 @@ class SessionToolOutputStore:
             digest = str(info["sha256"])
         except (OSError, ValueError, KeyError, TypeError) as exc:
             raise ToolOutputStoreError("tool output metadata is corrupt") from exc
-        try:
-            actual_bytes = content_path.stat().st_size
-        except OSError as exc:
-            raise ToolOutputStoreError("tool output content is unavailable") from exc
-        if total_bytes != actual_bytes:
-            raise ToolOutputStoreError("tool output content is corrupt")
         if offset_bytes > total_bytes:
             raise ValueError("offset beyond output")
         try:
-            with content_path.open("rb") as stream:
+            with self._lock, content_path.open("rb") as stream:
+                stat = os.fstat(stream.fileno())
+                if total_bytes != stat.st_size:
+                    raise ToolOutputStoreError("tool output content is corrupt")
+                signature = self._content_signature(stat)
+                cached = self._verified_content.get(ref)
+                if cached != (*signature, digest):
+                    hasher = hashlib.sha256()
+                    for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                        hasher.update(chunk)
+                    if not secrets.compare_digest(hasher.hexdigest(), digest):
+                        raise ToolOutputStoreError("tool output content is corrupt")
+                    self._verified_content[ref] = (*signature, digest)
                 if 0 < offset_bytes < total_bytes:
                     # Stored content is valid UTF-8. A byte offset is a boundary exactly
                     # when the byte at that position is not a continuation byte. Inspect
@@ -311,6 +370,7 @@ class SessionToolOutputStore:
         return refs
 
     def delete_all(self) -> None:
+        self._verified_content.clear()
         shutil.rmtree(self.directory, ignore_errors=True)
 
 

--- a/coworker/tools/registry.py
+++ b/coworker/tools/registry.py
@@ -32,10 +32,13 @@ class ToolRegistry:
         *,
         metadata: Any = None,
         schema: Optional[dict[str, Any]] = None,
+        replace: bool = True,
     ) -> ToolSpec:
         name = getattr(func, "__name__", None)
         if not name:
             raise ValueError("Tool function must have a __name__.")
+        if not replace and name in self._tools:
+            raise ValueError(f"Tool name is reserved or already registered: {name}")
         meta = metadata or getattr(func, "__aisuite_tool_metadata__", None)
         # Allow an explicit schema override (param or a `__coworker_schema__` attribute)
         # for tools whose signature can't be auto-converted to a valid JSON schema.

--- a/coworker/tools/shell.py
+++ b/coworker/tools/shell.py
@@ -36,12 +36,18 @@ from typing import Any, Optional
 
 import aisuite as ai
 
+from ..local_state import restrict_to_user
+
 _IS_WINDOWS = sys.platform == "win32"
 
 # Foreground timeout bounds: long enough for installs/builds/test runs by default, capped so
 # a model-requested timeout can't wedge the turn for more than ten minutes.
 _DEFAULT_TIMEOUT = 120.0
 _MAX_TIMEOUT = 600.0
+# Leave headroom for the JSON shell-result wrapper and worst-case JSON escaping
+# before the projector's 64 MiB per-result retention ceiling.
+_MAX_FOREGROUND_RETAINED_BYTES = 8 * 1024 * 1024
+_MAX_SESSION_CAPTURE_BYTES = 512 * 1024 * 1024
 
 # Env defaults that discourage commands from blocking on a prompt.
 _NONINTERACTIVE_ENV = {
@@ -73,12 +79,35 @@ class Executor(ABC):
 
 
 class _BackgroundTask:
-    """One detached background command: its own process (not the persistent shell), a
-    reader thread draining output into a buffer, and an incremental-read cursor."""
+    """One detached background command.
 
-    def __init__(self, task_id: str, command: str, cwd: str, env: dict[str, str]):
+    Output streams to an append-only capture file under the session capture
+    directory (or a temp dir when none is configured). The reader thread never
+    retains the full process output in memory. Incremental polls advance a byte
+    cursor; older bytes remain on disk until the session is deleted.
+    """
+
+    # Same ceiling as ToolOutputPolicy.max_single_output_bytes.
+    MAX_RETAINED_BYTES = 64 * 1024 * 1024
+
+    def __init__(
+        self,
+        task_id: str,
+        command: str,
+        cwd: str,
+        env: dict[str, str],
+        capture_dir: Path,
+        reserve_bytes,
+    ):
         self.id = task_id
         self.command = command
+        # Task ids restart when an executor is rebuilt. Keep the public id simple,
+        # but make the on-disk capture unique so a new bg-1 never appends to stale bg-1.
+        self.capture_path = (
+            Path(capture_dir) / f"{task_id}-{uuid.uuid4().hex}.log"
+        )
+        self._reserve_bytes = reserve_bytes
+        self.capture_path.parent.mkdir(parents=True, exist_ok=True)
         if _IS_WINDOWS:
             argv = ["powershell.exe", "-NoProfile", "-Command", command]
             spawn_kwargs: dict[str, Any] = {
@@ -93,28 +122,107 @@ class _BackgroundTask:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=cwd,
-            text=True,
-            bufsize=1,
+            # Binary mode so we can enforce a byte quota and UTF-8-safe paging later.
+            text=False,
+            bufsize=0,
             env=env,
             **spawn_kwargs,
         )
         self._lock = threading.Lock()
-        self._lines: list[str] = []
-        self._cursor = 0
+        self._cursor = 0  # bytes already returned by incremental polls
+        self._retained_bytes = 0
+        self._discarded_bytes = 0
+        self._retained_complete = True
+        self._capture = open(self.capture_path, "ab")
+        try:
+            restrict_to_user(self.capture_path, is_dir=False)
+        except OSError:
+            pass
         self._reader = threading.Thread(target=self._read_loop, daemon=True)
         self._reader.start()
 
     def _read_loop(self) -> None:
         assert self.proc.stdout is not None
-        for line in self.proc.stdout:
+        try:
+            while True:
+                chunk = self.proc.stdout.read(8192)
+                if not chunk:
+                    break
+                with self._lock:
+                    per_task_remaining = (
+                        self.MAX_RETAINED_BYTES - self._retained_bytes
+                    )
+                    remaining = self._reserve_bytes(
+                        min(len(chunk), max(0, per_task_remaining))
+                    )
+                    if remaining <= 0:
+                        self._discarded_bytes += len(chunk)
+                        self._retained_complete = False
+                        continue
+                    if len(chunk) > remaining:
+                        keep, drop = chunk[:remaining], chunk[remaining:]
+                        self._capture.write(keep)
+                        self._capture.flush()
+                        self._retained_bytes += len(keep)
+                        self._discarded_bytes += len(drop)
+                        self._retained_complete = False
+                    else:
+                        self._capture.write(chunk)
+                        self._capture.flush()
+                        self._retained_bytes += len(chunk)
+        finally:
             with self._lock:
-                self._lines.append(line)
+                try:
+                    self._capture.flush()
+                    self._capture.close()
+                except OSError:
+                    pass
 
-    def read_new(self) -> str:
+    def read_new(self, *, max_bytes: int | None = None) -> str:
+        """Return newly retained output since the last poll and advance the cursor."""
         with self._lock:
-            new = "".join(self._lines[self._cursor :])
-            self._cursor = len(self._lines)
-        return new
+            size = self._retained_bytes
+            start = self._cursor
+            if start >= size:
+                return ""
+            end = size if max_bytes is None else min(size, start + max_bytes)
+            # Don't advance past bytes we aren't returning.
+            path = self.capture_path
+        with open(path, "rb") as handle:
+            handle.seek(start)
+            raw = handle.read(end - start)
+        # Preserve a trailing partial UTF-8 sequence for the next poll. Invalid
+        # process bytes are replacement-decoded rather than wedging every future read.
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            if exc.reason == "unexpected end of data":
+                raw = raw[: exc.start]
+            text = raw.decode("utf-8", errors="replace")
+        with self._lock:
+            self._cursor = start + len(raw)
+        return text
+
+    def read_retained(self, offset_bytes: int = 0, limit_bytes: int = 8_000) -> bytes:
+        """Read a byte range from the durable capture (for tests / recovery)."""
+        with open(self.capture_path, "rb") as handle:
+            handle.seek(offset_bytes)
+            return handle.read(limit_bytes)
+
+    @property
+    def retained_bytes(self) -> int:
+        with self._lock:
+            return self._retained_bytes
+
+    @property
+    def discarded_bytes(self) -> int:
+        with self._lock:
+            return self._discarded_bytes
+
+    @property
+    def retained_complete(self) -> bool:
+        with self._lock:
+            return self._retained_complete
 
     def kill(self) -> None:
         if self.proc.poll() is not None:
@@ -143,6 +251,7 @@ class LocalExecutor(Executor):
         shell_path: Optional[str] = None,
         default_timeout: float = _DEFAULT_TIMEOUT,
         max_output_chars: int = 20_000,
+        capture_dir: Optional[str | Path] = None,
     ) -> None:
         self.cwd = str(Path(cwd).expanduser().resolve())
         self.default_timeout = default_timeout
@@ -151,6 +260,23 @@ class LocalExecutor(Executor):
         self._is_windows = _IS_WINDOWS
         self._bg_tasks: dict[str, _BackgroundTask] = {}
         self._bg_counter = 0
+        self._capture_quota_lock = threading.Lock()
+        # Capture directory for background tasks. When unset, use a per-executor temp dir.
+        if capture_dir is not None:
+            self._capture_dir = Path(capture_dir)
+            self._capture_dir.mkdir(parents=True, exist_ok=True)
+            self._own_capture_dir = False
+        else:
+            import tempfile
+
+            self._capture_tmpdir = tempfile.TemporaryDirectory(prefix="ow-shell-cap-")
+            self._capture_dir = Path(self._capture_tmpdir.name)
+            self._own_capture_dir = True
+        self._capture_retained_bytes = sum(
+            path.stat().st_size
+            for path in self._capture_dir.glob("*.log")
+            if path.is_file()
+        )
         # Set by interrupt_now() (user Stop) — run()'s read loop treats it like an
         # early deadline, so the in-flight foreground command dies within one tick.
         self._abort = threading.Event()
@@ -163,6 +289,16 @@ class LocalExecutor(Executor):
         self._shell_path = shell_path
         self._env = {**os.environ, **_NONINTERACTIVE_ENV, **(env or {})}
         self._spawn()
+
+    def _reserve_capture_bytes(self, requested: int) -> int:
+        """Atomically reserve part of the session-wide background capture budget."""
+        if requested <= 0:
+            return 0
+        with self._capture_quota_lock:
+            remaining = _MAX_SESSION_CAPTURE_BYTES - self._capture_retained_bytes
+            granted = min(requested, max(0, remaining))
+            self._capture_retained_bytes += granted
+            return granted
 
     def _spawn(self) -> None:
         """Start (or restart) the shell process and its reader. Reused for self-healing:
@@ -239,6 +375,8 @@ class LocalExecutor(Executor):
         aborted = False
         exit_code: Optional[int] = None
         lines: list[str] = []
+        retained_bytes = 0
+        discarded_bytes = 0
 
         while True:
             if self._abort.is_set():
@@ -281,14 +419,30 @@ class LocalExecutor(Executor):
                 if cwd:
                     self.cwd = cwd
                 break
-            lines.append(item)
+            encoded = item.encode("utf-8")
+            remaining = _MAX_FOREGROUND_RETAINED_BYTES - retained_bytes
+            if remaining <= 0:
+                discarded_bytes += len(encoded)
+                continue
+            if len(encoded) <= remaining:
+                lines.append(item)
+                retained_bytes += len(encoded)
+                continue
+            kept = encoded[:remaining]
+            while kept:
+                try:
+                    lines.append(kept.decode("utf-8"))
+                    break
+                except UnicodeDecodeError as exc:
+                    kept = kept[: exc.start]
+            retained_bytes += len(kept)
+            discarded_bytes += len(encoded) - len(kept)
 
         output = "".join(lines)
-        truncated = len(output) > self.max_output_chars
-        if truncated:
-            # Keep the TAIL: builds and test runners put the verdict at the end.
-            output = output[-self.max_output_chars :]
-        return self._result(
+        # Retain the full result. The engine's session-scoped output projector,
+        # not the executor, bounds model context without destroying evidence.
+        truncated = discarded_bytes > 0
+        result = self._result(
             command,
             exit_code,
             output,
@@ -296,6 +450,15 @@ class LocalExecutor(Executor):
             truncated=truncated,
             error="interrupted by user" if aborted else None,
         )
+        if truncated:
+            result.update(
+                {
+                    "retained_complete": False,
+                    "retained_bytes": retained_bytes,
+                    "discarded_bytes": discarded_bytes,
+                }
+            )
+        return result
 
     def interrupt_now(self) -> None:
         """User Stop: make an in-flight foreground `run()` bail on its next read tick
@@ -308,7 +471,14 @@ class LocalExecutor(Executor):
         self._bg_counter += 1
         task_id = f"bg-{self._bg_counter}"
         try:
-            task = _BackgroundTask(task_id, command, self.cwd, self._env)
+            task = _BackgroundTask(
+                task_id,
+                command,
+                self.cwd,
+                self._env,
+                self._capture_dir,
+                self._reserve_capture_bytes,
+            )
         except OSError as exc:
             return {"error": f"failed to start background task: {exc}"}
         self._bg_tasks[task_id] = task
@@ -324,16 +494,16 @@ class LocalExecutor(Executor):
         if task is None:
             return {"error": f"unknown task: {task_id}"}
         output = task.read_new()
-        truncated = len(output) > self.max_output_chars
-        if truncated:
-            output = output[-self.max_output_chars :]
         exit_code = task.proc.poll()
         return {
             "task_id": task_id,
             "status": "running" if exit_code is None else "exited",
             "exit_code": exit_code,
             "output": output,
-            "truncated": truncated,
+            "truncated": False,
+            "retained_complete": task.retained_complete,
+            "retained_bytes": task.retained_bytes,
+            "discarded_bytes": task.discarded_bytes,
         }
 
     def background_kill(self, task_id: str) -> dict[str, Any]:
@@ -350,6 +520,17 @@ class LocalExecutor(Executor):
             "status": "running" if task.proc.poll() is None else "killed",
             "exit_code": task.proc.poll(),
         }
+
+    def close_background_tasks(self) -> None:
+        """Stop and reap every detached task when its owning session is deleted."""
+        for task in self._bg_tasks.values():
+            task.kill()
+        for task in self._bg_tasks.values():
+            try:
+                task.proc.wait(timeout=5)
+            except (subprocess.TimeoutExpired, OSError):
+                pass
+            task._reader.join(timeout=1)
 
     def _trailer(self) -> str:
         """Command appended after each user command. Emits one line `<marker> <exit> <cwd>`
@@ -453,9 +634,9 @@ _RUN_SHELL_SCHEMA = {
         "name": "run_shell",
         "description": (
             "Run a shell command in the persistent session (cwd and env persist across "
-            "calls). Output longer than the limit keeps the END (where test/build verdicts "
-            "are). Set run_in_background for long-running processes like dev servers, then "
-            "poll with shell_task_output."
+            "calls). Large output is retained in full and projected by the engine for "
+            "model context. Set run_in_background for long-running processes like "
+            "dev servers, then poll with shell_task_output."
         ),
         "parameters": {
             "type": "object",

--- a/coworker/tools/shell.py
+++ b/coworker/tools/shell.py
@@ -31,6 +31,7 @@ import threading
 import time
 import uuid
 from abc import ABC, abstractmethod
+from collections import deque
 from pathlib import Path
 from typing import Any, Optional
 
@@ -44,8 +45,10 @@ _IS_WINDOWS = sys.platform == "win32"
 # a model-requested timeout can't wedge the turn for more than ten minutes.
 _DEFAULT_TIMEOUT = 120.0
 _MAX_TIMEOUT = 600.0
-# Leave headroom for the JSON shell-result wrapper and worst-case JSON escaping
-# before the projector's 64 MiB per-result retention ceiling.
+# Foreground commands remain bounded before their result reaches the engine. If a command
+# exceeds this capture quota, preserve both ends (where invocations and verdicts tend to
+# appear) and report the omitted byte count explicitly. The projector carries that
+# incompleteness into its envelope instead of claiming the original stream is recoverable.
 _MAX_FOREGROUND_RETAINED_BYTES = 8 * 1024 * 1024
 _MAX_SESSION_CAPTURE_BYTES = 512 * 1024 * 1024
 
@@ -374,9 +377,12 @@ class LocalExecutor(Executor):
         timed_out = False
         aborted = False
         exit_code: Optional[int] = None
-        lines: list[str] = []
-        retained_bytes = 0
-        discarded_bytes = 0
+        head_limit = _MAX_FOREGROUND_RETAINED_BYTES // 2
+        tail_limit = _MAX_FOREGROUND_RETAINED_BYTES - head_limit
+        head = bytearray()
+        tail: deque[bytes] = deque()
+        tail_bytes = 0
+        total_output_bytes = 0
 
         while True:
             if self._abort.is_set():
@@ -420,28 +426,44 @@ class LocalExecutor(Executor):
                     self.cwd = cwd
                 break
             encoded = item.encode("utf-8")
-            remaining = _MAX_FOREGROUND_RETAINED_BYTES - retained_bytes
-            if remaining <= 0:
-                discarded_bytes += len(encoded)
-                continue
-            if len(encoded) <= remaining:
-                lines.append(item)
-                retained_bytes += len(encoded)
-                continue
-            kept = encoded[:remaining]
-            while kept:
-                try:
-                    lines.append(kept.decode("utf-8"))
-                    break
-                except UnicodeDecodeError as exc:
-                    kept = kept[: exc.start]
-            retained_bytes += len(kept)
-            discarded_bytes += len(encoded) - len(kept)
+            total_output_bytes += len(encoded)
+            if len(head) < head_limit:
+                take = min(head_limit - len(head), len(encoded))
+                head.extend(encoded[:take])
+                encoded = encoded[take:]
+            if encoded:
+                tail.append(encoded)
+                tail_bytes += len(encoded)
+                overflow = tail_bytes - tail_limit
+                while overflow > 0 and tail:
+                    oldest = tail[0]
+                    if len(oldest) <= overflow:
+                        tail.popleft()
+                        tail_bytes -= len(oldest)
+                        overflow -= len(oldest)
+                    else:
+                        tail[0] = oldest[overflow:]
+                        tail_bytes -= overflow
+                        overflow = 0
 
-        output = "".join(lines)
-        # Retain the full result. The engine's session-scoped output projector,
-        # not the executor, bounds model context without destroying evidence.
-        truncated = discarded_bytes > 0
+        truncated = total_output_bytes > _MAX_FOREGROUND_RETAINED_BYTES
+        tail_raw = b"".join(tail)
+        if truncated:
+            head_text, head_bytes = _decode_utf8_head(bytes(head))
+            tail_text, decoded_tail_bytes = _decode_utf8_tail(tail_raw)
+            retained_bytes = head_bytes + decoded_tail_bytes
+            discarded_bytes = max(0, total_output_bytes - retained_bytes)
+            output = (
+                head_text
+                + f"\n\n[... {discarded_bytes} bytes discarded by shell capture quota ...]\n\n"
+                + tail_text
+            )
+        else:
+            raw = bytes(head) + tail_raw
+            output = raw.decode("utf-8", errors="replace")
+            retained_bytes = total_output_bytes
+            discarded_bytes = 0
+
         result = self._result(
             command,
             exit_code,
@@ -612,6 +634,27 @@ class LocalExecutor(Executor):
         return result
 
 
+def _decode_utf8_head(raw: bytes) -> tuple[str, int]:
+    """Decode a prefix, dropping only a trailing split UTF-8 character."""
+    while raw:
+        try:
+            return raw.decode("utf-8"), len(raw)
+        except UnicodeDecodeError as exc:
+            if exc.reason != "unexpected end of data":
+                return raw.decode("utf-8", errors="replace"), len(raw)
+            raw = raw[: exc.start]
+    return "", 0
+
+
+def _decode_utf8_tail(raw: bytes) -> tuple[str, int]:
+    """Decode a suffix, dropping only leading UTF-8 continuation bytes."""
+    start = 0
+    while start < len(raw) and raw[start] & 0xC0 == 0x80:
+        start += 1
+    kept = raw[start:]
+    return kept.decode("utf-8", errors="replace"), len(kept)
+
+
 def _parse_exit_code(line: str, marker: str) -> Optional[int]:
     parts = line.strip().split()
     try:
@@ -634,9 +677,10 @@ _RUN_SHELL_SCHEMA = {
         "name": "run_shell",
         "description": (
             "Run a shell command in the persistent session (cwd and env persist across "
-            "calls). Large output is retained in full and projected by the engine for "
-            "model context. Set run_in_background for long-running processes like "
-            "dev servers, then poll with shell_task_output."
+            "calls). Large output is projected by the engine for model context; output "
+            "beyond the shell capture quota preserves both ends and is marked partial. "
+            "Set run_in_background for long-running processes like dev servers, then "
+            "poll with shell_task_output."
         ),
         "parameters": {
             "type": "object",

--- a/coworker/tools/shell.py
+++ b/coworker/tools/shell.py
@@ -33,7 +33,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections import deque
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import aisuite as ai
 
@@ -100,7 +100,8 @@ class _BackgroundTask:
         cwd: str,
         env: dict[str, str],
         capture_dir: Path,
-        reserve_bytes,
+        append_capture: Callable[[Path, bytes], int],
+        max_retained_bytes: int,
     ):
         self.id = task_id
         self.command = command
@@ -109,7 +110,8 @@ class _BackgroundTask:
         self.capture_path = (
             Path(capture_dir) / f"{task_id}-{uuid.uuid4().hex}.log"
         )
-        self._reserve_bytes = reserve_bytes
+        self._append_capture = append_capture
+        self._max_retained_bytes = max_retained_bytes
         self.capture_path.parent.mkdir(parents=True, exist_ok=True)
         if _IS_WINDOWS:
             argv = ["powershell.exe", "-NoProfile", "-Command", command]
@@ -136,7 +138,7 @@ class _BackgroundTask:
         self._retained_bytes = 0
         self._discarded_bytes = 0
         self._retained_complete = True
-        self._capture = open(self.capture_path, "ab")
+        self.capture_path.touch()
         try:
             restrict_to_user(self.capture_path, is_dir=False)
         except OSError:
@@ -146,40 +148,24 @@ class _BackgroundTask:
 
     def _read_loop(self) -> None:
         assert self.proc.stdout is not None
-        try:
-            while True:
-                chunk = self.proc.stdout.read(8192)
-                if not chunk:
-                    break
-                with self._lock:
-                    per_task_remaining = (
-                        self.MAX_RETAINED_BYTES - self._retained_bytes
-                    )
-                    remaining = self._reserve_bytes(
-                        min(len(chunk), max(0, per_task_remaining))
-                    )
-                    if remaining <= 0:
-                        self._discarded_bytes += len(chunk)
-                        self._retained_complete = False
-                        continue
-                    if len(chunk) > remaining:
-                        keep, drop = chunk[:remaining], chunk[remaining:]
-                        self._capture.write(keep)
-                        self._capture.flush()
-                        self._retained_bytes += len(keep)
-                        self._discarded_bytes += len(drop)
-                        self._retained_complete = False
-                    else:
-                        self._capture.write(chunk)
-                        self._capture.flush()
-                        self._retained_bytes += len(chunk)
-        finally:
+        while True:
+            chunk = self.proc.stdout.read(8192)
+            if not chunk:
+                break
             with self._lock:
-                try:
-                    self._capture.flush()
-                    self._capture.close()
-                except OSError:
-                    pass
+                per_task_remaining = self._max_retained_bytes - self._retained_bytes
+                requested = min(len(chunk), max(0, per_task_remaining))
+                retained = self._append_capture(
+                    self.capture_path, chunk[:requested]
+                )
+                if retained <= 0:
+                    self._discarded_bytes += len(chunk)
+                    self._retained_complete = False
+                    continue
+                self._retained_bytes += retained
+                if len(chunk) > retained:
+                    self._discarded_bytes += len(chunk) - retained
+                    self._retained_complete = False
 
     def read_new(self, *, max_bytes: int | None = None) -> str:
         """Return newly retained output since the last poll and advance the cursor."""
@@ -255,6 +241,8 @@ class LocalExecutor(Executor):
         default_timeout: float = _DEFAULT_TIMEOUT,
         max_output_chars: int = 20_000,
         capture_dir: Optional[str | Path] = None,
+        capture_writer: Optional[Callable[[Path, bytes], int]] = None,
+        max_capture_bytes: int = _BackgroundTask.MAX_RETAINED_BYTES,
     ) -> None:
         self.cwd = str(Path(cwd).expanduser().resolve())
         self.default_timeout = default_timeout
@@ -280,6 +268,8 @@ class LocalExecutor(Executor):
             for path in self._capture_dir.glob("*.log")
             if path.is_file()
         )
+        self._capture_writer = capture_writer or self._append_capture
+        self._max_capture_bytes = max_capture_bytes
         # Set by interrupt_now() (user Stop) — run()'s read loop treats it like an
         # early deadline, so the in-flight foreground command dies within one tick.
         self._abort = threading.Event()
@@ -293,13 +283,18 @@ class LocalExecutor(Executor):
         self._env = {**os.environ, **_NONINTERACTIVE_ENV, **(env or {})}
         self._spawn()
 
-    def _reserve_capture_bytes(self, requested: int) -> int:
-        """Atomically reserve part of the session-wide background capture budget."""
-        if requested <= 0:
+    def _append_capture(self, path: Path, data: bytes) -> int:
+        """Fallback capture writer for standalone executors without a session store."""
+        if not data:
             return 0
         with self._capture_quota_lock:
             remaining = _MAX_SESSION_CAPTURE_BYTES - self._capture_retained_bytes
-            granted = min(requested, max(0, remaining))
+            granted = min(len(data), max(0, remaining))
+            if granted <= 0:
+                return 0
+            with path.open("ab") as handle:
+                handle.write(data[:granted])
+                handle.flush()
             self._capture_retained_bytes += granted
             return granted
 
@@ -499,7 +494,8 @@ class LocalExecutor(Executor):
                 self.cwd,
                 self._env,
                 self._capture_dir,
-                self._reserve_capture_bytes,
+                self._capture_writer,
+                self._max_capture_bytes,
             )
         except OSError as exc:
             return {"error": f"failed to start background task: {exc}"}

--- a/coworker/tui/app.py
+++ b/coworker/tui/app.py
@@ -117,6 +117,7 @@ class CoworkerApp(App):
             provider=self._provider,
             memory_store=self._memory_store,
             messages=self._resume_messages,
+            session_id=self._session_id,
         )
         self._write(
             f"[b]coworker · code[/b]  ·  model {self.model}  ·  mode {self.mode.value}"
@@ -182,7 +183,13 @@ class CoworkerApp(App):
         elif event.type is EventType.TOOL_FINISHED:
             status = data.get("status")
             tag = "green" if status == "ok" else "red"
-            extra = data.get("result_preview") or data.get("reason") or ""
+            if data.get("truncated") and data.get("output_ref"):
+                chars = data.get("original_chars")
+                extra = (
+                    f"retained locally ({chars} chars)" if chars else "retained locally"
+                )
+            else:
+                extra = data.get("result_preview") or data.get("reason") or ""
             self._write(
                 f"  [{tag}]✓ {data['name']} · {status}[/{tag}] {_short(extra, 100)}"
             )
@@ -229,6 +236,7 @@ class CoworkerApp(App):
                     mode=self.mode,
                     approver=self._approve,
                     provider=self._provider,
+                    session_id=self._session_id,
                 )
             self.query_one("#log", RichLog).clear()
             self.rendered.clear()

--- a/coworker/tui/app.py
+++ b/coworker/tui/app.py
@@ -229,7 +229,20 @@ class CoworkerApp(App):
             self._write(f"model → {arg}")
         elif name == "/clear":
             if self.engine:
-                self.engine.messages = []
+                old_engine = self.engine
+                old_engine.messages = []
+                self._persist_session()
+                executor = getattr(old_engine, "executor", None)
+                if executor is not None:
+                    close_background = getattr(
+                        executor, "close_background_tasks", None
+                    )
+                    if callable(close_background):
+                        close_background()
+                    executor.close()
+                output_store = getattr(old_engine, "tool_output_store", None)
+                if output_store is not None:
+                    output_store.delete_all()
                 self.engine = build_code_engine(
                     workspace=self.workspace,
                     model=self.model,

--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -760,6 +760,23 @@ export async function mockApi(page: import("@playwright/test").Page) {
     // session-scoped (id-agnostic — any session resolves to the same fixture).
     // POST = the per-session mute override (§32 Access toggles) — flip the shared state so
     // the section's reload sees the change.
+    if (/\/v1\/sessions\/[^/]+\/tool-outputs\/[^/]+$/.test(p)) {
+      const offset = Number(new URL(req.url()).searchParams.get("offset_bytes") || 0);
+      const full = "HEAD_SENTINEL" + "x".repeat(200) + "MIDDLE_SENTINEL" + "y".repeat(200) + "TAIL_SENTINEL";
+      const limit = Number(new URL(req.url()).searchParams.get("limit_bytes") || 4000);
+      const slice = full.slice(offset, offset + limit);
+      const next = offset + slice.length;
+      return json({
+        output_ref: p.split("/").pop(),
+        offset_bytes: offset,
+        content: slice,
+        next_offset_bytes: next >= full.length ? null : next,
+        complete: next >= full.length,
+        total_chars: full.length,
+        total_bytes: full.length,
+        sha256: "fixture",
+      });
+    }
     if (/\/v1\/sessions\/[^/]+\/connections$/.test(p)) {
       if (m === "POST") {
         const b = req.postDataJSON() || {};

--- a/surfaces/gui/e2e/tool-outputs.spec.ts
+++ b/surfaces/gui/e2e/tool-outputs.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "./fixtures";
+
+test("retained tool output card can page full output", async ({ page }) => {
+  const ref = "out_" + "d".repeat(32);
+  await page.route("**/v1/sessions/pinned-cowork-1/messages", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        messages: [
+          { role: "user", content: "Inspect the build log" },
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              {
+                id: "call-output",
+                function: {
+                  name: "run_shell",
+                  arguments: JSON.stringify({ command: "npm test" }),
+                },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            tool_call_id: "call-output",
+            content: JSON.stringify({
+              output_ref_version: 1,
+              output_ref: ref,
+              truncated: true,
+              original_chars: 450,
+              preview: "HEAD_SENTINEL\n[…]\nTAIL_SENTINEL",
+            }),
+          },
+          { role: "assistant", content: "The tests passed." },
+        ],
+      }),
+    }),
+  );
+  await page.goto("/");
+  await page.getByText("1 step").click();
+  await expect(page.getByTestId("tool-output-retained")).toBeVisible();
+  await page.getByRole("button", { name: "raw" }).click();
+  await page.getByRole("button", { name: "View full output" }).click();
+  await expect(page.getByText(/MIDDLE_SENTINEL/)).toBeVisible();
+  await expect(page.getByTestId("tool-output-complete")).toBeVisible();
+});

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -671,6 +671,13 @@ export function App() {
               d.result_preview || d.reason,
               d.display?.hidden_by_filters,
               d.standing_rule,
+              d.output_ref
+                ? {
+                    outputRef: d.output_ref,
+                    originalChars: d.original_chars,
+                    truncated: !!d.truncated,
+                  }
+                : undefined,
             ),
           );
           // Refresh the right rail when something it shows may have changed: browser state, or a
@@ -1470,6 +1477,7 @@ export function App() {
                     onApprove={approve}
                     running={running}
                     onRetry={retry}
+                    sessionId={sessionId}
                     // §33 ref #3: sub-threshold streamed text renders INSIDE the live turn
                     // group (header when collapsed, quiet line when expanded) — never as a
                     // floating paragraph.
@@ -1665,6 +1673,7 @@ function updateLastTool(
   preview?: string,
   hidden?: number,
   standingRule?: string,
+  durable?: { outputRef: string; originalChars?: number; truncated?: boolean },
 ): Item[] {
   const copy = [...items];
   for (let i = copy.length - 1; i >= 0; i--) {
@@ -1676,6 +1685,13 @@ function updateLastTool(
         preview,
         ...(hidden ? { hidden } : {}),
         ...(standingRule ? { standingRule } : {}),
+        ...(durable
+          ? {
+              outputRef: durable.outputRef,
+              originalChars: durable.originalChars,
+              truncated: durable.truncated,
+            }
+          : {}),
       };
       break;
     }

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -676,6 +676,7 @@ export function App() {
                     outputRef: d.output_ref,
                     originalChars: d.original_chars,
                     truncated: !!d.truncated,
+                    contentComplete: d.content_complete !== false,
                   }
                 : undefined,
             ),
@@ -1673,7 +1674,12 @@ function updateLastTool(
   preview?: string,
   hidden?: number,
   standingRule?: string,
-  durable?: { outputRef: string; originalChars?: number; truncated?: boolean },
+  durable?: {
+    outputRef: string;
+    originalChars?: number;
+    truncated?: boolean;
+    contentComplete?: boolean;
+  },
 ): Item[] {
   const copy = [...items];
   for (let i = copy.length - 1; i >= 0; i--) {
@@ -1690,6 +1696,7 @@ function updateLastTool(
               outputRef: durable.outputRef,
               originalChars: durable.originalChars,
               truncated: durable.truncated,
+              contentComplete: durable.contentComplete,
             }
           : {}),
       };

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -149,6 +149,42 @@ export async function getSessionMessages(sessionId: string): Promise<Conversatio
   return (await res.json()).messages ?? [];
 }
 
+export interface ToolOutputPage {
+  output_ref: string;
+  offset_bytes: number;
+  content: string;
+  next_offset_bytes: number | null;
+  complete: boolean;
+  total_chars: number;
+  total_bytes: number;
+  sha256: string;
+}
+
+export async function getToolOutput(
+  sessionId: string,
+  outputRef: string,
+  offsetBytes = 0,
+  limitBytes = 4000,
+): Promise<ToolOutputPage> {
+  const q = new URLSearchParams({
+    offset_bytes: String(offsetBytes),
+    limit_bytes: String(limitBytes),
+  });
+  const res = await fetch(
+    `${httpBase()}/v1/sessions/${encodeURIComponent(sessionId)}/tool-outputs/${encodeURIComponent(outputRef)}?${q}`,
+  );
+  if (!res.ok) {
+    let detail = "could not load tool output";
+    try {
+      detail = (await res.json()).detail || detail;
+    } catch {
+      // Keep the stable fallback for an empty or non-JSON server response.
+    }
+    throw new Error(detail);
+  }
+  return res.json();
+}
+
 export async function renameSession(sessionId: string, title: string): Promise<{ ok: boolean; error?: string }> {
   const res = await fetch(`${httpBase()}/v1/sessions/${encodeURIComponent(sessionId)}`, {
     method: "PATCH",

--- a/surfaces/gui/src/components/Transcript.test.tsx
+++ b/surfaces/gui/src/components/Transcript.test.tsx
@@ -298,4 +298,74 @@ describe("durable tool output card", () => {
     await waitFor(() => expect(screen.getByTestId("tool-output-error")).toBeTruthy());
     fetchSpy.mockRestore();
   });
+
+  it("labels quota-limited source output as partial", () => {
+    const items: Item[] = [
+      {
+        kind: "tool",
+        id: "t1",
+        name: "run_shell",
+        args: {},
+        status: "ok",
+        preview: "HEAD…TAIL",
+        truncated: true,
+        outputRef: "out_" + "d".repeat(32),
+        originalChars: 8000,
+        contentComplete: false,
+      },
+    ];
+    const { container } = render(
+      <Transcript items={items} onApprove={vi.fn()} sessionId="sess-1" />,
+    );
+    fireEvent.click(container.querySelector("summary.stepgroup-head")!);
+    expect(screen.getByTestId("tool-output-retained").textContent).toContain("partial");
+    fireEvent.click(screen.getByText("raw"));
+    expect(screen.getByTestId("tool-output-actions").textContent).toContain(
+      "Partial output retained locally",
+    );
+  });
+
+  it("drops loaded pages when the session or output identity changes", async () => {
+    const firstRef = "out_" + "e".repeat(32);
+    const secondRef = "out_" + "f".repeat(32);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        output_ref: firstRef,
+        offset_bytes: 0,
+        content: "SESSION_ONE_PRIVATE_OUTPUT",
+        next_offset_bytes: null,
+        complete: true,
+        total_chars: 26,
+        total_bytes: 26,
+        sha256: "x",
+      }),
+    } as Response);
+    const retained = (ref: string): Item[] => [
+      {
+        kind: "tool",
+        id: "same-position",
+        name: "run_shell",
+        args: {},
+        status: "ok",
+        preview: "preview",
+        truncated: true,
+        outputRef: ref,
+        contentComplete: true,
+      },
+    ];
+    const view = render(
+      <Transcript items={retained(firstRef)} onApprove={vi.fn()} sessionId="sess-1" />,
+    );
+    fireEvent.click(view.container.querySelector("summary.stepgroup-head")!);
+    fireEvent.click(screen.getByText("raw"));
+    fireEvent.click(screen.getByTestId("tool-output-load-more"));
+    await waitFor(() => expect(screen.getByText(/SESSION_ONE_PRIVATE_OUTPUT/)).toBeTruthy());
+
+    view.rerender(
+      <Transcript items={retained(secondRef)} onApprove={vi.fn()} sessionId="sess-2" />,
+    );
+    expect(screen.queryByText(/SESSION_ONE_PRIVATE_OUTPUT/)).toBeNull();
+    fetchSpy.mockRestore();
+  });
 });

--- a/surfaces/gui/src/components/Transcript.test.tsx
+++ b/surfaces/gui/src/components/Transcript.test.tsx
@@ -206,3 +206,96 @@ describe("humanizeTool", () => {
     expect(line.obj).toContain("Old plan");
   });
 });
+
+describe("durable tool output card", () => {
+  it("shows retained affordance and pages on load more", async () => {
+    const ref = "out_" + "b".repeat(32);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input: any) => {
+      const url = String(input);
+      const u = new URL(url, "http://local");
+      const offset = Number(u.searchParams.get("offset_bytes") || 0);
+      const body =
+        offset === 0
+          ? {
+              output_ref: ref,
+              offset_bytes: 0,
+              content: "PAGE_ONE ",
+              next_offset_bytes: 9,
+              complete: false,
+              total_chars: 18,
+              total_bytes: 18,
+              sha256: "x",
+            }
+          : {
+              output_ref: ref,
+              offset_bytes: 9,
+              content: "PAGE_TWO",
+              next_offset_bytes: null,
+              complete: true,
+              total_chars: 18,
+              total_bytes: 18,
+              sha256: "x",
+            };
+      return { ok: true, json: async () => body } as Response;
+    });
+
+    const items: Item[] = [
+      { kind: "user", text: "go" },
+      {
+        kind: "tool",
+        id: "t1",
+        name: "run_shell",
+        args: { command: "echo" },
+        status: "ok",
+        preview: "HEAD…TAIL",
+        truncated: true,
+        outputRef: ref,
+        originalChars: 18,
+      },
+      { kind: "assistant", text: "done" },
+    ];
+    const { container } = render(
+      <Transcript items={items} onApprove={vi.fn()} sessionId="sess-1" />,
+    );
+    fireEvent.click(container.querySelector("summary.stepgroup-head")!);
+    expect(screen.getByTestId("tool-output-retained")).toBeTruthy();
+    fireEvent.click(screen.getByText("raw"));
+    expect(screen.getByTestId("tool-output-actions").textContent).toMatch(/Full output retained locally/);
+    fireEvent.click(screen.getByTestId("tool-output-load-more"));
+    await waitFor(() => expect(screen.getByText(/PAGE_ONE/)).toBeTruthy());
+    fireEvent.click(screen.getByTestId("tool-output-load-more"));
+    await waitFor(() => expect(screen.getByTestId("tool-output-complete")).toBeTruthy());
+    expect(screen.getByText(/PAGE_TWO/)).toBeTruthy();
+    fetchSpy.mockRestore();
+  });
+
+  it("surfaces a non-fatal fetch error", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      json: async () => ({ detail: "tool output not found" }),
+    } as Response);
+    const items: Item[] = [
+      { kind: "user", text: "go" },
+      {
+        kind: "tool",
+        id: "t1",
+        name: "run_shell",
+        args: {},
+        status: "ok",
+        preview: "x",
+        truncated: true,
+        outputRef: "out_" + "c".repeat(32),
+        originalChars: 10,
+      },
+      { kind: "assistant", text: "done" },
+    ];
+    const { container } = render(
+      <Transcript items={items} onApprove={vi.fn()} sessionId="sess-1" />,
+    );
+    fireEvent.click(container.querySelector("summary.stepgroup-head")!);
+    fireEvent.click(screen.getByText("raw"));
+    fireEvent.click(screen.getByTestId("tool-output-load-more"));
+    await waitFor(() => expect(screen.getByTestId("tool-output-error")).toBeTruthy());
+    fetchSpy.mockRestore();
+  });
+});

--- a/surfaces/gui/src/components/Transcript.tsx
+++ b/surfaces/gui/src/components/Transcript.tsx
@@ -174,6 +174,7 @@ function StepRow({
   const running = tool.status === "…";
   const failed = tool.status !== "ok" && !running;
   const retained = !!(tool.truncated && tool.outputRef && sessionId);
+  const contentComplete = tool.contentComplete !== false;
 
   const loadMore = async () => {
     if (!sessionId || !tool.outputRef || loading || complete) return;
@@ -224,9 +225,13 @@ function StepRow({
           <span
             className="text-[11px] text-faint shrink-0"
             data-testid="tool-output-retained"
-            title="Complete output is retained locally and can be loaded without adding it to model context."
+            title={
+              contentComplete
+                ? "Complete output is retained locally and can be loaded without adding it to model context."
+                : "The retained head and tail can be loaded locally, but the source exceeded its capture quota."
+            }
           >
-            retained
+            {contentComplete ? "retained" : "retained (partial)"}
           </span>
         )}
         {failed && <span className="text-[11px] text-danger shrink-0">{tool.status}</span>}
@@ -252,7 +257,7 @@ function StepRow({
           data-testid="tool-output-actions"
         >
           <span>
-            Full output retained locally
+            {contentComplete ? "Full output retained locally" : "Partial output retained locally"}
             {typeof tool.originalChars === "number"
               ? ` · ${tool.originalChars.toLocaleString()} chars`
               : ""}
@@ -268,7 +273,9 @@ function StepRow({
             </button>
           )}
           {complete && pages.length > 0 && (
-            <span data-testid="tool-output-complete">complete</span>
+            <span data-testid="tool-output-complete">
+              {contentComplete ? "complete" : "all retained bytes loaded"}
+            </span>
           )}
           {loadError && (
             <span className="text-danger" data-testid="tool-output-error">
@@ -358,7 +365,12 @@ function TurnGroup({
                 {approvalChip(row.approval.resolved)}
               </div>
             ) : (
-              <StepRow tool={row.tool} approval={row.approval} sessionId={sessionId} key={i} />
+              <StepRow
+                tool={row.tool}
+                approval={row.approval}
+                sessionId={sessionId}
+                key={`tool:${sessionId || ""}:${row.tool.id}:${row.tool.outputRef || ""}`}
+              />
             ),
           )}
           {streamingText && (

--- a/surfaces/gui/src/components/Transcript.tsx
+++ b/surfaces/gui/src/components/Transcript.tsx
@@ -5,6 +5,7 @@ import { humanizeAsk, humanizeTool, type HumanLine } from "../humanize";
 import { Markdown } from "./Markdown";
 import { ConnectorMessageCard } from "./ConnectorMessageCard";
 import { Icon } from "./Icon";
+import { getToolOutput } from "../api";
 
 // Hover affordances for a message bubble (FB-005): copy the raw text + the message's time.
 // Lives in a ZERO-HEIGHT strip under the bubble (absolute, inside the transcript's 20px gap)
@@ -155,10 +156,44 @@ function LineText({ line }: { line: HumanLine }) {
   );
 }
 
-function StepRow({ tool, approval }: { tool: ToolItem; approval?: ApprovalItem }) {
+function StepRow({
+  tool,
+  approval,
+  sessionId,
+}: {
+  tool: ToolItem;
+  approval?: ApprovalItem;
+  sessionId?: string;
+}) {
   const [raw, setRaw] = useState(false);
+  const [pages, setPages] = useState<string[]>([]);
+  const [nextOffset, setNextOffset] = useState(0);
+  const [complete, setComplete] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const running = tool.status === "…";
   const failed = tool.status !== "ok" && !running;
+  const retained = !!(tool.truncated && tool.outputRef && sessionId);
+
+  const loadMore = async () => {
+    if (!sessionId || !tool.outputRef || loading || complete) return;
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const page = await getToolOutput(sessionId, tool.outputRef, nextOffset);
+      setPages((p) => [...p, page.content]);
+      if (page.complete || page.next_offset_bytes == null) {
+        setComplete(true);
+      } else {
+        setNextOffset(page.next_offset_bytes);
+      }
+    } catch (err: any) {
+      setLoadError(String(err?.message || err || "could not load tool output"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div>
       <div className="group flex items-baseline gap-2 px-2 py-0.5 rounded-lg hover:bg-paper" data-testid="turn-step">
@@ -185,6 +220,15 @@ function StepRow({ tool, approval }: { tool: ToolItem; approval?: ApprovalItem }
             {tool.hidden} hidden
           </span>
         )}
+        {retained && (
+          <span
+            className="text-[11px] text-faint shrink-0"
+            data-testid="tool-output-retained"
+            title="Complete output is retained locally and can be loaded without adding it to model context."
+          >
+            retained
+          </span>
+        )}
         {failed && <span className="text-[11px] text-danger shrink-0">{tool.status}</span>}
         {!running && (
           <button
@@ -199,7 +243,39 @@ function StepRow({ tool, approval }: { tool: ToolItem; approval?: ApprovalItem }
         <pre className="ml-8 mr-2 my-1 px-2.5 py-1.5 rounded-lg border border-line bg-paper font-mono text-[11.5px] leading-relaxed text-muted whitespace-pre-wrap break-words max-h-56 overflow-auto">
           {`${tool.name}  ${shortArgs(tool.args)}`}
           {tool.preview ? `\n→ ${tool.preview.length > 1500 ? tool.preview.slice(0, 1500) + "\n…" : tool.preview}` : ""}
+          {pages.length > 0 ? `\n\n—— retained output ——\n${pages.join("")}` : ""}
         </pre>
+      )}
+      {raw && retained && (
+        <div
+          className="ml-8 mr-2 mb-1 flex flex-wrap items-center gap-2 text-[11px] text-faint"
+          data-testid="tool-output-actions"
+        >
+          <span>
+            Full output retained locally
+            {typeof tool.originalChars === "number"
+              ? ` · ${tool.originalChars.toLocaleString()} chars`
+              : ""}
+          </span>
+          {!complete && (
+            <button
+              className="cursor-pointer hover:text-muted underline-offset-2 hover:underline disabled:opacity-50"
+              data-testid="tool-output-load-more"
+              disabled={loading}
+              onClick={loadMore}
+            >
+              {loading ? "Loading…" : pages.length ? "Load more" : "View full output"}
+            </button>
+          )}
+          {complete && pages.length > 0 && (
+            <span data-testid="tool-output-complete">complete</span>
+          )}
+          {loadError && (
+            <span className="text-danger" data-testid="tool-output-error">
+              {loadError}
+            </span>
+          )}
+        </div>
       )}
     </div>
   );
@@ -209,12 +285,14 @@ function TurnGroup({
   items,
   live,
   streamingText,
+  sessionId,
 }: {
   items: TurnItem[];
   live?: boolean;
   // Sub-threshold streamed text belongs to THIS group (§33 ref #3): collapsed → it rides
   // the header as the live line; expanded → the small quiet line under the steps.
   streamingText?: string;
+  sessionId?: string;
 }) {
   // Turns start COLLAPSED, running or not (owner call 2026-07-14) — the header's live
   // line is the pulse; expanding is opt-in.
@@ -280,7 +358,7 @@ function TurnGroup({
                 {approvalChip(row.approval.resolved)}
               </div>
             ) : (
-              <StepRow tool={row.tool} approval={row.approval} key={i} />
+              <StepRow tool={row.tool} approval={row.approval} sessionId={sessionId} key={i} />
             ),
           )}
           {streamingText && (
@@ -311,6 +389,8 @@ interface Props {
   // Re-run the failed turn (no new user message). Offered only on a retriable notice that
   // is the transcript tail of an idle session — anywhere else the error is history.
   onRetry?: () => void;
+  // Needed to page retained tool outputs without putting them back into model context.
+  sessionId?: string;
 }
 
 // The transcript index whose notice gets the Retry button: the tail error notice, looking
@@ -326,7 +406,7 @@ export function retryAnchor(items: Item[]): number {
   return -1;
 }
 
-export function Transcript({ items, running, streamingText, onRetry }: Props) {
+export function Transcript({ items, running, streamingText, onRetry, sessionId }: Props) {
   // §33 grouping: a turn = the maximal run of assistant/tool/resolved-approval items between
   // breakers (user, connector, notices, plan/dir requests…). Trailing assistant texts are the
   // ANSWER and render as bubbles after the group; interior assistant texts are narration and
@@ -376,6 +456,7 @@ export function Transcript({ items, running, streamingText, onRetry }: Props) {
               items={block.turn}
               live={block.live}
               streamingText={block.live && bi === lastTurnIndex ? streamingText : undefined}
+              sessionId={sessionId}
               key={bi}
             />
           );

--- a/surfaces/gui/src/itemsFromMessages.test.ts
+++ b/surfaces/gui/src/itemsFromMessages.test.ts
@@ -94,3 +94,44 @@ describe("itemsFromMessages reasoning", () => {
     expect(items[2]).toEqual({ kind: "assistant", text: "", reasoning: "stopped mid-thought" });
   });
 });
+
+describe("itemsFromMessages durable tool outputs", () => {
+  it("parses envelopes into truncated tool items with preview", () => {
+    const envelope = {
+      output_ref_version: 1,
+      output_ref: "out_" + "a".repeat(32),
+      truncated: true,
+      original_chars: 12000,
+      preview: "HEAD\n\n[... omitted ...]\n\nTAIL",
+    };
+    const items = itemsFromMessages([
+      { role: "user", content: "run" },
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [{ id: "c1", function: { name: "run_shell", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "c1", content: JSON.stringify(envelope) },
+    ] as any);
+    const tool = items.find((i: any) => i.kind === "tool") as any;
+    expect(tool.outputRef).toBe(envelope.output_ref);
+    expect(tool.originalChars).toBe(12000);
+    expect(tool.truncated).toBe(true);
+    expect(tool.preview).toContain("HEAD");
+    expect(tool.preview).not.toContain("output_ref");
+  });
+
+  it("treats malformed JSON as ordinary output", () => {
+    const items = itemsFromMessages([
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [{ id: "c1", function: { name: "run_shell", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "c1", content: "not-json {" },
+    ] as any);
+    const tool = items.find((i: any) => i.kind === "tool") as any;
+    expect(tool.preview).toBe("not-json {");
+    expect(tool.outputRef).toBeUndefined();
+  });
+});

--- a/surfaces/gui/src/itemsFromMessages.test.ts
+++ b/surfaces/gui/src/itemsFromMessages.test.ts
@@ -101,6 +101,7 @@ describe("itemsFromMessages durable tool outputs", () => {
       output_ref_version: 1,
       output_ref: "out_" + "a".repeat(32),
       truncated: true,
+      content_complete: true,
       original_chars: 12000,
       preview: "HEAD\n\n[... omitted ...]\n\nTAIL",
     };
@@ -117,6 +118,7 @@ describe("itemsFromMessages durable tool outputs", () => {
     expect(tool.outputRef).toBe(envelope.output_ref);
     expect(tool.originalChars).toBe(12000);
     expect(tool.truncated).toBe(true);
+    expect(tool.contentComplete).toBe(true);
     expect(tool.preview).toContain("HEAD");
     expect(tool.preview).not.toContain("output_ref");
   });
@@ -132,6 +134,21 @@ describe("itemsFromMessages durable tool outputs", () => {
     ] as any);
     const tool = items.find((i: any) => i.kind === "tool") as any;
     expect(tool.preview).toBe("not-json {");
+    expect(tool.outputRef).toBeUndefined();
+  });
+
+  it("does not mistake an ordinary result containing output_ref for an envelope", () => {
+    const ordinary = { output_ref: "external-system-id", ok: true };
+    const items = itemsFromMessages([
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [{ id: "c1", function: { name: "connector_tool", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "c1", content: JSON.stringify(ordinary) },
+    ] as any);
+    const tool = items.find((i: any) => i.kind === "tool") as any;
+    expect(tool.preview).toBe(JSON.stringify(ordinary));
     expect(tool.outputRef).toBeUndefined();
   });
 });

--- a/surfaces/gui/src/itemsFromMessages.ts
+++ b/surfaces/gui/src/itemsFromMessages.ts
@@ -8,6 +8,20 @@
 import type { ConversationMessage } from "./api";
 import type { Attachment, Item } from "./types";
 
+const OUTPUT_REF = /^out_[0-9a-f]{32}$/;
+
+function retainedOutputEnvelope(value: any): any | null {
+  return value &&
+    typeof value === "object" &&
+    value.output_ref_version === 1 &&
+    value.truncated === true &&
+    typeof value.output_ref === "string" &&
+    OUTPUT_REF.test(value.output_ref) &&
+    typeof value.preview === "string"
+    ? value
+    : null;
+}
+
 export function itemsFromMessages(messages: ConversationMessage[]): Item[] {
   const items: Item[] = [];
   // Index tool results by tool_call_id so replayed tool rows can show their output
@@ -60,10 +74,7 @@ export function itemsFromMessages(messages: ConversationMessage[]): Item[] {
         const preview = results[tc.id];
         const hidden = hiddenCounts[tc.id];
         const output = durable[tc.id];
-        const envelope =
-          output && typeof output === "object" && typeof output.output_ref === "string"
-            ? output
-            : null;
+        const envelope = retainedOutputEnvelope(output);
         items.push({
           kind: "tool",
           id: tc.id,
@@ -76,6 +87,7 @@ export function itemsFromMessages(messages: ConversationMessage[]): Item[] {
                 outputRef: envelope.output_ref,
                 originalChars: envelope.original_chars,
                 truncated: true,
+                contentComplete: envelope.content_complete !== false,
               }
             : {}),
           ...(hidden ? { hidden } : {}),

--- a/surfaces/gui/src/itemsFromMessages.ts
+++ b/surfaces/gui/src/itemsFromMessages.ts
@@ -13,6 +13,7 @@ export function itemsFromMessages(messages: ConversationMessage[]): Item[] {
   // Index tool results by tool_call_id so replayed tool rows can show their output
   // (the live view gets this from `tool_finished` events; on replay it's the `role:"tool"` msgs).
   const results: Record<string, string> = {};
+  const durable: Record<string, any> = {};
   // `_display` sidecar on a tool message = user-facing metadata the agent never saw
   // (e.g. how many hits the privacy filters hid) — surfaces on the tool card.
   const hiddenCounts: Record<string, number> = {};
@@ -20,6 +21,11 @@ export function itemsFromMessages(messages: ConversationMessage[]): Item[] {
     if (m.role === "tool" && m.tool_call_id) {
       results[m.tool_call_id] =
         typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+      try {
+        durable[m.tool_call_id] = JSON.parse(results[m.tool_call_id]);
+      } catch {
+        // Ordinary text tool results are not JSON envelopes.
+      }
       const hidden = Number(m._display?.hidden_by_filters || 0);
       if (hidden > 0) hiddenCounts[m.tool_call_id] = hidden;
     }
@@ -53,13 +59,25 @@ export function itemsFromMessages(messages: ConversationMessage[]): Item[] {
         }
         const preview = results[tc.id];
         const hidden = hiddenCounts[tc.id];
+        const output = durable[tc.id];
+        const envelope =
+          output && typeof output === "object" && typeof output.output_ref === "string"
+            ? output
+            : null;
         items.push({
           kind: "tool",
           id: tc.id,
           name: tc.function?.name,
           args,
           status: "ok",
-          preview,
+          preview: envelope?.preview ? String(envelope.preview) : preview,
+          ...(envelope
+            ? {
+                outputRef: envelope.output_ref,
+                originalChars: envelope.original_chars,
+                truncated: true,
+              }
+            : {}),
           ...(hidden ? { hidden } : {}),
         });
       }

--- a/surfaces/gui/src/types.ts
+++ b/surfaces/gui/src/types.ts
@@ -96,6 +96,7 @@ export type Item =
       outputRef?: string;
       originalChars?: number;
       truncated?: boolean;
+      contentComplete?: boolean;
     }
   | {
       kind: "approval";

--- a/surfaces/gui/src/types.ts
+++ b/surfaces/gui/src/types.ts
@@ -84,7 +84,19 @@ export type Item =
   // `hidden` = results the user's privacy filters removed before the agent saw them
   // (from the tool message's `_display` sidecar; the agent-visible content has no trace).
   // `standingRule` = the task-scoped rule that auto-allowed this call ("tool → target").
-  | { kind: "tool"; id: string; name: string; args: any; status: string; preview?: string; hidden?: number; standingRule?: string }
+  | {
+      kind: "tool";
+      id: string;
+      name: string;
+      args: any;
+      status: string;
+      preview?: string;
+      hidden?: number;
+      standingRule?: string;
+      outputRef?: string;
+      originalChars?: number;
+      truncated?: boolean;
+    }
   | {
       kind: "approval";
       name: string;

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,22 @@
+"""Audit-log regressions for projected tool results."""
+
+from coworker.audit import AuditStore
+
+
+def test_explicit_resource_preserves_result_url_without_raw_result(tmp_path):
+    store = AuditStore(tmp_path / "audit.db")
+    try:
+        store.append(
+            {
+                "session_id": "s",
+                "tool": "example",
+                "stage": "finished",
+                "resource": "https://example.test/item/1",
+                "result_preview": "projected",
+            }
+        )
+        event = store.list()[0]
+        assert event["resource"] == "https://example.test/item/1"
+        assert event["result_preview"] == "projected"
+    finally:
+        store.close()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import asyncio
 import threading
 import time
@@ -439,3 +440,222 @@ def test_outbound_replaces_images_for_non_vision_models(tmp_path):
     assert all(p["type"] != "image_url" for p in parts)
     assert "not viewable" in parts[-1]["text"]
     assert engine.messages[-1]["content"][1]["type"] == "image_url"  # history untouched
+
+
+# -- durable tool outputs -------------------------------------------------------
+
+
+def test_large_tool_result_projects_envelope(tmp_path):
+    from coworker.tool_outputs import SessionToolOutputStore, ToolOutputPolicy
+
+    policy = ToolOutputPolicy(inline_limit_chars=80, preview_chars=40, min_disk_headroom_bytes=0)
+    store = SessionToolOutputStore(tmp_path, "eng", policy)
+    sentinel = "MIDDLE_SENTINEL_UNIQUE"
+    payload = "H" * 200 + sentinel + "T" * 200
+
+    def big_tool():
+        return payload
+
+    big_tool.__name__ = "big_tool"
+    big_tool.__coworker_schema__ = {
+        "type": "function",
+        "function": {"name": "big_tool", "parameters": {"type": "object", "properties": {}}},
+    }
+    big_tool.__aisuite_tool_metadata__ = ai.ToolMetadata(
+        name="big_tool", category="files", risk_level="low", capabilities=["read"], requires_approval=False
+    )
+
+    provider = ScriptedProvider([_tool_turn("big_tool", {}, "c1"), _text_turn("done")])
+    registry = ToolRegistry()
+    registry.register(big_tool)
+    engine = TurnEngine(
+        provider=provider,
+        registry=registry,
+        permissions=PermissionEngine(workspace_root=tmp_path),
+        model="gpt-5.5",
+        tool_output_store=store,
+        max_iterations=4,
+    )
+    events = _collect(engine, "go")
+    finished = [e for e in events if e.type is EventType.TOOL_FINISHED][0]
+    assert finished.data["truncated"] is True
+    assert finished.data["output_ref"].startswith("out_")
+    tool_msg = next(m for m in engine.messages if m.get("role") == "tool")
+    body = json.loads(tool_msg["content"])
+    assert body["output_ref"] == finished.data["output_ref"]
+    assert sentinel not in body["preview"]
+    assert provider.calls >= 2
+    assert sentinel in serialize_join(store, body["output_ref"])
+
+
+def serialize_join(store, ref):
+    parts, offset = [], 0
+    while True:
+        page = store.read(ref, offset)
+        parts.append(page["content"])
+        if page["complete"]:
+            break
+        offset = page["next_offset_bytes"]
+    return "".join(parts)
+
+
+def test_read_tool_output_never_recurses(tmp_path):
+    from coworker.tool_outputs import SessionToolOutputStore, ToolOutputPolicy, read_tool_output_tool
+
+    policy = ToolOutputPolicy(
+        inline_limit_chars=500,
+        preview_chars=100,
+        read_max_bytes=8_000,
+        min_disk_headroom_bytes=0,
+    )
+    store = SessionToolOutputStore(tmp_path, "eng", policy)
+    record = store.put("c", "t", "Q" * 5000)
+    tool = read_tool_output_tool(store)
+    registry = ToolRegistry()
+    registry.register(tool)
+    provider = ScriptedProvider(
+        [_tool_turn("read_tool_output", {"output_ref": record.ref, "limit_bytes": 4000}, "r1"), _text_turn("ok")]
+    )
+    engine = TurnEngine(
+        provider=provider,
+        registry=registry,
+        permissions=PermissionEngine(workspace_root=tmp_path),
+        model="gpt-5.5",
+        tool_output_store=store,
+    )
+    _collect(engine, "read")
+    tool_msg = next(m for m in engine.messages if m.get("role") == "tool")
+    body = json.loads(tool_msg["content"])
+    assert "output_ref" in body and body.get("truncated") is not True
+    assert "content" in body
+
+
+def test_display_sidecar_survives_projection(tmp_path):
+    from coworker.tool_outputs import SessionToolOutputStore, ToolOutputPolicy
+
+    store = SessionToolOutputStore(
+        tmp_path, "eng", ToolOutputPolicy(inline_limit_chars=10, preview_chars=6, min_disk_headroom_bytes=0)
+    )
+
+    def noisy():
+        return {"data": "Z" * 100, "_display": {"hidden_by_filters": 2}}
+
+    noisy.__name__ = "noisy"
+    noisy.__coworker_schema__ = {
+        "type": "function",
+        "function": {"name": "noisy", "parameters": {"type": "object", "properties": {}}},
+    }
+    noisy.__aisuite_tool_metadata__ = ai.ToolMetadata(
+        name="noisy", category="files", risk_level="low", capabilities=["read"], requires_approval=False
+    )
+    provider = ScriptedProvider([_tool_turn("noisy", {}, "n1"), _text_turn("ok")])
+    registry = ToolRegistry()
+    registry.register(noisy)
+    audits = []
+    engine = TurnEngine(
+        provider=provider,
+        registry=registry,
+        permissions=PermissionEngine(workspace_root=tmp_path),
+        model="gpt-5.5",
+        tool_output_store=store,
+        audit_sink=audits.append,
+    )
+    events = _collect(engine, "go")
+    finished = next(e for e in events if e.type is EventType.TOOL_FINISHED)
+    assert finished.data["display"]["hidden_by_filters"] == 2
+    tool_msg = next(m for m in engine.messages if m.get("role") == "tool")
+    assert tool_msg["_display"]["hidden_by_filters"] == 2
+    assert "_display" not in json.loads(tool_msg["content"])
+    assert all("ZZZZ" not in json.dumps(a) for a in audits)
+
+
+def test_denied_call_creates_no_blob(tmp_path):
+    from coworker.tool_outputs import SessionToolOutputStore, ToolOutputPolicy, ToolResultProjector
+
+    store = SessionToolOutputStore(tmp_path, "eng", ToolOutputPolicy(min_disk_headroom_bytes=0))
+
+    async def deny(_req):
+        return ApprovalOutcome.DENY
+
+    engine, _ = _engine(
+        tmp_path,
+        [
+            _tool_turn("write_file", {"path": "new.py", "content": "x"}),
+            _text_turn("ok, skipped it"),
+        ],
+        approver=deny,
+    )
+    engine.tool_output_store = store
+    engine._tool_projector = ToolResultProjector(store)
+    _collect(engine, "create new.py")
+    assert store.list_references() == set()
+
+
+def test_retention_failure_is_bounded_error(tmp_path):
+    from coworker.tool_outputs import SessionToolOutputStore, ToolOutputPolicy, ToolResultProjector
+
+    store = SessionToolOutputStore(
+        tmp_path,
+        "eng",
+        ToolOutputPolicy(inline_limit_chars=10, preview_chars=6, max_single_output_bytes=20, min_disk_headroom_bytes=0),
+    )
+
+    def huge():
+        return "X" * 500
+
+    huge.__name__ = "huge"
+    huge.__coworker_schema__ = {
+        "type": "function",
+        "function": {"name": "huge", "parameters": {"type": "object", "properties": {}}},
+    }
+    huge.__aisuite_tool_metadata__ = ai.ToolMetadata(
+        name="huge", category="files", risk_level="low", capabilities=["read"], requires_approval=False
+    )
+    provider = ScriptedProvider([_tool_turn("huge", {}, "h1"), _text_turn("ok")])
+    registry = ToolRegistry()
+    registry.register(huge)
+    engine = TurnEngine(
+        provider=provider,
+        registry=registry,
+        permissions=PermissionEngine(workspace_root=tmp_path),
+        model="gpt-5.5",
+        tool_output_store=store,
+    )
+    events = _collect(engine, "go")
+    finished = next(e for e in events if e.type is EventType.TOOL_FINISHED)
+    assert finished.data["status"] == "error"
+    body = json.loads(next(m for m in engine.messages if m.get("role") == "tool")["content"])
+    assert body["recoverable"] is False
+    assert "could not be retained" in body["error"]
+
+
+def test_unserializable_result_becomes_bounded_error(tmp_path):
+    from coworker.tool_outputs import SessionToolOutputStore, ToolOutputPolicy
+
+    store = SessionToolOutputStore(
+        tmp_path,
+        "eng",
+        ToolOutputPolicy(
+            inline_limit_chars=80,
+            preview_chars=40,
+            min_disk_headroom_bytes=0,
+        ),
+    )
+    circular = []
+    circular.append(circular)
+    engine, _ = _engine(tmp_path, [_text_turn("unused")])
+    engine.tool_output_store = store
+    from coworker.tool_outputs import ToolResultProjector
+
+    engine._tool_projector = ToolResultProjector(store)
+    event = engine._record_result(
+        ToolCall(id="circular", name="example", arguments={}),
+        circular,
+        "ok",
+    )
+    assert event.data["status"] == "error"
+    body = json.loads(engine.messages[-1]["content"])
+    assert body == {
+        "error": "tool output could not be retained",
+        "recoverable": False,
+    }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -56,6 +56,24 @@ def test_chat_completions_openai_shape(tmp_path):
     assert body["choices"][0]["message"]["content"] == "hello world"
     assert body["choices"][0]["finish_reason"] == "stop"
 
+def test_tool_output_route_is_paged_and_session_scoped(tmp_path):
+    manager = SessionManager(workspace=tmp_path, provider=ScriptedProvider([]))
+    manager.session_store.save(
+        SessionRecord(
+            session_id="one",
+            workspace=str(tmp_path),
+            model="m",
+            mode="interactive",
+            agent="cowork",
+        )
+    )
+    record = manager.tool_output_store("one").put("call", "tool", "hello durable output")
+    client = TestClient(create_app(manager))
+    page = client.get(f"/v1/sessions/one/tool-outputs/{record.ref}?limit_bytes=5")
+    assert page.status_code == 200 and page.json()["content"] == "hello"
+    assert client.get(f"/v1/sessions/two/tool-outputs/{record.ref}").status_code == 404
+    assert client.get("/v1/sessions/one/tool-outputs/not-a-reference").status_code == 400
+
 
 def test_agents_and_memory_rest(tmp_path):
     client = _client(tmp_path, [])
@@ -1050,3 +1068,82 @@ def test_set_provider_persists_extra_fields(tmp_path):
     manager.set_provider("ollama", {"base_url": ""})
     providers = {p["name"]: p for p in manager.get_providers()}
     assert "base_url" not in providers["ollama"]["values"]
+
+
+def test_tool_output_route_security_and_deletion(tmp_path):
+    from coworker.conversations import SessionRecord
+
+    manager = SessionManager(workspace=tmp_path, provider=ScriptedProvider([]))
+    manager.session_store.save(
+        SessionRecord(
+            session_id="keep",
+            workspace=str(tmp_path),
+            model="m",
+            mode="interactive",
+            agent="cowork",
+        )
+    )
+    store = manager.tool_output_store("keep")
+    record = store.put("call", "tool", "abcdefghijklmnopqrstuvwxyz")
+    client = TestClient(create_app(manager))
+
+    assert client.get(f"/v1/sessions/keep/tool-outputs/{record.ref}?offset_bytes=-1").status_code == 400
+    assert client.get(f"/v1/sessions/keep/tool-outputs/{record.ref}?limit_bytes=0").status_code == 400
+    assert client.get(f"/v1/sessions/keep/tool-outputs/{record.ref}?limit_bytes=999999").status_code == 400
+    assert client.get("/v1/sessions/keep/tool-outputs/out_" + ("a" * 32)).status_code == 404
+    assert client.get("/v1/sessions/keep/tool-outputs/out_notvalid").status_code == 400
+    assert client.get("/v1/sessions/keep/tool-outputs/out_" + ("a" * 31)).status_code == 400
+
+    page = client.get(f"/v1/sessions/keep/tool-outputs/{record.ref}?limit_bytes=8").json()
+    assert page["content"] == "abcdefgh" and page["complete"] is False
+
+    (store.directory / f"{record.ref}.json").write_text("{", encoding="utf-8")
+    assert (
+        client.get(f"/v1/sessions/keep/tool-outputs/{record.ref}").status_code
+        == 409
+    )
+
+    assert client.delete("/v1/sessions/keep").json()["ok"] is True
+    assert client.get(f"/v1/sessions/keep/tool-outputs/{record.ref}").status_code == 404
+
+
+def test_tool_output_orphan_gc(tmp_path):
+    import os
+    import time
+    from coworker.conversations import SessionRecord
+    from coworker.tool_outputs import session_output_key
+
+    manager = SessionManager(workspace=tmp_path, provider=ScriptedProvider([]))
+    manager.session_store.save(
+        SessionRecord(
+            session_id="live",
+            workspace=str(tmp_path),
+            model="m",
+            mode="interactive",
+            agent="cowork",
+        )
+    )
+    manager.tool_output_store("live").put("c", "t", "keep-me")
+    orphan = manager.tool_output_store("orphan-old")
+    orphan.put("c", "t", "drop-me")
+    # Age the orphan directory past grace.
+    stale = orphan.directory
+    old = time.time() - 48 * 60 * 60
+    os.utime(stale, (old, old))
+    removed = manager.collect_tool_output_orphans(grace_seconds=24 * 60 * 60)
+    assert removed == 1
+    assert not stale.exists()
+    assert (manager._data_base / "tool-outputs" / session_output_key("live")).is_dir()
+
+
+def test_tool_output_orphan_gc_ignores_non_hash_directory(tmp_path):
+    import os
+    import time
+
+    manager = SessionManager(workspace=tmp_path, provider=ScriptedProvider([]))
+    unrelated = manager._data_base / "tool-outputs" / ("g" * 64)
+    unrelated.mkdir(parents=True)
+    old = time.time() - 48 * 60 * 60
+    os.utime(unrelated, (old, old))
+    assert manager.collect_tool_output_orphans(grace_seconds=0) == 0
+    assert unrelated.is_dir()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -12,6 +12,7 @@ import time
 
 import pytest
 
+import coworker.tools.shell as shell_module
 from coworker.permissions import PermissionEngine
 from coworker.tools import ToolRegistry
 from coworker.tools.shell import LocalExecutor, shell_tools
@@ -77,6 +78,34 @@ def test_large_output_is_preserved_for_engine_projection(tmp_path):
         # Both ends survive; the engine projects large output for model context.
         assert "line1000" in result["output"]
         assert "line1\n" in result["output"]
+    finally:
+        ex.close()
+
+
+def test_capture_quota_preserves_head_and_tail_and_marks_partial(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(shell_module, "_MAX_FOREGROUND_RETAINED_BYTES", 1024)
+    if _WIN:
+        command = (
+            '$s = "HEAD_SENTINEL" + ("x" * 3000) + "TAIL_SENTINEL"; '
+            "[Console]::Write($s)"
+        )
+    else:
+        command = (
+            "python3 -c \"import sys; "
+            "sys.stdout.write('HEAD_SENTINEL' + 'x'*3000 + 'TAIL_SENTINEL')\""
+        )
+    ex = LocalExecutor(cwd=tmp_path, default_timeout=10)
+    try:
+        result = ex.run(command)
+        assert result["truncated"] is True
+        assert result["retained_complete"] is False
+        assert result["discarded_bytes"] > 0
+        assert result["retained_bytes"] <= 1024
+        assert "HEAD_SENTINEL" in result["output"]
+        assert "TAIL_SENTINEL" in result["output"]
+        assert "discarded by shell capture quota" in result["output"]
     finally:
         ex.close()
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -68,15 +68,15 @@ def test_timeout_kills_command(executor):
     assert executor.run("echo alive")["output"].strip().endswith("alive")
 
 
-def test_large_output_truncated_keeps_tail(tmp_path):
+def test_large_output_is_preserved_for_engine_projection(tmp_path):
     ex = LocalExecutor(cwd=tmp_path, max_output_chars=200, default_timeout=10)
     try:
         result = ex.run(PRINT_1000)
-        assert result["truncated"] is True
-        assert len(result["output"]) <= 200
-        # the END survives (where test/build verdicts live), the head is dropped
+        assert result["truncated"] is False
+        assert len(result["output"]) > 200
+        # Both ends survive; the engine projects large output for model context.
         assert "line1000" in result["output"]
-        assert "line1\n" not in result["output"]
+        assert "line1\n" in result["output"]
     finally:
         ex.close()
 
@@ -181,3 +181,91 @@ def test_background_unknown_task_errors(executor):
     assert (
         "unknown task" in reg.execute("shell_task_kill", {"task_id": "bg-99"})["error"]
     )
+
+
+def test_background_large_output_is_recoverable(tmp_path):
+    # Emit more than the old foreground cap; capture must retain head/middle/tail.
+    if _WIN:
+        cmd = (
+            '$s = ("A" * 5000) + "MIDDLE_BG_SENTINEL" + ("Z" * 5000); '
+            "Write-Output $s"
+        )
+    else:
+        cmd = "python3 -c \"print('A'*5000 + 'MIDDLE_BG_SENTINEL' + 'Z'*5000)\""
+    ex = LocalExecutor(cwd=tmp_path, capture_dir=tmp_path / "caps", default_timeout=15)
+    try:
+        reg = ToolRegistry()
+        reg.register_all(shell_tools(ex))
+        started = reg.execute("run_shell", {"command": cmd, "run_in_background": True})
+        acc, res = _poll_output(reg, started["task_id"], until_status="exited", deadline=15)
+        assert res["status"] == "exited"
+        assert "MIDDLE_BG_SENTINEL" in acc
+        task = ex._bg_tasks[started["task_id"]]
+        retained = task.read_retained(0, 20_000).decode("utf-8", errors="replace")
+        assert "MIDDLE_BG_SENTINEL" in retained
+        assert retained.startswith("A") or "AAAA" in retained
+        # Kill must not delete retained capture.
+        reg.execute("shell_task_kill", {"task_id": started["task_id"]})
+        assert task.capture_path.is_file()
+        again = reg.execute("shell_task_output", {"task_id": started["task_id"]})
+        assert again["output"] == ""
+    finally:
+        ex.close()
+
+
+def test_background_polls_are_incremental(tmp_path):
+    if _WIN:
+        cmd = "Write-Output one; Start-Sleep -Milliseconds 200; Write-Output two"
+    else:
+        cmd = "echo one; sleep 0.2; echo two"
+    ex = LocalExecutor(cwd=tmp_path, capture_dir=tmp_path / "caps", default_timeout=10)
+    try:
+        reg = ToolRegistry()
+        reg.register_all(shell_tools(ex))
+        started = reg.execute("run_shell", {"command": cmd, "run_in_background": True})
+        seen = []
+        end = time.monotonic() + 8
+        while time.monotonic() < end:
+            res = reg.execute("shell_task_output", {"task_id": started["task_id"]})
+            if res["output"]:
+                seen.append(res["output"])
+            if res["status"] == "exited":
+                break
+            time.sleep(0.05)
+        joined = "".join(seen)
+        assert "one" in joined and "two" in joined
+        # No duplicate whole stream across polls.
+        assert joined.count("one") == 1
+    finally:
+        ex.close()
+
+
+def test_rebuilt_executor_uses_a_fresh_capture_file(tmp_path):
+    capture_dir = tmp_path / "caps"
+    first = LocalExecutor(cwd=tmp_path, capture_dir=capture_dir)
+    second = None
+    try:
+        first_task = first.run_background(QUICK_ECHO)
+        task_one = first._bg_tasks[first_task["task_id"]]
+        task_one.proc.wait(timeout=10)
+        second = LocalExecutor(cwd=tmp_path, capture_dir=capture_dir)
+        second_task = second.run_background(QUICK_ECHO)
+        task_two = second._bg_tasks[second_task["task_id"]]
+        task_two.proc.wait(timeout=10)
+        assert first_task["task_id"] == second_task["task_id"] == "bg-1"
+        assert task_one.capture_path != task_two.capture_path
+    finally:
+        first.close()
+        if second is not None:
+            second.close()
+
+
+def test_close_background_tasks_stops_detached_process(tmp_path):
+    ex = LocalExecutor(cwd=tmp_path, capture_dir=tmp_path / "caps")
+    try:
+        started = ex.run_background(ECHO_THEN_SLEEP)
+        task = ex._bg_tasks[started["task_id"]]
+        ex.close_background_tasks()
+        assert task.proc.poll() is not None
+    finally:
+        ex.close()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -14,6 +14,7 @@ import pytest
 
 import coworker.tools.shell as shell_module
 from coworker.permissions import PermissionEngine
+from coworker.tool_outputs import SessionToolOutputStore, ToolOutputPolicy
 from coworker.tools import ToolRegistry
 from coworker.tools.shell import LocalExecutor, shell_tools
 
@@ -239,6 +240,38 @@ def test_background_large_output_is_recoverable(tmp_path):
         again = reg.execute("shell_task_output", {"task_id": started["task_id"]})
         assert again["output"] == ""
     finally:
+        ex.close()
+
+
+def test_background_capture_shares_session_quota_with_tool_outputs(tmp_path):
+    policy = ToolOutputPolicy(
+        max_single_output_bytes=2_000,
+        max_session_output_bytes=2_000,
+        min_disk_headroom_bytes=0,
+    )
+    store = SessionToolOutputStore(tmp_path, "shared-quota", policy)
+    store.put("call", "tool", "x" * 1_200)
+    command = (
+        '[Console]::Write("y" * 1500)'
+        if _WIN
+        else "printf 'y%.0s' {1..1500}"
+    )
+    ex = LocalExecutor(
+        cwd=tmp_path,
+        capture_dir=store.captures_dir,
+        capture_writer=store.append_capture,
+        max_capture_bytes=policy.max_single_output_bytes,
+    )
+    try:
+        started = ex.run_background(command)
+        task = ex._bg_tasks[started["task_id"]]
+        task.proc.wait(timeout=10)
+        task._reader.join(timeout=10)
+        assert task.retained_bytes > 0
+        assert task.discarded_bytes > 0
+        assert store._used_bytes() <= policy.max_session_output_bytes
+    finally:
+        ex.close_background_tasks()
         ex.close()
 
 

--- a/tests/test_tool_outputs.py
+++ b/tests/test_tool_outputs.py
@@ -1,0 +1,286 @@
+"""Durable tool-output store, projector, and retrieval tool."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from coworker.tool_outputs import (
+    SessionToolOutputStore,
+    ToolOutputPolicy,
+    ToolOutputStoreError,
+    ToolResultProjector,
+    is_valid_output_ref,
+    read_tool_output_tool,
+    serialize_tool_result,
+)
+
+
+def _policy(**kwargs) -> ToolOutputPolicy:
+    base = dict(
+        inline_limit_chars=40,
+        preview_chars=16,
+        read_default_bytes=16,
+        read_max_bytes=64,
+        max_single_output_bytes=1024,
+        max_session_output_bytes=4096,
+        min_disk_headroom_bytes=0,
+    )
+    base.update(kwargs)
+    if base["preview_chars"] >= base["inline_limit_chars"]:
+        base["preview_chars"] = max(2, base["inline_limit_chars"] // 2)
+    return ToolOutputPolicy(**base)
+
+
+def test_small_result_keeps_exact_python_value(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "s", _policy())
+    value = {"ok": True, "n": 3}
+    projected = ToolResultProjector(store).project("c1", "example", value)
+    assert projected.stored is None
+    assert projected.model_value is value
+
+
+def test_string_and_structured_round_trip(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "s", _policy(inline_limit_chars=10))
+    projector = ToolResultProjector(store)
+    for value in ("x" * 50, {"items": list(range(30))}):
+        projected = projector.project("call", "tool", value)
+        assert projected.stored is not None
+        pieces, offset = [], 0
+        while True:
+            page = store.read(projected.stored.ref, offset)
+            pieces.append(page["content"])
+            if page["complete"]:
+                break
+            offset = page["next_offset_bytes"]
+        assert "".join(pieces) == serialize_tool_result(value)
+
+
+def test_large_envelope_has_head_tail_and_omission(tmp_path):
+    store = SessionToolOutputStore(
+        tmp_path, "s", _policy(inline_limit_chars=600, preview_chars=20)
+    )
+    raw = "HEAD" + ("m" * 800) + "TAIL"
+    projected = ToolResultProjector(store).project("c", "t", raw)
+    env = projected.model_value
+    assert env["truncated"] is True
+    assert env["output_ref_version"] == 1
+    assert env["preview"].startswith("HEAD")
+    assert env["preview"].endswith("TAIL")
+    assert "characters omitted" in env["preview"]
+    assert "mmmmmmmmmm" not in env["preview"]
+
+
+def test_escape_heavy_preview_stays_within_inline_limit(tmp_path):
+    policy = _policy(
+        inline_limit_chars=600,
+        preview_chars=200,
+        max_single_output_bytes=10_000,
+        max_session_output_bytes=10_000,
+    )
+    store = SessionToolOutputStore(tmp_path, "s", policy)
+    projected = ToolResultProjector(store).project(
+        "c",
+        "t",
+        "\x00🙂" * 1_000,
+    )
+    assert projected.stored is not None
+    assert len(serialize_tool_result(projected.model_value)) <= 600
+
+
+def test_non_ascii_counts_and_utf8_paging(tmp_path):
+    store = SessionToolOutputStore(
+        tmp_path,
+        "s",
+        _policy(inline_limit_chars=5, read_default_bytes=5, read_max_bytes=20),
+    )
+    text = "é🙂漢字" * 20
+    record = store.put("c", "t", text)
+    assert record.chars == len(text)
+    assert record.bytes == len(text.encode("utf-8"))
+    with pytest.raises(ValueError, match="UTF-8"):
+        store.read(record.ref, offset_bytes=1)
+    pieces, offset = [], 0
+    while True:
+        page = store.read(record.ref, offset, limit_bytes=7)
+        pieces.append(page["content"])
+        if page["complete"]:
+            break
+        offset = page["next_offset_bytes"]
+    assert "".join(pieces) == text
+    assert page["sha256"] == record.sha256
+
+
+def test_restart_reopens_same_bytes(tmp_path):
+    policy = _policy(inline_limit_chars=8)
+    store = SessionToolOutputStore(tmp_path, "session-a", policy)
+    projected = ToolResultProjector(store).project(
+        "provider/../../id", "example", "Z" * 80
+    )
+    ref = projected.stored.ref
+    reopened = SessionToolOutputStore(tmp_path, "session-a", policy, create=False)
+    assert reopened.read(ref)["total_chars"] == 80
+
+
+def test_invalid_refs_offsets_limits(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "s", _policy())
+    record = store.put("c", "t", "hello")
+    with pytest.raises(ValueError):
+        store.read("../../etc/passwd")
+    with pytest.raises(ValueError):
+        store.read("out_" + "a" * 64)
+    with pytest.raises(ValueError):
+        store.read(record.ref, offset_bytes=-1)
+    with pytest.raises(ValueError):
+        store.read(record.ref, limit_bytes=0)
+    with pytest.raises(ValueError):
+        store.read(record.ref, limit_bytes=10_000)
+    with pytest.raises(ValueError):
+        store.read(record.ref, offset_bytes=len("hello") + 1)
+    with pytest.raises(KeyError):
+        store.read("out_" + "0" * 32)
+    assert not is_valid_output_ref("out_short")
+
+
+def test_session_isolation_and_provider_id_independence(tmp_path):
+    a = SessionToolOutputStore(tmp_path, "a", _policy())
+    b = SessionToolOutputStore(tmp_path, "b", _policy())
+    r1 = a.put("../../untrusted", "tool", "one")
+    r2 = a.put("../../untrusted", "tool", "two")
+    assert r1.ref != r2.ref
+    with pytest.raises(KeyError):
+        b.read(r1.ref)
+    assert "untrusted" not in str(a.directory)
+    assert r1.ref.startswith("out_")
+
+
+def test_concurrent_puts_are_distinct(tmp_path):
+    store = SessionToolOutputStore(
+        tmp_path, "s", _policy(max_session_output_bytes=100_000)
+    )
+    refs = []
+
+    def _put(i):
+        refs.append(store.put(f"c{i}", "t", f"payload-{i}-" + ("x" * 20)).ref)
+
+    with ThreadPoolExecutor(8) as pool:
+        list(pool.map(_put, range(20)))
+    assert len(set(refs)) == 20
+    assert store.list_references() == set(refs)
+
+
+def test_quota_and_headroom_failures(tmp_path):
+    store = SessionToolOutputStore(
+        tmp_path, "s", _policy(max_single_output_bytes=20, max_session_output_bytes=50)
+    )
+    with pytest.raises(ToolOutputStoreError):
+        store.put("c", "t", "x" * 40)
+    store.put("c", "t", "x" * 10)
+    store.put("c", "t", "y" * 10)
+    # Content + metadata for another 40-byte payload exceeds the session budget.
+    with pytest.raises(ToolOutputStoreError):
+        store.put("c", "t", "z" * 40)
+    tight = SessionToolOutputStore(
+        tmp_path, "disk", _policy(min_disk_headroom_bytes=10**18)
+    )
+    with pytest.raises(ToolOutputStoreError, match="headroom"):
+        tight.put("c", "t", "small")
+
+
+def test_atomic_failure_leaves_no_reference(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "s", _policy())
+    with mock.patch.object(store, "_atomic_write", side_effect=OSError("boom")):
+        with pytest.raises(OSError):
+            store.put("c", "t", "payload")
+    assert store.list_references() == set()
+
+
+def test_delete_all_and_create_false(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "s", _policy())
+    store.put("c", "t", "bye")
+    path = store.directory
+    store.delete_all()
+    assert not path.exists()
+    with pytest.raises(FileNotFoundError):
+        SessionToolOutputStore(tmp_path, "s", create=False)
+
+
+def test_restrict_to_user_invoked(tmp_path, monkeypatch):
+    calls = []
+
+    def fake(path, *, is_dir):
+        calls.append((Path(path), is_dir))
+
+    monkeypatch.setattr("coworker.tool_outputs.restrict_to_user", fake)
+    SessionToolOutputStore(tmp_path, "s", _policy()).put("c", "t", "hi")
+    assert any(is_dir for _, is_dir in calls)
+    assert any(not is_dir for _, is_dir in calls)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits")
+def test_posix_modes(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "s", _policy())
+    record = store.put("c", "t", "secret")
+    assert oct(store.directory.stat().st_mode & 0o777) == "0o700"
+    assert (
+        oct((store.directory / f"{record.ref}.txt").stat().st_mode & 0o777) == "0o600"
+    )
+
+
+def test_read_tool_output_tool_errors(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "s", _policy())
+    tool = read_tool_output_tool(store)
+    assert tool.__aisuite_tool_metadata__.requires_approval is False
+    assert tool.__aisuite_tool_metadata__.risk_level == "low"
+    bad = tool("not-a-ref")
+    assert bad["error_kind"] == "invalid"
+    missing = tool("out_" + "0" * 32)
+    assert missing["error_kind"] == "missing"
+
+
+def test_read_tool_adapts_escape_heavy_page_to_inline_limit(tmp_path):
+    policy = _policy(
+        inline_limit_chars=300,
+        read_default_bytes=64,
+        read_max_bytes=256,
+        max_single_output_bytes=10_000,
+    )
+    store = SessionToolOutputStore(tmp_path, "s", policy)
+    record = store.put("c", "t", "\x00🙂" * 100)
+    result = read_tool_output_tool(store)(record.ref, limit_bytes=256)
+    assert "content" in result
+    assert len(serialize_tool_result(result)) <= policy.inline_limit_chars
+    assert result["complete"] is False
+
+
+def test_projector_never_recursively_stores_read_result(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "s", _policy(inline_limit_chars=80))
+    huge = {"content": "Y" * 200}
+    projected = ToolResultProjector(store).project("c", "read_tool_output", huge)
+    assert projected.stored is None
+    assert projected.model_value["error_kind"] == "limit"
+    assert store.list_references() == set()
+
+
+def test_corrupt_metadata_is_controlled_error(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "s", _policy())
+    record = store.put("c", "t", "hello")
+    (store.directory / f"{record.ref}.json").write_text("{", encoding="utf-8")
+    with pytest.raises(ToolOutputStoreError, match="metadata is corrupt"):
+        store.read(record.ref)
+    result = read_tool_output_tool(store)(record.ref)
+    assert result["error_kind"] == "corrupt"
+
+
+def test_corrupt_content_length_is_controlled_error(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "s", _policy())
+    record = store.put("c", "t", "hello")
+    (store.directory / f"{record.ref}.txt").write_text("changed", encoding="utf-8")
+    with pytest.raises(ToolOutputStoreError, match="content is corrupt"):
+        store.read(record.ref)

--- a/tests/test_tool_outputs.py
+++ b/tests/test_tool_outputs.py
@@ -77,6 +77,29 @@ def test_large_envelope_has_head_tail_and_omission(tmp_path):
     assert "mmmmmmmmmm" not in env["preview"]
 
 
+def test_partial_source_is_disclosed_in_envelope(tmp_path):
+    store = SessionToolOutputStore(
+        tmp_path,
+        "s",
+        _policy(
+            inline_limit_chars=800,
+            preview_chars=40,
+            max_single_output_bytes=2_000,
+        ),
+    )
+    result = {
+        "output": "HEAD" + ("x" * 1000) + "TAIL",
+        "truncated": True,
+        "retained_complete": False,
+        "discarded_bytes": 500,
+    }
+    projected = ToolResultProjector(store).project("c", "run_shell", result)
+    assert projected.stored is not None
+    assert projected.stored.content_complete is False
+    assert projected.model_value["content_complete"] is False
+    assert "not fully recoverable" in projected.model_value["instruction"]
+
+
 def test_escape_heavy_preview_stays_within_inline_limit(tmp_path):
     policy = _policy(
         inline_limit_chars=600,
@@ -177,15 +200,21 @@ def test_concurrent_puts_are_distinct(tmp_path):
 
 def test_quota_and_headroom_failures(tmp_path):
     store = SessionToolOutputStore(
-        tmp_path, "s", _policy(max_single_output_bytes=20, max_session_output_bytes=50)
+        tmp_path, "s", _policy(max_single_output_bytes=20, max_session_output_bytes=700)
     )
     with pytest.raises(ToolOutputStoreError):
         store.put("c", "t", "x" * 40)
     store.put("c", "t", "x" * 10)
     store.put("c", "t", "y" * 10)
-    # Content + metadata for another 40-byte payload exceeds the session budget.
+    # Content + metadata count toward the session budget.
     with pytest.raises(ToolOutputStoreError):
-        store.put("c", "t", "z" * 40)
+        store.put("c", "t", "z" * 10)
+    used = store._used_bytes()
+    assert used == sum(
+        path.stat().st_size
+        for path in store.directory.iterdir()
+        if path.is_file() and path.suffix in {".txt", ".json"}
+    )
     tight = SessionToolOutputStore(
         tmp_path, "disk", _policy(min_disk_headroom_bytes=10**18)
     )
@@ -195,10 +224,21 @@ def test_quota_and_headroom_failures(tmp_path):
 
 def test_atomic_failure_leaves_no_reference(tmp_path):
     store = SessionToolOutputStore(tmp_path, "s", _policy())
-    with mock.patch.object(store, "_atomic_write", side_effect=OSError("boom")):
+    original = store._atomic_write
+    calls = 0
+
+    def fail_metadata(path, data):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("boom")
+        return original(path, data)
+
+    with mock.patch.object(store, "_atomic_write", side_effect=fail_metadata):
         with pytest.raises(OSError):
             store.put("c", "t", "payload")
     assert store.list_references() == set()
+    assert list(store.directory.glob("out_*")) == []
 
 
 def test_delete_all_and_create_false(tmp_path):

--- a/tests/test_tool_outputs.py
+++ b/tests/test_tool_outputs.py
@@ -324,3 +324,12 @@ def test_corrupt_content_length_is_controlled_error(tmp_path):
     (store.directory / f"{record.ref}.txt").write_text("changed", encoding="utf-8")
     with pytest.raises(ToolOutputStoreError, match="content is corrupt"):
         store.read(record.ref)
+
+
+def test_same_length_content_corruption_is_detected(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "s", _policy())
+    record = store.put("c", "t", "hello")
+    content = store.directory / f"{record.ref}.txt"
+    content.write_text("jello", encoding="utf-8")
+    with pytest.raises(ToolOutputStoreError, match="content is corrupt"):
+        store.read(record.ref)

--- a/tests/test_tools_permissions.py
+++ b/tests/test_tools_permissions.py
@@ -50,6 +50,16 @@ def test_registry_execute_unknown_tool(tmp_path):
         reg.execute("nope", {})
 
 
+def test_registry_can_reserve_an_internal_tool_name():
+    def internal_tool():
+        return "internal"
+
+    reg = ToolRegistry()
+    reg.register(internal_tool)
+    with pytest.raises(ValueError, match="reserved or already registered"):
+        reg.register(internal_tool, replace=False)
+
+
 # -- PermissionEngine -----------------------------------------------------------
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from coworker.conversations import ConversationStore
 from coworker.providers import (
     AssistantTurn,
     ModelCapabilities,
@@ -75,3 +76,25 @@ async def test_tui_approval_then_write(tmp_path):
 
     assert (tmp_path / "made.py").read_text() == "print(1)\n"
     assert any("done, wrote made.py" in line for line in app.rendered)
+
+
+@pytest.mark.asyncio
+async def test_tui_clear_removes_retained_outputs_and_persists_empty_history(tmp_path):
+    session_store = ConversationStore(tmp_path / "state")
+    app = CoworkerApp(
+        workspace=tmp_path,
+        provider=_ScriptedProvider([]),
+        session_store=session_store,
+        session_id="clear-session",
+    )
+    async with app.run_test():
+        output_store = app.engine.tool_output_store
+        record = output_store.put("call", "tool", "retained")
+        content_path = output_store.directory / f"{record.ref}.txt"
+        app.engine.messages.append({"role": "user", "content": "old history"})
+
+        app._handle_command("/clear")
+
+        assert not content_path.exists()
+        assert app.engine.tool_output_store.list_references() == set()
+        assert session_store.load("clear-session").messages == []


### PR DESCRIPTION
## Problem

Shell results over 20,000 characters currently keep only their tail, so the
agent cannot recover omitted commands or intermediate failures. Other
oversized tool results are sent back to the model in full, which can consume
the remaining context window or fail the next provider request.

This makes large logs, test output, connector responses, and MCP results either
lossy or unsafe for the model context.

## Changes

- retain oversized tool results in session-scoped local storage and send the
  model a bounded head/tail preview with an opaque reference
- add a reserved, low-risk `read_tool_output` tool for exact, paged retrieval
  of retained bytes without recursively expanding model context
- stream background shell output to bounded capture files instead of retaining
  the full process output in memory
- preserve both the head and tail when foreground shell output exceeds its
  8 MiB capture quota, and report that retained result as partial
- expose retained output through the session API and transcript UI, including
  replayed conversations
- remove retained output with its session and collect stale orphan directories

Small tool results keep their existing shape and remain inline.

## Safety and compatibility

- output references are random and path-independent; session directories use
  hashed ids
- UTF-8 paging validates byte boundaries, and page/envelope limits are applied
  after JSON serialization
- a 64 MiB serialized-result quota and 512 MiB session quota bound disk use;
  content and metadata both count, and retention failures become bounded tool
  errors
- retained files use user-only POSIX permissions or Windows ACLs
- raw retained output is not copied into the audit log
- shell capture uses native Bash on macOS/Linux and PowerShell process handling
  on Windows
- the paging route inherits the local sidecar's existing trust boundary;
  sidecar-wide authentication is tracked in
  [#40](https://github.com/andrewyng/openworker/issues/40)

For ordinary oversized results, every byte is recoverable through paging. If
shell output exceeds its capture quota, the model and GUI both say that only
the retained head and tail are available; neither describes the original
stream as complete.

## Screenshots

<img width="1280" height="720" alt="durable-output-after" src="https://github.com/user-attachments/assets/d855e449-aa6c-4e96-9224-48b38a8ac0a3" />
<img width="1280" height="720" alt="durable-output-before" src="https://github.com/user-attachments/assets/cb21e65e-e718-40d7-b895-055f3a6ce4c1" />


## Validation

- `.venv/bin/pytest tests -q`
  - 889 passed, 1 skipped
  - `test_manager_curated_models` remains the only failure and reproduces on
    `upstream/main`
- `npm test` with the CI-pinned Node 20 runtime: 74 passed
- `npm run build`: passed
- `npm run e2e` with Node 20: 154 passed, including the retained-output flow
  - the unrelated `thinking streams live` timing test failed once; its focused
    rerun passed

Windows-specific subprocess and ACL paths are covered by platform-conditional
tests but were not manually exercised for this PR.
