### PR TITLE
Prevent IME candidate confirmation from sending

### DIFF
--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -268,6 +268,9 @@ export function Composer(props: Props) {
   };
 
   const onKey = (e: React.KeyboardEvent) => {
+    // Enter is also used to confirm candidates while composing with a CJK IME.
+    // Do not submit until the composition has finished.
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       submit();

--- a/surfaces/gui/src/components/Composer.voice.test.tsx
+++ b/surfaces/gui/src/components/Composer.voice.test.tsx
@@ -102,3 +102,18 @@ describe("Composer voice input (§37)", () => {
     expect(screen.getByLabelText("Start dictation").hasAttribute("disabled")).toBe(false);
   });
 });
+
+describe("Composer IME input", () => {
+  it("does not submit Enter while an IME composition is active", () => {
+    const onSend = vi.fn();
+    render(<Composer {...props({ onSend })} />);
+    const box = screen.getByPlaceholderText(/Ask the coworker/) as HTMLTextAreaElement;
+    fireEvent.change(box, { target: { value: "ni hao" } });
+
+    fireEvent.keyDown(box, { key: "Enter", isComposing: true });
+    fireEvent.keyDown(box, { key: "Enter", keyCode: 229 });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(box.value).toBe("ni hao");
+  });
+});


### PR DESCRIPTION
## What changed

Fixes #64. The chat composer now ignores Enter key events while a CJK IME composition is active, including legacy IME events reported with `keyCode === 229`. Added a regression test covering both event forms.

## User impact

Pressing Enter to confirm a Chinese, Japanese, or Korean candidate no longer sends the partially composed message. Enter still submits normally after composition completes.

## Validation

- `git diff --check`
- Backend suite previously passed: 853 passed, 1 skipped
- GUI Vitest could not run locally because npm dependencies are unavailable in this environment; CI should run the GUI test suite.