### PR TITLE
Make the conversation-log shrink rewrite atomic (prevent history loss on a mid-write crash)

### DIFF
--- a/coworker/conversations.py
+++ b/coworker/conversations.py
@@ -184,9 +184,16 @@ class ConversationStore:
             if len(record.messages) > existing:
                 self._append(sid, record.messages[existing:])
             elif len(record.messages) < existing:  # rare; not append-only
-                with open(self._file(sid), "w", encoding="utf-8") as f:
+                # Atomic rewrite: write the full log to a temp file, then replace in one
+                # step. An in-place open(..., "w") truncates the file immediately, so a
+                # crash mid-rewrite would erase the conversation history (same
+                # tmp-then-replace pattern as subscriptions.ChannelBuffer._save).
+                path = self._file(sid)
+                tmp = path.with_suffix(".tmp")
+                with open(tmp, "w", encoding="utf-8") as f:
                     for m in record.messages:
                         f.write(json.dumps(m) + "\n")
+                tmp.replace(path)
 
             title = record.title or title_from(record.messages)
             self._conn.execute(

--- a/tests/test_conversation_atomicity.py
+++ b/tests/test_conversation_atomicity.py
@@ -1,0 +1,96 @@
+"""Crash-safety of ConversationStore's shrink rewrite (write-side atomicity).
+
+`save()` appends new messages on the common path, but when a turn *reduces* the message
+count (context compaction / summarization) it rewrites the whole ``.jsonl``. That rewrite
+must be atomic: a crash partway through must not truncate or erase the existing history —
+the most valuable data the app holds.
+
+This is the write-side complement to read-side corrupt-line tolerance: prevent the
+truncated file rather than cope with one after the fact.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from coworker.conversations import ConversationStore
+from coworker.sessions import SessionRecord
+
+
+def _rec(sid: str, n: int) -> SessionRecord:
+    return SessionRecord(
+        session_id=sid,
+        workspace="/w",
+        model="m",
+        mode="interactive",
+        messages=[{"role": "user", "content": f"msg-{i}"} for i in range(n)],
+    )
+
+
+def test_shrink_rewrite_preserves_history_when_write_crashes(tmp_path, monkeypatch):
+    store = ConversationStore(tmp_path)
+    sid = "sess1"
+
+    # Persist a 5-message history via the append path.
+    store.save(_rec(sid, 5))
+    assert len(store.load(sid).messages) == 5
+
+    # Force a crash partway through the shrink rewrite (5 -> 2): the write fails after the
+    # first line. A non-atomic in-place open(..., "w") truncates the real file at open() and
+    # the crash then erases the history; an atomic tmp-then-replace leaves the original
+    # untouched because the swap never happens.
+    import coworker.conversations as conv
+
+    real_open = open
+    writes = {"n": 0}
+
+    class _CrashingFile:
+        def __init__(self, fh):
+            self._fh = fh
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self._fh.close()
+            return False
+
+        def write(self, s):
+            writes["n"] += 1
+            if writes["n"] >= 2:
+                raise OSError("simulated crash mid-write")
+            return self._fh.write(s)
+
+    def crashing_open(file, mode="r", *args, **kwargs):
+        fh = real_open(file, mode, *args, **kwargs)
+        if "w" in mode and os.path.basename(str(file)).startswith(sid):
+            return _CrashingFile(fh)
+        return fh
+
+    monkeypatch.setattr(conv, "open", crashing_open, raising=False)
+
+    with pytest.raises(OSError):
+        store.save(_rec(sid, 2))
+
+    monkeypatch.undo()
+
+    # The interrupted shrink must not have destroyed the existing history.
+    assert len(store.load(sid).messages) == 5
+
+
+def test_shrink_rewrite_persists_reduced_history(tmp_path):
+    """The (non-crash) shrink path still rewrites the log to exactly the reduced set."""
+    store = ConversationStore(tmp_path)
+    sid = "sess2"
+
+    store.save(_rec(sid, 5))
+    assert len(store.load(sid).messages) == 5
+
+    store.save(_rec(sid, 3))  # shrink 5 -> 3
+    reloaded = store.load(sid)
+    assert [m["content"] for m in reloaded.messages] == ["msg-0", "msg-1", "msg-2"]
+
+    # No leftover temp file next to the conversation log.
+    assert not (tmp_path / "conversations" / f"{sid}.tmp").exists()


### PR DESCRIPTION
## Problem

`ConversationStore.save()` appends new messages on the common path, but when a turn *reduces* the message count (context compaction / summarization) it rewrites the whole `.jsonl` in place:

```python
elif len(record.messages) < existing:  # rare; not append-only
    with open(self._file(sid), "w", encoding="utf-8") as f:
        for m in record.messages:
            f.write(json.dumps(m) + "\n")
```

`open(..., "w")` truncates the file at `open()`, so a crash (or disk-full) partway through the rewrite leaves a **truncated or empty log — permanently losing conversation history**, the most valuable data the app stores. The append path is safe; only this shrink branch is non-atomic.

This is the write-side companion to #56 (tolerate a corrupt line on *read*). #56's per-line skip can't recover a whole-file truncation from this path — the messages are simply gone — so preventing the truncation closes the remaining gap. (#56's own note already observes that an interrupted mid-write corrupts the file.)

## Fix

Write the reduced log to a temp file and `Path.replace()` it in one atomic step — the same tmp-then-replace pattern `subscriptions.ChannelBuffer._save()` already uses in this repo. `os.replace` is atomic on POSIX and Windows when the temp file is on the same filesystem (it is — same directory), so a concurrent reader or a crash sees either the old complete log or the new one, never a partial.

Kept intentionally minimal: the atomic rename is what fixes the truncation. I left out an `fsync` (power-loss durability) to match the existing `ChannelBuffer` idiom — happy to add it if you'd prefer.

## Tests

New `tests/test_conversation_atomicity.py`:

- **`test_shrink_rewrite_preserves_history_when_write_crashes`** — persists a 5-message history, then simulates a crash partway through a shrink rewrite, and asserts the history survives.
  - Before the fix: `FAILED — AssertionError: assert 1 == 5` (history truncated to a single message).
  - After the fix: passes.
- **`test_shrink_rewrite_persists_reduced_history`** — the normal (non-crash) shrink still writes exactly the reduced set, with no leftover temp file.

The surrounding conversation tests (autotitle, durable-resume, session-persona, attachments, memory) still pass.

*This is a backend fix with no UI surface, so the "before / after" is the test result above (red `FAILED assert 1 == 5` → green `2 passed`) rather than a screenshot — glad to attach a terminal capture if you'd like one.*
