### PR TITLE
fix: tighten CORS ports, Windows venv path, and requires-python floor

### DIFF
--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -28,8 +28,8 @@ from fastapi.middleware.cors import CORSMiddleware
 # allowed — the gate targets browsers, which always attach an unforgeable Origin.
 _ALLOWED_ORIGIN_RE = re.compile(
     r"^(tauri://localhost"
-    r"|https?://localhost(:\d+)?"
-    r"|https?://127\.0\.0\.1(:\d+)?"
+    r"|https?://localhost:(8765|1420)"
+    r"|https?://127\.0\.0\.1:(8765|1420)"
     r"|https?://tauri\.localhost)$"
 )
 

--- a/packaging/setup_dev_env.sh
+++ b/packaging/setup_dev_env.sh
@@ -10,13 +10,18 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VENV="$ROOT/.venv"
 
+case "$(uname -s)" in
+  MINGW*|CYGWIN*|MSYS*) VENV_BIN="Scripts" ;;
+  *) VENV_BIN="bin" ;;
+esac
+
 python3 -m venv "$VENV"
 # The coworker package (server, engine, connectors) + inbound-messaging extras.
 # aisuite comes in as a regular dependency (git-pinned in pyproject.toml until
 # the next PyPI release).
-"$VENV/bin/pip" install --quiet --upgrade pip
-"$VENV/bin/pip" install --quiet -e "$ROOT[messaging,dev]"
+"$VENV/$VENV_BIN/pip" install --quiet --upgrade pip
+"$VENV/$VENV_BIN/pip" install --quiet -e "$ROOT[messaging,dev]"
 
-"$VENV/bin/python" -c 'import aisuite, coworker' # fail loudly if the wiring broke
+"$VENV/$VENV_BIN/python" -c 'import aisuite, coworker' # fail loudly if the wiring broke
 echo "Ready: $VENV"
-echo "  server: $VENV/bin/openworker-server --cwd /path/to/your/project --port 8765"
+echo "  server: $VENV/$VENV_BIN/openworker-server --cwd /path/to/your/project --port 8765"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "coworker"
 version = "0.0.0"
 description = "Agent coworker platform — provider-agnostic agentic coworker runtime"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "openai>=1.0",
     "anthropic>=0.40",  # native Claude Messages API provider


### PR DESCRIPTION
Fixes three issues in a single commit:

## Changes

**Closes #38 — CORS allows any localhost port**
`_ALLOWED_ORIGIN_RE` previously matched any `localhost:<port>`. Since the server binds to 127.0.0.1 and can be reached by any page in the browser, an arbitrary site could enumerate sessions or drive tool calls via WebSocket. Tightened to only allow the two known ports: 8765 (openworker-server default) and 1420 (Tauri dev server).

**Closes #9 — Windows Git Bash uses `Scripts/` not `bin/`**
`packaging/setup_dev_env.sh` hardcoded `$VENV/bin/pip` and `$VENV/bin/python`. On Windows (Git Bash / MSYS2 / Cygwin) the venv layout puts executables under `Scripts/`. Added a `uname -s` check to set `VENV_BIN` accordingly before the venv is created.

**Closes #13 — `requires-python = ">=3.10"` but `tomllib` needs 3.11**
`coworker/config.py` imports `tomllib` from stdlib, which is only available from Python 3.11+. The floor was bumped to `>=3.11` to prevent silent import errors on 3.10 installs.

## Test notes
- CORS: verified regex change rejects `http://localhost:9999` and accepts `http://localhost:8765`
- Windows path: logic is a `uname -s` branch — testable manually on Git Bash / MSYS2
- requires-python: `pip install` will now reject Python 3.10 with a clear version error