### PR TITLE
Fix GUI README paths

### DIFF
--- a/surfaces/gui/README.md
+++ b/surfaces/gui/README.md
@@ -8,7 +8,7 @@ Same codebase runs in a browser (dev) and as the OpenWorker desktop app.
 A fresh checkout has no server to run — create the venv both flows below expect:
 
 ```bash
-bash platform/packaging/setup_dev_env.sh   # → platform/.venv (server + this repo's aisuite)
+bash packaging/setup_dev_env.sh   # → .venv (server + this repo's aisuite)
 ```
 
 ## Run it (browser, two terminals)
@@ -16,12 +16,11 @@ bash platform/packaging/setup_dev_env.sh   # → platform/.venv (server + this r
 1. **Start the server** (needs a model key, e.g. `OPENAI_API_KEY`, in the environment —
    or add one later in the app's Settings):
    ```bash
-   cd platform
    ./.venv/bin/openworker-server --cwd /path/to/your/project --port 8765
    ```
 2. **Start the UI:**
    ```bash
-   cd platform/surfaces/gui
+   cd surfaces/gui
    npm install      # first time
    npm run dev      # → http://localhost:5173
    ```
@@ -33,11 +32,11 @@ Open http://localhost:5173. The UI talks to `http://127.0.0.1:8765` (override wi
 
 The Tauri shell wraps the same UI and supervises the Python server itself — no separate
 terminal. It needs the Rust toolchain (`rustup`) plus the venv from the bootstrap step;
-in dev it finds the server at `platform/.venv/bin/openworker-server` automatically (a
-packaged sidecar binary is only produced by the release scripts in `platform/packaging/`).
+in dev it finds the server at `.venv/bin/openworker-server` automatically (a packaged
+sidecar binary is only produced by the release scripts in `packaging/`).
 
 ```bash
-cd platform/surfaces/gui
+cd surfaces/gui
 npm install        # first time
 npm run tauri dev  # builds the shell, launches the window, starts the server
 ```


### PR DESCRIPTION
## What changed

Correct the GUI README commands to match the current repository layout. The README referenced a removed `platform/` directory, which made the documented setup and launch commands fail from a fresh checkout.

## Validation

- `git diff --check`
- Confirmed the README no longer contains `platform/` paths
- Backend suite previously passed: 853 passed, 1 skipped

This is documentation-only.