### PR TITLE
feat(linux): add hardened AppImage release support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
-# Desktop release builds — macOS (.dmg, arm64 + Intel) and Windows (.msi + NSIS .exe).
+# Desktop release builds — macOS (.dmg, arm64), Windows (.msi + NSIS .exe), and Linux
+# (.AppImage, x86-64).
 #
-# CI calls the SAME scripts developers run locally (packaging/build_dmg.sh and
-# build_windows.ps1); this file only provisions the toolchain (Node, Rust, a Python venv at
-# .venv with PyInstaller) and publishes the results.
+# CI calls the SAME scripts developers run locally (packaging/build_dmg.sh,
+# build_windows.ps1, and build_appimage.sh); this file only provisions the toolchain (Node,
+# Rust, a Python venv at .venv with PyInstaller) and publishes the results.
 #
 # Triggers:
 #   - tag push `v*`  → builds all targets and attaches them to a DRAFT GitHub Release
@@ -50,6 +51,11 @@ jobs:
             slug: macos-arm64
           - os: windows-latest
             slug: windows
+          # Ubuntu 22.04 keeps the Linux release's glibc ABI floor conservative. ARM64 remains
+          # source-portable, but the initial published Linux release is explicitly x86-64 only.
+          - os: ubuntu-22.04
+            slug: linux-x86_64
+            arch: x86_64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -69,6 +75,26 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          test "$(uname -m)" = "${{ matrix.arch }}"
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            file \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libssl-dev \
+            libxdo-dev \
+            patchelf \
+            libasound2-dev \
+            wget
 
       - name: Set up the sidecar venv (.venv)
         # The build scripts expect a venv at .venv with the package + PyInstaller.
@@ -120,6 +146,13 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: ./packaging/build_windows.ps1
 
+      - name: Build AppImage (Linux x86-64)
+        if: runner.os == 'Linux'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: ./packaging/build_appimage.sh
+
       - name: Stage artifacts (versioned + stable names)
         run: |
           mkdir -p out
@@ -131,9 +164,9 @@ jobs:
             cp "$BUNDLE"/msi/*.msi out/OpenWorker-windows.msi
             # Updater signature for the NSIS installer (present only when the updater key
             # secret is configured). The .sig signs CONTENT, so the stable rename is safe.
-            SIG=$(ls "$BUNDLE"/nsis/*.exe.sig 2>/dev/null | head -1 || true)
+            SIG=$(find "$BUNDLE/nsis" -maxdepth 1 -type f -name '*.exe.sig' -print -quit 2>/dev/null || true)
             [ -n "$SIG" ] && cp "$SIG" out/OpenWorker-windows-setup.exe.sig
-          else
+          elif [ "$RUNNER_OS" = "macOS" ]; then
             cp "$BUNDLE"/dmg/*.dmg out/
             cp "$BUNDLE"/dmg/*.dmg out/OpenWorker-${{ matrix.slug }}.dmg
             # macOS updater artifact: the signed .app tarball the installed app swaps in.
@@ -141,6 +174,22 @@ jobs:
               cp "$BUNDLE"/macos/OpenWorker.app.tar.gz out/OpenWorker-${{ matrix.slug }}.app.tar.gz
               cp "$BUNDLE"/macos/OpenWorker.app.tar.gz.sig out/OpenWorker-${{ matrix.slug }}.app.tar.gz.sig
             fi
+          elif [ "$RUNNER_OS" = "Linux" ]; then
+            APPIMAGE=("$BUNDLE"/appimage/*.AppImage)
+            [ -f "${APPIMAGE[0]}" ]
+            cp "${APPIMAGE[0]}" out/
+            cp "${APPIMAGE[0]}" out/OpenWorker-linux-x86_64.AppImage
+
+            UPDATER=("$BUNDLE"/appimage/*.AppImage.tar.gz)
+            if [ -f "${UPDATER[0]}" ]; then
+              cp "${UPDATER[0]}" out/OpenWorker-linux-x86_64.AppImage.tar.gz
+              if [ -f "${UPDATER[0]}.sig" ]; then
+                cp "${UPDATER[0]}.sig" out/OpenWorker-linux-x86_64.AppImage.tar.gz.sig
+              fi
+            fi
+          else
+            echo "::error::unsupported release runner: $RUNNER_OS"
+            exit 1
           fi
           ls -la out
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,30 @@ It runs on your machine and doesn't lock you into any model: bring your own API 
 [**⬇ Windows 10/11 (x64)**](https://download.openworker.com/windows)
 <sub>builds are not yet code-signed, so SmartScreen will warn; signing is in progress</sub>
 
+[**⬇ Linux AppImage (x86-64)**](https://github.com/andrewyng/openworker/releases/latest/download/OpenWorker-linux-x86_64.AppImage)
+<sub>Ubuntu 22.04+ and other glibc-based distributions with WebKitGTK 4.1</sub>
+
+On Linux, make the download executable before launching it:
+
+```shell
+chmod +x OpenWorker-linux-x86_64.AppImage
+./OpenWorker-linux-x86_64.AppImage
+```
+
+Supported hosts include Ubuntu 22.04 or newer and current Debian, Fedora, Arch, and derivative
+distributions that provide glibc and WebKitGTK 4.1. The host must also provide GTK 3, libsoup 3,
+and ALSA. For example, Debian/Ubuntu packages these as `libwebkit2gtk-4.1-0`, `libgtk-3-0`,
+`libsoup-3.0-0`, and `libasound2`. Voice input uses ALSA directly or through PipeWire's ALSA
+compatibility layer. Keep awake uses `systemd-inhibit` and therefore requires systemd/logind; if
+no inhibitor can be acquired, the toggle remains off rather than claiming to be active.
+
+NixOS does not run AppImages directly. Use `appimage-run`:
+
+```shell
+nix shell nixpkgs#appimage-run --command \
+  appimage-run ./OpenWorker-linux-x86_64.AppImage
+```
+
 Open the app, add a model key (or point it at Ollama), and ask for something real.
 
 ## How it works
@@ -62,7 +86,7 @@ OpenWorker is local-first. Everything lives on your machine: the agent loop, you
 
 ## Run from source
 
-Prerequisites: Python 3.10+, Node 20+, and (for the desktop shell) the Rust toolchain via [rustup](https://rustup.rs/).
+Prerequisites: Python 3.10+, Node 20+, and (for the desktop shell) the Rust toolchain via [rustup](https://rustup.rs/). Linux desktop builds also need the Tauri and ALSA development packages listed in [`packaging/build_appimage.sh`](packaging/build_appimage.sh).
 
 ```shell
 git clone https://github.com/andrewyng/openworker
@@ -84,7 +108,51 @@ npm run dev        # browser UI on the Vite dev port
 
 To run the full desktop app instead of the browser UI, replace step 3 with `npm run tauri dev` (from `surfaces/gui/`) - the Tauri shell launches the window and supervises the server itself.
 
-Tests: `.venv/bin/pytest` (server), `npm test` and `npm run e2e` in `surfaces/gui` (GUI unit + hermetic end-to-end). Desktop bundles are built with `packaging/build_dmg.sh` / `packaging/build_windows.ps1`.
+Tests: `.venv/bin/pytest` (server), `npm test` and `npm run e2e` in `surfaces/gui` (GUI unit + hermetic end-to-end). Desktop bundles are built with `packaging/build_dmg.sh`, `packaging/build_windows.ps1`, or `packaging/build_appimage.sh`.
+
+### Linux release testing
+
+Linux releases use two deliberately different environments:
+
+| Environment | Purpose |
+|---|---|
+| Ubuntu 22.04 GitHub Actions | Reproducible x86-64 release build with a conservative glibc ABI floor |
+| Dubnium/NixOS + Hyprland | Hostile consumer/runtime compatibility test under Wayland and NixOS |
+
+Automated release checks:
+
+```shell
+# Python backend
+.venv/bin/pytest
+
+# React GUI
+cd surfaces/gui
+npm test
+npm run e2e
+
+# Rust
+cargo fmt --check --manifest-path src-tauri/Cargo.toml
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml
+
+# Package (from the repository root)
+cd ../..
+./packaging/build_appimage.sh
+```
+
+The NixOS/Hyprland smoke test runs the versioned artifact with `appimage-run` and verifies that:
+
+```shell
+nix shell nixpkgs#appimage-run --command \
+  appimage-run ./OpenWorker_0.1.6_amd64.AppImage
+```
+
+- The AppImage starts under Wayland, discovers its bundled sidecar, and progresses past “Starting coworker…”.
+- `~/.config/coworker/logs/openworker-server.log` contains no startup errors.
+- The portal folder picker, file tools, terminal tools, tray hide/reopen, and single-instance focus work.
+- Quitting terminates the Python sidecar; voice works through PipeWire/ALSA and disables cleanly without a microphone.
+- Autostart creates a valid XDG entry, paths containing spaces work, and moving the AppImage does not break startup.
+- `systemd-inhibit --list` shows OpenWorker only while keep awake is enabled, and the entry disappears after disabling it or quitting.
 
 ## Repository layout
 
@@ -93,7 +161,7 @@ Tests: `.venv/bin/pytest` (server), `npm test` and `npm run e2e` in `surfaces/gu
 | `coworker/` | Python backend - agent engine, model providers, connectors, MCP client, memory, automations |
 | `surfaces/gui/` | Desktop app - React UI + Tauri shell that supervises the server |
 | `stt/` | Speech-to-text sidecar (Rust) for voice input |
-| `packaging/` | Installer builds (macOS DMG, Windows), auto-update manifest, dev bootstrap |
+| `packaging/` | Installer builds (macOS DMG, Windows, Linux AppImage), auto-update manifest, dev bootstrap |
 | `docs/` | Design specs and decision logs |
 | `tests/` | Backend test suite |
 

--- a/packaging/build_appimage.sh
+++ b/packaging/build_appimage.sh
@@ -26,7 +26,7 @@
 #       dnf install webkit2gtk4.1-devel gtk3-devel libappindicator-gtk3-devel \
 #                   librsvg2-devel libsoup3-devel patchelf alsa-lib-devel
 #     Debian/Ubuntu:
-#       apt install libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev \
+#       apt install libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
 #                   librsvg2-dev libsoup-3.0-dev patchelf libasound2-dev
 #     `alsa-lib-devel` / `libasound2-dev` is required by cpal (the STT sidecar's audio
 #     backend) — without alsa.pc the `ocw-stt` crate fails to compile.

--- a/packaging/build_appimage.sh
+++ b/packaging/build_appimage.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Build the Linux desktop app as an AppImage.
+#
+#   1. PyInstaller-bundle the server into a standalone onedir folder (no venv at runtime).
+#   2. Stage it at binaries/sidecar/ for Tauri's `resources` slot.
+#   3. `tauri build --bundles appimage` → OpenWorker_<version>_<arch>.AppImage
+#      (+ updater artifacts OpenWorker_<version>_<arch>.AppImage.tar.gz + .sig when the
+#      updater signing key is available).
+#
+# Why AppImage: OpenWorker is a host-acting agent (shell, files, MCP subprocesses), so a
+# sandboxed format (Flatpak/Snap) would fight the app's nature. AppImage ships one portable
+# file with full host access — and it is the ONLY Linux bundle the Tauri updater supports,
+# so picking it keeps auto-update working (deb/rpm throw "Cannot run updater on this Linux
+# package" at install time).
+#
+# Prerequisites (mirrors build_dmg.sh's header):
+#   - Rust (rustup) + Node/npm, and the GUI deps installed (npm ci in surfaces/gui).
+#   - A Python venv at .venv (repo root) with this package installed editable, plus the
+#     build-only deps:
+#       python3.12 -m venv .venv
+#       .venv/bin/pip install -e . pyinstaller typer
+#     `typer` is needed only at BUILD time: PyInstaller walks the `mcp` package and
+#     `mcp.cli` calls sys.exit() at import if typer is absent, which aborts the freeze.
+#     (aisuite installs like any other dependency — git-pinned in pyproject.toml.)
+#   - Tauri's Linux build-time libs. Fedora:
+#       dnf install webkit2gtk4.1-devel gtk3-devel libappindicator-gtk3-devel \
+#                   librsvg2-devel libsoup3-devel patchelf alsa-lib-devel
+#     Debian/Ubuntu:
+#       apt install libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev \
+#                   librsvg2-dev libsoup-3.0-dev patchelf libasound2-dev
+#     `alsa-lib-devel` / `libasound2-dev` is required by cpal (the STT sidecar's audio
+#     backend) — without alsa.pc the `ocw-stt` crate fails to compile.
+#     Tauri downloads appimagetool + linuxdeploy itself on first build.
+#     (At runtime an AppImage needs webkit2gtk-4.1, gtk3, libsoup3-3.0, libasound2 on the
+#     host — standard on any modern distro.)
+#
+# AUTO-UPDATE (optional): set TAURI_SIGNING_PRIVATE_KEY to produce the .AppImage.tar.gz +
+# .sig artifacts the updater manifest (packaging/make_update_manifest.py) references.
+# From the env, or from `.ocw-updater.env` one directory above the repo (same convention
+# as build_dmg.sh). Keyless builds skip the overlay entirely so dev/fork builds still work;
+# a keyless RELEASE would strand every install without auto-update, hence the loud warning.
+#
+# Experimental (use-at-your-own-risk) connectors are EXCLUDED from this build by default —
+# the spec strips coworker.connectors.experimental. Self-builders can opt in with:
+#   COWORKER_EXPERIMENTAL=1 ./build_appimage.sh
+set -euo pipefail
+
+# NO_STRIP=1: linuxdeploy bundles its own `strip` (an old GNU binutils inside the
+# AppImage) that predates the `.relr.dyn` ELF section (type 0x13, SHT_RELR, added in
+# binutils 2.31). Libraries built on modern distros (Fedora 40+, recent Ubuntu) carry
+# that section, so the bundled strip rejects EVERY .so ("unknown type [0x13] section
+# `.relr.dyn'") and linuxdeploy aborts. NO_STRIP tells linuxdeploy-plugin-appimage to
+# skip the strip pass entirely — the libraries are already release builds, so the only
+# cost is keeping their (typically already-stripped) debug sections. Harmless on older
+# distros too, so set unconditionally.
+export NO_STRIP=1
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PLATFORM="$(cd "$HERE/.." && pwd)"
+GUI="$PLATFORM/surfaces/gui"
+APP="OpenWorker"
+# Single source of truth for the version: tauri.conf.json (also stamps the bundle).
+VERSION="$(node -p "require('$GUI/src-tauri/tauri.conf.json').version")"
+TRIPLE="$(rustc -vV | sed -n 's/host: //p')"   # e.g. x86_64-unknown-linux-gnu
+ARCH="${TRIPLE%%-*}"                            # x86_64 | aarch64
+# AppImage bundle naming (and Tauri's --target) uses the Debian arch convention,
+# not the GNU triple: x86_64 -> amd64, aarch64 -> arm64.
+case "$ARCH" in
+  x86_64) BUNDLE_ARCH="amd64";;
+  aarch64) BUNDLE_ARCH="arm64";;
+  *) BUNDLE_ARCH="$ARCH";;
+esac
+
+echo "==> [1/3] PyInstaller: bundling openworker-server ($TRIPLE)"
+"$PLATFORM/.venv/bin/pyinstaller" --noconfirm --clean \
+  --distpath "$HERE/dist" --workpath "$HERE/build" "$HERE/openworker-server.spec"
+
+echo "==> [2/3] staging sidecar resources"
+# Onedir bundle (exe + _internal/) ships via Tauri `resources` as usr/lib/<binary>/sidecar/
+# inside the AppImage (see server_bin()'s Linux candidate in src-tauri/src/lib.rs). rm -rf
+# first: cp writes through a symlink at the destination; also clears any stale onefile binary
+# from pre-onedir builds.
+mkdir -p "$GUI/src-tauri/binaries"
+rm -rf "$GUI/src-tauri/binaries/sidecar" "$GUI/src-tauri/binaries/openworker-server-$TRIPLE"
+# -RL (dereference): Tauri's resource bundler flattens symlinks into duplicate REAL files.
+# Dereferencing at staging makes what tauri COPIES deterministic; no framework layout is
+# produced on Linux (unlike macOS), but dereferencing keeps the two build scripts identical
+# and avoids any stray symlink surviving into the AppDir.
+cp -RL "$HERE/dist/openworker-server" "$GUI/src-tauri/binaries/sidecar"
+if [ -n "$(find "$GUI/src-tauri/binaries/sidecar" -type l | head -1)" ]; then
+  echo "ERROR: symlinks survived sidecar staging — tauri would flatten them into duplicates" >&2
+  exit 1
+fi
+chmod +x "$GUI/src-tauri/binaries/sidecar/openworker-server"
+
+echo "==> [3/3] tauri build (AppImage)"
+# Auto-update artifacts (.AppImage.tar.gz + minisign .sig): produced only when the updater
+# signing key is available — from the env (CI secret TAURI_SIGNING_PRIVATE_KEY), or from
+# `.ocw-updater.env` one directory above the repo (same convention as the notary env on macOS).
+# Keyless builds skip the overlay entirely so dev/fork builds keep working; keyless RELEASES
+# would strand every install without auto-update, hence the loud warning.
+UPDATER_ENV="${OCW_UPDATER_ENV:-$PLATFORM/../.ocw-updater.env}"
+if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ] && [ -f "$UPDATER_ENV" ]; then
+  # shellcheck disable=SC1090
+  source "$UPDATER_ENV"
+fi
+UPDATER_OVERLAY=()
+if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+  UPDATER_OVERLAY=(--config '{"bundle":{"createUpdaterArtifacts":true}}')
+else
+  echo "    WARNING: no updater signing key — building WITHOUT auto-update artifacts (not releasable)."
+fi
+# ${arr[@]+…} guard: plain "${arr[@]}" on an EMPTY array is an "unbound variable" under set -u.
+# NO_STRIP=1 is exported at the top of this script (see comment there).
+( cd "$GUI" && npm run tauri build -- --bundles appimage ${UPDATER_OVERLAY[@]+"${UPDATER_OVERLAY[@]}"} )
+
+BUNDLE="$GUI/src-tauri/target/release/bundle/appimage"
+APPIMAGE="$BUNDLE/${APP}_${VERSION}_${BUNDLE_ARCH}.AppImage"
+
+if [ ! -f "$APPIMAGE" ]; then
+  echo "ERROR: expected AppImage not found at $APPIMAGE" >&2
+  echo "       (Tauri may have named it differently — check $BUNDLE/)" >&2
+  exit 1
+fi
+
+echo ""
+echo "Done → $APPIMAGE"
+echo "  run:      chmod +x \"$APPIMAGE\" && \"$APPIMAGE\""
+echo "  update:   (set TAURI_SIGNING_PRIVATE_KEY to also emit the .tar.gz + .sig for the updater manifest)"

--- a/packaging/make_update_manifest.py
+++ b/packaging/make_update_manifest.py
@@ -35,6 +35,7 @@ import sys
 ARTIFACTS = {
     "OpenWorker-macos-arm64.app.tar.gz": "darwin-aarch64",
     "OpenWorker-windows-setup.exe": "windows-x86_64",
+    "OpenWorker-linux-x86_64.AppImage.tar.gz": "linux-x86_64",
 }
 
 

--- a/packaging/make_update_manifest.py
+++ b/packaging/make_update_manifest.py
@@ -11,6 +11,7 @@ uploads):
 
     OpenWorker-macos-arm64.app.tar.gz(.sig)   -> platforms["darwin-aarch64"]
     OpenWorker-windows-setup.exe(.sig)        -> platforms["windows-x86_64"]
+    OpenWorker-linux-x86_64.AppImage.tar.gz(.sig) -> platforms["linux-x86_64"]
 
 URLs point at the TAG-pinned GitHub download path (releases/download/<tag>/<asset>),
 never at `latest/` — a manifest must reference exactly the artifacts it shipped with,

--- a/stt/src/lib.rs
+++ b/stt/src/lib.rs
@@ -33,6 +33,24 @@ pub const DEFAULT_MODEL_SHA256: &str =
     "a03779c86df3323075f5e796cb2ce5029f00ec8869eee3fdfb897afe36c6d002";
 const WHISPER_SAMPLE_RATE: u32 = 16_000;
 
+/// Whether a microphone is reachable from the default CPAL host.
+///
+/// Hosts call this to decide whether to offer voice input at all. On Linux it is the only
+/// gate — the STT engine itself (cpal ALSA backend + whisper-rs on CPU) runs on any arch,
+/// so a missing or unreachable input device cleanly disables voice input instead of failing
+/// at record time. Wrapped in `catch_unwind` so a misbehaving audio stack can never crash the
+/// host: a panic here just reports "no microphone".
+///
+/// Cheap enough for a UI compatibility probe: it enumerates devices but opens no stream.
+pub fn input_device_available() -> bool {
+    std::panic::catch_unwind(|| {
+        cpal::default_host()
+            .default_input_device()
+            .is_some()
+    })
+    .unwrap_or(false)
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct DictationStatus {
     pub recording: bool,
@@ -459,7 +477,7 @@ fn start_recording() -> Result<Recording, String> {
     let host = cpal::default_host();
     let device = host
         .default_input_device()
-        .ok_or_else(|| "No microphone is available. Check your Mac sound settings.".to_owned())?;
+        .ok_or_else(|| "No microphone is available. Check your sound settings.".to_owned())?;
     let supported = device
         .default_input_config()
         .map_err(|e| format!("Could not open the microphone: {e}"))?;

--- a/surfaces/gui/src-tauri/build.rs
+++ b/surfaces/gui/src-tauri/build.rs
@@ -1,3 +1,6 @@
 fn main() {
+    // Release scripts replace this ignored directory with the PyInstaller sidecar. Keep plain
+    // Cargo checks from failing Tauri's resource validation in a fresh checkout.
+    std::fs::create_dir_all("binaries/sidecar").expect("create sidecar resource directory");
     tauri_build::build()
 }

--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -51,7 +51,7 @@ fn free_port() -> u16 {
 ///      builds used Tauri externalBin).
 ///   4. Dev fallback: the repo venv, relative to this crate (`src-tauri` → `platform/.venv`;
 ///      `bin/` on POSIX, `Scripts\` on Windows).
-fn server_bin() -> PathBuf {
+fn server_bin(product_name: Option<&str>) -> PathBuf {
     if let Ok(p) = std::env::var("COWORKER_SERVER_BIN") {
         return PathBuf::from(p);
     }
@@ -65,8 +65,20 @@ fn server_bin() -> PathBuf {
             // macOS: Contents/MacOS/<app> → Contents/Resources/sidecar/; Windows: resources
             // unpack next to the exe, so <install>/sidecar/.
             let mut candidates = vec![dir.join("sidecar").join(exe_name)];
-            if let Some(contents) = dir.parent() {
-                candidates.push(contents.join("Resources").join("sidecar").join(exe_name));
+            if let Some(parent) = dir.parent() {
+                // macOS: <bundle>/Contents/MacOS/<app> → Contents/Resources/sidecar/.
+                candidates.push(parent.join("Resources").join("sidecar").join(exe_name));
+                // Linux (AppImage / deb / rpm): the exe ships in usr/bin/ while Tauri
+                // unpacks `resources` to usr/lib/<productName>/ (NOT the cargo pkg name —
+                // verified in a built AppImage: usr/bin/openworker-desktop but
+                // usr/lib/OpenWorker/sidecar/). product_name comes from the Tauri config so
+                // this never desyncs from tauri.conf.json. Without this candidate the server
+                // is never found inside a bundled AppImage and the GUI stalls on "Starting
+                // coworker…".
+                #[cfg(target_os = "linux")]
+                if let Some(name) = product_name {
+                    candidates.push(parent.join("lib").join(name).join("sidecar").join(exe_name));
+                }
             }
             candidates.push(dir.join(exe_name)); // legacy onefile externalBin slot
             for c in candidates {
@@ -141,7 +153,8 @@ fn write_keep_awake_pref(enabled: bool) {
 // Cross-platform behind a uniform `start_keep_awake() -> Option<KeepAwakeGuard>`; dropping the
 // guard releases the hold. macOS uses the built-in `caffeinate`; Windows uses the
 // SetThreadExecutionState API (a dedicated thread holds ES_CONTINUOUS so the state survives
-// regardless of which Tauri worker thread toggled it); other platforms are a no-op.
+// regardless of which Tauri worker thread toggled it); Linux uses `systemd-inhibit` when
+// available, falling back to a no-op on systems without systemd (containers, some WSL setups).
 
 #[cfg(target_os = "macos")]
 struct KeepAwakeGuard(Child);
@@ -210,13 +223,43 @@ fn start_keep_awake() -> Option<KeepAwakeGuard> {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-struct KeepAwakeGuard;
+struct KeepAwakeGuard(Option<Child>);
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+impl Drop for KeepAwakeGuard {
+    fn drop(&mut self) {
+        // Killing the child (systemd-inhibit) releases the sleep hold, mirroring macOS's
+        // caffeinate kill. None on the no-op fallback path.
+        if let Some(mut child) = self.0.take() {
+            let _ = child.kill();
+        }
+    }
+}
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn start_keep_awake() -> Option<KeepAwakeGuard> {
-    // No portable built-in inhibitor on Linux; keep-awake is a no-op (the toggle still reflects
-    // state so the UI behaves, but the OS sleep policy is left to the user).
-    Some(KeepAwakeGuard)
+    // Try systemd-inhibit (present on virtually every modern Linux distro). `--mode=block`
+    // holds the inhibition for as long as the child (`sleep infinity`) is alive; killing the
+    // child here releases the hold, mirroring macOS's caffeinate.
+    // If systemd-inhibit is absent or spawn fails (containers, non-systemd distros, WSL without
+    // systemd), fall back to a no-op guard so the toggle still reflects state but the OS sleep
+    // policy is left to the user — same behaviour as before this change. Detection is runtime:
+    // there is no build-time guarantee systemd is present, so we probe instead of assuming.
+    Command::new("systemd-inhibit")
+        .args([
+            "--what=sleep",
+            "--why=OpenWorker is working",
+            "--mode=block",
+            "sleep",
+            "infinity",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()
+        .map(|child| KeepAwakeGuard(Some(child)))
+        .or_else(|| Some(KeepAwakeGuard(None)))
 }
 
 // -- native commands (invoked from the SPA via window.__TAURI__.core.invoke) -----------------
@@ -366,11 +409,32 @@ fn voice_input_compatibility() -> (bool, String, Option<String>) {
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn voice_input_compatibility() -> (bool, String, Option<String>) {
-    (
-        false,
-        format!("{} · {}", std::env::consts::OS, std::env::consts::ARCH),
-        Some("Voice Input is currently supported on macOS and Windows.".to_owned()),
-    )
+    // The STT engine (cpal ALSA backend + whisper-rs on CPU) builds and runs on Linux, so the
+    // only gate is whether a microphone is reachable. Probe cpal at runtime so voice input is
+    // offered on Linux desktops with audio input and cleanly disabled elsewhere (headless
+    // servers, containers without ALSA, WSL without an audio sink) — exactly the pattern the UI
+    // already handles via `supported` + `compatibility_reason`.
+    let arch = std::env::consts::ARCH;
+    let summary = format!("{} · {}", std::env::consts::OS, arch);
+    let (supported, reason) = if arch != "x86_64" && arch != "aarch64" {
+        (
+            false,
+            Some(format!(
+                "Voice Input is not built for the {arch} architecture on Linux."
+            )),
+        )
+    } else if !ocw_stt::input_device_available() {
+        (
+            false,
+            Some(
+                "No microphone is available. Connect an audio input device and check your sound settings."
+                    .to_owned(),
+            ),
+        )
+    } else {
+        (true, None)
+    };
+    (supported, summary, reason)
 }
 
 #[tauri::command]
@@ -620,7 +684,7 @@ pub fn run() {
         ])
         .setup(move |app| {
             // 1. Start the Python server sidecar on the chosen port (inherits our env).
-            let mut server_cmd = Command::new(server_bin());
+            let mut server_cmd = Command::new(server_bin(app.config().product_name.as_deref()));
             server_cmd
                 .args(["--host", "127.0.0.1", "--port", &port.to_string()])
                 // The sidecar self-exits if we die abruptly (dev-watcher restart, crash) —

--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -154,7 +154,7 @@ fn write_keep_awake_pref(enabled: bool) {
 // guard releases the hold. macOS uses the built-in `caffeinate`; Windows uses the
 // SetThreadExecutionState API (a dedicated thread holds ES_CONTINUOUS so the state survives
 // regardless of which Tauri worker thread toggled it); Linux uses `systemd-inhibit` when
-// available, falling back to a no-op on systems without systemd (containers, some WSL setups).
+// available. Unsupported systems leave the setting off rather than claiming a hold exists.
 
 #[cfg(target_os = "macos")]
 struct KeepAwakeGuard(Child);
@@ -222,30 +222,23 @@ fn start_keep_awake() -> Option<KeepAwakeGuard> {
     })
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-struct KeepAwakeGuard(Option<Child>);
+#[cfg(target_os = "linux")]
+struct KeepAwakeGuard(Child);
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(target_os = "linux")]
 impl Drop for KeepAwakeGuard {
     fn drop(&mut self) {
-        // Killing the child (systemd-inhibit) releases the sleep hold, mirroring macOS's
-        // caffeinate kill. None on the no-op fallback path.
-        if let Some(mut child) = self.0.take() {
-            let _ = child.kill();
-        }
+        // Killing systemd-inhibit releases the sleep hold, mirroring macOS's caffeinate kill.
+        let _ = self.0.kill();
     }
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(target_os = "linux")]
 fn start_keep_awake() -> Option<KeepAwakeGuard> {
     // Try systemd-inhibit (present on virtually every modern Linux distro). `--mode=block`
     // holds the inhibition for as long as the child (`sleep infinity`) is alive; killing the
     // child here releases the hold, mirroring macOS's caffeinate.
-    // If systemd-inhibit is absent or spawn fails (containers, non-systemd distros, WSL without
-    // systemd), fall back to a no-op guard so the toggle still reflects state but the OS sleep
-    // policy is left to the user — same behaviour as before this change. Detection is runtime:
-    // there is no build-time guarantee systemd is present, so we probe instead of assuming.
-    Command::new("systemd-inhibit")
+    let mut child = Command::new("systemd-inhibit")
         .args([
             "--what=sleep",
             "--why=OpenWorker is working",
@@ -257,9 +250,27 @@ fn start_keep_awake() -> Option<KeepAwakeGuard> {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .ok()
-        .map(|child| KeepAwakeGuard(Some(child)))
-        .or_else(|| Some(KeepAwakeGuard(None)))
+        .ok()?;
+
+    // A missing login1 service can let the process spawn but fail immediately. Only report the
+    // setting as active after systemd-inhibit has remained alive long enough to acquire its hold.
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    match child.try_wait() {
+        Ok(None) => Some(KeepAwakeGuard(child)),
+        Ok(Some(_)) => None,
+        Err(_) => {
+            let _ = child.kill();
+            None
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+struct KeepAwakeGuard;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+fn start_keep_awake() -> Option<KeepAwakeGuard> {
+    None
 }
 
 // -- native commands (invoked from the SPA via window.__TAURI__.core.invoke) -----------------
@@ -407,7 +418,7 @@ fn voice_input_compatibility() -> (bool, String, Option<String>) {
     (supported, format!("{version} · x64"), reason)
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(target_os = "linux")]
 fn voice_input_compatibility() -> (bool, String, Option<String>) {
     // The STT engine (cpal ALSA backend + whisper-rs on CPU) builds and runs on Linux, so the
     // only gate is whether a microphone is reachable. Probe cpal at runtime so voice input is
@@ -435,6 +446,15 @@ fn voice_input_compatibility() -> (bool, String, Option<String>) {
         (true, None)
     };
     (supported, summary, reason)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+fn voice_input_compatibility() -> (bool, String, Option<String>) {
+    (
+        false,
+        format!("{} · {}", std::env::consts::OS, std::env::consts::ARCH),
+        Some("Voice Input is not supported on this operating system.".to_owned()),
+    )
 }
 
 #[tauri::command]
@@ -584,7 +604,11 @@ async fn download_update(
     // (Guard scope stays sync: a std MutexGuard must not live across an await.)
     {
         let slot = pending.0.lock().unwrap();
-        if slot.as_ref().map(|(v, _)| v == &update.version).unwrap_or(false) {
+        if slot
+            .as_ref()
+            .map(|(v, _)| v == &update.version)
+            .unwrap_or(false)
+        {
             return Ok(());
         }
     }
@@ -745,6 +769,7 @@ pub fn run() {
 
             // 2. Build the window, injecting the sidecar endpoints before the SPA loads.
             //    Overlay title bar (macOS): traffic lights float over the edge-to-edge UI.
+            #[allow(unused_mut)] // Mutated only by the macOS-specific title-bar configuration.
             let mut builder =
                 WebviewWindowBuilder::new(app, "main", WebviewUrl::App("index.html".into()))
                     .title("OpenWorker")

--- a/tests/test_make_update_manifest.py
+++ b/tests/test_make_update_manifest.py
@@ -1,0 +1,39 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_signed_linux_artifact_produces_linux_x86_64_entry(tmp_path: Path) -> None:
+    asset: str = "OpenWorker-linux-x86_64.AppImage.tar.gz"
+    (tmp_path / asset).write_bytes(b"appimage updater archive")
+    (tmp_path / f"{asset}.sig").write_text("linux-signature\n")
+    output = tmp_path / "latest.json"
+    script = Path(__file__).parents[1] / "packaging" / "make_update_manifest.py"
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--version",
+            "0.1.6",
+            "--tag",
+            "v0.1.6",
+            "--repo",
+            "andrewyng/openworker",
+            "--dist",
+            str(tmp_path),
+            "--out",
+            str(output),
+        ],
+        check=True,
+    )
+
+    manifest = json.loads(output.read_text())
+    assert manifest["platforms"]["linux-x86_64"] == {
+        "signature": "linux-signature",
+        "url": (
+            "https://github.com/andrewyng/openworker/releases/download/v0.1.6/"
+            "OpenWorker-linux-x86_64.AppImage.tar.gz"
+        ),
+    }


### PR DESCRIPTION
## Summary

- add Linux AppImage packaging with sidecar discovery, ALSA voice input, and systemd/logind keep-awake support
- build and stage signed x86-64 AppImage release artifacts on Ubuntu 22.04
- use explicit Linux platform gates and report keep-awake active only after acquiring an inhibitor
- publish the Linux updater manifest entry with regression coverage
- document AppImage installation, runtime dependencies, NixOS usage, and the Linux release test strategy

This preserves and builds on @rmanicardi's original implementation in #19. The original commit remains separate from the signed hardening commit for independent review; this PR supersedes #19 because the contributor branch is not writable by this fork.

## Verification

- `actionlint .github/workflows/release.yml`
- `shellcheck packaging/build_appimage.sh`
- `cargo fmt --check --manifest-path surfaces/gui/src-tauri/Cargo.toml`
- `cargo check --manifest-path surfaces/gui/src-tauri/Cargo.toml`
- `cargo test --manifest-path surfaces/gui/src-tauri/Cargo.toml`
- `.venv/bin/pytest tests/test_make_update_manifest.py -q`
- `npm test` (67 tests)
- `npm run build`
- `packaging/build_appimage.sh` completed PyInstaller, sidecar staging, frontend build, and optimized Rust compilation on NixOS; final AppImage assembly is intentionally delegated to Ubuntu 22.04 CI because Nix linker paths are not suitable release inputs

## Release scope

The initial published Linux target is explicitly x86-64. The implementation remains portable to ARM64 for a later separately staged release target.