### PR TITLE
Fix flaky curated-models test (Ollama liveness probe)

### DIFF
--- a/tests/test_provider_router.py
+++ b/tests/test_provider_router.py
@@ -322,6 +322,11 @@ def test_manager_curated_models(tmp_path, monkeypatch):
             monkeypatch.delenv(d.env_key, raising=False)
     from coworker.server.manager import SessionManager
 
+    # Ollama selectability rides a live localhost probe (_ollama_alive); pin it so the
+    # picker is deterministic in CI (no Ollama) as well as on dev machines that happen
+    # to run one. This test is about matrix/custom filtering, not local liveness.
+    monkeypatch.setattr(SessionManager, "_ollama_alive", lambda self: True)
+
     mgr = SessionManager(data_dir=tmp_path)
     # no provider keys → nothing but the always-selectable default
     assert mgr.get_settings()["models"] == [mgr.model]


### PR DESCRIPTION
`test_manager_curated_models` asserts a custom `ollama:` model becomes selectable, but selectability runs through a live `localhost:11434` liveness probe (`_ollama_alive`), so the test only passed on machines where an Ollama happened to be answering and has been red in CI since the liveness gating landed. This mocks the probe in the test so it's deterministic everywhere; no product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)