### PR TITLE
Make the composer's model pick stick to new sessions

### DIFF
--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -507,6 +507,9 @@ export async function mockApi(page: import("@playwright/test").Page) {
       hidden_fields: [...hubspotState.hidden_fields],
     };
   };
+  // Default model — PER-TEST state, since a composer pick now persists it (App.changeModel).
+  // /v1/health and /v1/settings both report it, exactly like the server's `manager.model`.
+  let defaultModel = HEALTH.model;
   // Installed personas — mutable so enable/surface/delete round-trip through the UI.
   const personas: any[] = PERSONAS.personas.map((p) => ({ ...p }));
   // Sessions — mutable so archive (PATCH), rename (PATCH), and delete round-trip.
@@ -569,7 +572,8 @@ export async function mockApi(page: import("@playwright/test").Page) {
   await page.routeWebSocket(/\/ws\/session\//, (ws) => {
     const send = (type: string, data: Record<string, unknown> = {}) =>
       ws.send(JSON.stringify({ type, data }));
-    send("ready");
+    // A fresh session binds the persisted default, like `manager.get_engine` does.
+    send("ready", { model: defaultModel });
     let pendingTool = "run_shell"; // which proposal the next approval decision resolves
     let epicTimer: ReturnType<typeof setInterval> | null = null; // the slow stream, stoppable via interrupt
     let hadTurn = false; // a user_message landed — set_model is now a mid-session switch
@@ -805,8 +809,15 @@ export async function mockApi(page: import("@playwright/test").Page) {
       return json(i >= 0 ? sessions[i] : PINNED_SESSION);
     }
 
-    if (p.endsWith("/v1/health")) return json(HEALTH);
-    if (p.endsWith("/v1/settings")) return json(SETTINGS);
+    if (p.endsWith("/v1/health")) return json({ ...HEALTH, model: defaultModel });
+    if (p.endsWith("/v1/settings")) return json({ ...SETTINGS, model: defaultModel });
+    if (p.endsWith("/v1/settings/default-model") && m === "POST") {
+      // Like the server: the default is PERSISTED, so /v1/health and /v1/settings both
+      // report it from here on — that's what makes a composer pick outlive the session.
+      const picked = String((req.postDataJSON() || {}).model || "");
+      if (picked) defaultModel = picked;
+      return json({ ok: true, ...SETTINGS, model: defaultModel });
+    }
     if (p.endsWith("/v1/settings/pdf") && m === "POST") {
       Object.assign(SETTINGS, req.postDataJSON());
       return json({

--- a/surfaces/gui/e2e/model-sticky.spec.ts
+++ b/surfaces/gui/e2e/model-sticky.spec.ts
@@ -1,0 +1,26 @@
+// A composer model pick is STICKY (2026-07-24): it also becomes the default for new
+// sessions. Before this, the pick was session-scoped only — every "New session" snapped
+// back to whatever configuring the provider had stamped as the default, so anyone running
+// a custom model had to re-pick on each conversation.
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+test("a composer model pick becomes the default for new sessions", async ({ page }) => {
+  await page.goto("/");
+
+  // The model chip — an uncurated id renders raw ("gpt-5.5"), a curated one its label.
+  const chip = page.locator(".dd").filter({ hasText: /claude opus 4\.8|gpt-5\.5/i });
+  await expect(chip).toContainText("Claude Opus 4.8");
+
+  await chip.locator(".pill").click();
+  await page.locator(".dd-item").filter({ hasText: "gpt-5.5" }).click();
+  await expect(chip).toContainText("gpt-5.5");
+
+  // New session: the server binds the persisted default, so the pick rides along.
+  await page.getByRole("button", { name: "New session" }).click();
+  await expect(chip).toContainText("gpt-5.5");
+
+  // And it outlives the app — a cold boot reads the same default back from the server.
+  await page.reload();
+  await expect(chip).toContainText("gpt-5.5");
+});

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -18,6 +18,7 @@ import {
   deleteSession,
   renameSession,
   runAutomation,
+  setDefaultModel,
   setSessionFlags,
   setUnattended,
   Session,
@@ -861,6 +862,14 @@ export function App() {
     if (running) return; // the server refuses mid-turn rebinds — don't let the header lie
     setModel(m);
     sessionRef.current?.setModel(m);
+    // Sticky (2026-07-24): an explicit pick in the composer is also the default for NEW
+    // sessions. Without this the pick was session-scoped only, so every "New session"
+    // silently snapped back to whatever `set_provider` stamped as the default — a
+    // custom-model user had to re-pick every single time. Resuming an existing session is
+    // unaffected: the server replays that session's own model from its record.
+    // Fire-and-forget: the picker must not block on the round trip, and a failed write
+    // only costs stickiness (the session itself already switched over the socket).
+    setDefaultModel(m).catch(() => {});
   };
 
   const startNewSession = (forAgent?: string) => {


### PR DESCRIPTION
### The problem

Picking a model in the composer only rebinds the **live** session. `changeModel` sends `set_model` over the socket, the server applies it to that session's engine and persists it on the session record — but nothing touches the global default.

So `manager.get_engine()` on a brand-new session takes the `else` branch:

```python
if record:
    model, mode, messages = record.model, ...   # resume → the session's own model
else:
    model, mode, messages = self.model, ...     # new → the global default
```

…and `self.model` is still whatever `set_provider()` stamped when the provider key was saved (its descriptor's `recommended_model`). Anyone running a model other than that one — most obviously a custom id typed into Settings ▸ Models ▸ "Add another model…" — had to re-pick it on every single new conversation.

### The change

An explicit pick in the composer now also writes the default (`POST /v1/settings/default-model`), so new sessions inherit it.

- **Resuming is unchanged** — the server replays that session's own model from its record.
- The write is **fire-and-forget**: the picker must not block on a round trip, and a failure costs only the stickiness (the live session already switched over the socket).
- Deliberately client-side, at the explicit-pick call site, rather than in the server's `_apply_model`. That handler also runs for the model riding every `user_message`, so making *it* sticky would mean typing into a resumed old session silently re-flips your default.

### Tests

`e2e/model-sticky.spec.ts`: pick a model → New session → reload, and the pick survives both. Verified it fails on the "New session" assertion without the `App.tsx` change.

The e2e mock gained per-test default-model state — `/v1/health` and `/v1/settings` report it and a fresh session's `ready` frame binds it, mirroring `manager.model` — so the spec exercises the real round trip instead of leftover component state.

Full GUI e2e suite: 154 passed, plus the one pre-existing `nav-collapse` ⌘B failure that also fails on a clean `main` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)