### PR TITLE
fix: Python version check in setup_dev_env.sh + IME Enter key in Composer

### DIFF
--- a/packaging/setup_dev_env.sh
+++ b/packaging/setup_dev_env.sh
@@ -10,7 +10,25 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VENV="$ROOT/.venv"
 
-python3 -m venv "$VENV"
+# Find a Python >= 3.10 (macOS system python3 is often 3.9 and too old)
+PYTHON=""
+for candidate in python3.13 python3.12 python3.11 python3.10 python3; do
+  if command -v "$candidate" &>/dev/null; then
+    version=$("$candidate" -c 'import sys; print(sys.version_info >= (3,10))')
+    if [ "$version" = "True" ]; then
+      PYTHON="$candidate"
+      break
+    fi
+  fi
+done
+
+if [ -z "$PYTHON" ]; then
+  echo "Error: Python 3.10+ is required but not found." >&2
+  echo "Install it via: brew install python@3.13  (macOS) or your system package manager." >&2
+  exit 1
+fi
+
+"$PYTHON" -m venv "$VENV"
 # The coworker package (server, engine, connectors) + inbound-messaging extras.
 # aisuite comes in as a regular dependency (git-pinned in pyproject.toml until
 # the next PyPI release).

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -268,7 +268,7 @@ export function Composer(props: Props) {
   };
 
   const onKey = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       submit();
     }


### PR DESCRIPTION
Fixes two bugs reported on day one:

## Fix 1 — #42: setup_dev_env.sh fails on macOS with Python 3.9

macOS ships `python3` pointing to 3.9.6 which is below the 3.10+ requirement. The script would fail immediately with a confusing error.

**Before:** `python3 -m venv` — uses whatever `python3` resolves to, fails on 3.9.

**After:** Tries `python3.13`, `python3.12`, `python3.11`, `python3.10` in order, then falls back to `python3` only if it's ≥ 3.10. Prints a clear install hint if nothing qualifies.

## Fix 2 — #64: Enter in CJK IME composer submits message instead of confirming candidate

When using a CJK input method (Zhuyin/Pinyin/etc.), pressing Enter to confirm a character candidate was triggering `submit()` instead of committing the IME selection.

**Before:** `e.key === "Enter" && !e.shiftKey`

**After:** `e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing`

`isComposing` is `true` while an IME composition is in progress. This is the standard fix used by VS Code, Linear, Notion, and others.