### PR TITLE
Peel inline <think> tags out of content for MiniMax M2 and R1-style models

### DIFF
--- a/coworker/providers/base.py
+++ b/coworker/providers/base.py
@@ -55,6 +55,11 @@ class ModelCapabilities:
     pdf: bool = False
     parallel_tool_calls: bool = True
     streaming: bool = True
+    # DeepSeek-R1-style: reasoning arrives inline in `content` wrapped in
+    # `<think>...</think>` instead of a separate `reasoning_content` field. MiniMax M2/M2.5,
+    # DeepSeek R1, and most Ollama-hosted thinking models do this. When True, the OpenAI
+    # provider peels the tags out and routes the inner text to the `reasoning` sidecar.
+    inline_think_tags: bool = False
 
 
 @dataclass

--- a/coworker/providers/capabilities.py
+++ b/coworker/providers/capabilities.py
@@ -8,6 +8,24 @@ from __future__ import annotations
 
 from .base import ModelCapabilities
 
+# Model families that stream reasoning inline as `<think>...</think>` inside `content`
+# instead of a separate `reasoning_content`/`reasoning` field (DeepSeek-R1 convention).
+# Matched by prefix against the normalized (lowercase, `.`/`_` -> `-`) bare model name,
+# so `MiniMax-M2.5` -> `minimax-m2-5` still hits `minimax-m2`. Kept narrow: only families
+# we've verified against a live endpoint or the vendor's own docs.
+_INLINE_THINK_PREFIXES = (
+    "minimax-m2",  # MiniMax M2 / M2.5 / M2.5-highspeed (verified 2026-07-24)
+    "minimax-m3",  # MiniMax's next-gen reasoner (docs say same convention)
+    "deepseek-r",  # DeepSeek R1 / R1-Distill; v3+ chat uses reasoning_content instead
+    "qwen3-thinking",  # local Qwen3 thinking variant (Ollama, vLLM)
+    "qwq",  # Qwen QwQ reasoner
+)
+
+
+def _uses_inline_think_tags(name: str) -> bool:
+    n = name.lower().replace(".", "-").replace("_", "-")
+    return any(n.startswith(p) for p in _INLINE_THINK_PREFIXES)
+
 
 def capabilities_for(model: str) -> ModelCapabilities:
     # Curated models answer from the matrix (exact full-id match — including reseller ids
@@ -26,7 +44,11 @@ def capabilities_for(model: str) -> ModelCapabilities:
     # tools work (we only point at tool-capable models) but stay conservative otherwise.
     if provider == "ollama":
         return ModelCapabilities(
-            tools=True, vision=False, parallel_tool_calls=False, streaming=True
+            tools=True,
+            vision=False,
+            parallel_tool_calls=False,
+            streaming=True,
+            inline_think_tags=_uses_inline_think_tags(name),
         )
 
     # Claude / Gemini (both native): tools + vision + parallel tool calls + streaming. The
@@ -56,7 +78,11 @@ def capabilities_for(model: str) -> ModelCapabilities:
         ("deepseek", "glm", "kimi", "minimax", "qwen", "grok", "mistral", "magistral")
     ):
         return ModelCapabilities(
-            tools=True, vision=False, parallel_tool_calls=True, streaming=True
+            tools=True,
+            vision=False,
+            parallel_tool_calls=True,
+            streaming=True,
+            inline_think_tags=_uses_inline_think_tags(name),
         )
 
     # Conservative default for unknown models.

--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -25,6 +25,16 @@ from .base import ModelCapabilities
 _AGENTIC = ModelCapabilities(
     tools=True, vision=False, parallel_tool_calls=True, streaming=True
 )
+# Same as _AGENTIC but flags the DeepSeek-R1-style inline reasoning convention: content
+# arrives with `<think>...</think>` wrapping the thinking text instead of a separate
+# `reasoning_content` field (see providers/base.py:ModelCapabilities.inline_think_tags).
+_AGENTIC_INLINE_THINK = ModelCapabilities(
+    tools=True,
+    vision=False,
+    parallel_tool_calls=True,
+    streaming=True,
+    inline_think_tags=True,
+)
 # The native three (OpenAI, Anthropic, Gemini) all take PDFs directly; every
 # OpenAI-compatible vendor and reseller in the matrix does not (their chat APIs have
 # no inline file part — checked 2026-07-17), so those fall back via pdf_support.py.
@@ -75,7 +85,7 @@ MATRIX: dict[str, ModelEntry] = {
     "deepseek:deepseek-v4-flash": ModelEntry("DeepSeek V4 Flash · DeepSeek"),
     "deepseek:deepseek-v4-pro": ModelEntry("DeepSeek V4 Pro · DeepSeek"),
     "kimi:kimi-k2.6": ModelEntry("Kimi K2.6 · Moonshot"),
-    "minimax:MiniMax-M2.5": ModelEntry("MiniMax M2.5 · MiniMax"),
+    "minimax:MiniMax-M2.5": ModelEntry("MiniMax M2.5 · MiniMax", _AGENTIC_INLINE_THINK),
     "qwen:qwen3-max": ModelEntry("Qwen3 Max · Alibaba"),
     "xai:grok-4.3": ModelEntry("Grok 4.3 · xAI"),
     "mistral:mistral-large-latest": ModelEntry("Mistral Large · Mistral"),

--- a/coworker/providers/openai_provider.py
+++ b/coworker/providers/openai_provider.py
@@ -59,6 +59,86 @@ def _delta_reasoning(obj: Any) -> Optional[str]:
     return value if isinstance(value, str) and value else None
 
 
+# DeepSeek-R1-style reasoning delivery: some vendors (MiniMax M2/M2.5, DeepSeek R1,
+# local Qwen thinking variants) leave `reasoning_content` empty and instead wrap the
+# thinking inside the normal `content` string as `<think>...</think>`. The stripper
+# pulls those blocks out so text/reasoning route to the right places the UI expects.
+# Gated per-model on ModelCapabilities.inline_think_tags so ordinary responses (where
+# a user might legitimately be discussing `<think>` in their own text) are untouched.
+_THINK_OPEN = "<think>"
+_THINK_CLOSE = "</think>"
+
+
+class _ThinkTagStripper:
+    """Streaming state machine that splits an inline-`<think>` content stream into
+    (text, reasoning) pieces. Buffers across chunks so a marker split like `<thi` + `nk>`
+    still resolves. Handles multiple think blocks and an unterminated tail (treated as
+    reasoning on flush, since the model was mid-thought when the stream ended)."""
+
+    def __init__(self) -> None:
+        self._buf = ""
+        self._in_think = False
+
+    def feed(self, delta: str) -> tuple[str, str]:
+        """Push a content delta; return `(text, reasoning)` ready to yield. Either can be
+        empty; both empty means the whole delta is being held pending marker resolution."""
+        self._buf += delta
+        text_parts: list[str] = []
+        reason_parts: list[str] = []
+        while self._buf:
+            marker = _THINK_CLOSE if self._in_think else _THINK_OPEN
+            idx = self._buf.find(marker)
+            if idx >= 0:
+                if self._in_think:
+                    reason_parts.append(self._buf[:idx])
+                else:
+                    text_parts.append(self._buf[:idx])
+                self._buf = self._buf[idx + len(marker) :]
+                self._in_think = not self._in_think
+                continue
+            # No full marker in view. Emit everything except the last (len(marker)-1) chars,
+            # which might be the start of a marker completed by the next chunk.
+            safe_upto = len(self._buf) - (len(marker) - 1)
+            if safe_upto > 0:
+                chunk = self._buf[:safe_upto]
+                (reason_parts if self._in_think else text_parts).append(chunk)
+                self._buf = self._buf[safe_upto:]
+            break
+        return "".join(text_parts), "".join(reason_parts)
+
+    def flush(self) -> tuple[str, str]:
+        """End-of-stream: release any held bytes. If we're still inside a `<think>` block
+        the stream ended mid-thought; surface the tail as reasoning rather than text."""
+        if not self._buf:
+            return "", ""
+        remaining, self._buf = self._buf, ""
+        return ("", remaining) if self._in_think else (remaining, "")
+
+
+def _extract_think_blocks(content: str) -> tuple[str, Optional[str]]:
+    """Non-streaming counterpart: pull every `<think>...</think>` block out of `content`
+    and return `(visible_text, joined_reasoning_or_None)`. An unterminated `<think>` at
+    the tail is treated as reasoning too, mirroring the streaming flush behavior."""
+    if _THINK_OPEN not in content:
+        return content, None
+    reasoning: list[str] = []
+
+    def take(m):
+        reasoning.append(m.group(1))
+        return ""
+
+    text = re.sub(
+        r"<think>(.*?)</think>\s*", take, content, flags=re.DOTALL
+    )
+    # Handle a trailing, unterminated <think>: DOTALL regex above missed it by design.
+    tail_open = text.find(_THINK_OPEN)
+    if tail_open >= 0:
+        reasoning.append(text[tail_open + len(_THINK_OPEN) :])
+        text = text[:tail_open]
+    joined = "\n".join(r for r in reasoning if r) or None
+    return text, joined
+
+
 def _strip_foreign_sidecars(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Drop provider-private message sidecars (underscore-prefixed keys, e.g. `_gemini`
     thought signatures — see providers/base.py): they belong to other providers, and the
@@ -168,12 +248,22 @@ class OpenAIProvider(ProviderClient):
         text = getattr(message, "content", None)
         tool_calls = _parse_tool_calls(getattr(message, "tool_calls", None))
         text, tool_calls = _maybe_salvage_tool_calls(text, tool_calls, tools=tools)
+        reasoning = _delta_reasoning(message)
+        # Inline-<think> vendors (MiniMax M2, DeepSeek R1, some Ollama models) put the
+        # thinking inside `content` instead of a separate field. Peel it out so it lands
+        # on the same `reasoning` sidecar the UI already knows how to render.
+        if (
+            reasoning is None
+            and text
+            and capabilities_for(model).inline_think_tags
+        ):
+            text, reasoning = _extract_think_blocks(text)
         return AssistantTurn(
             text=text,
             tool_calls=tool_calls,
             finish_reason=getattr(choice, "finish_reason", None),
             raw=response,
-            reasoning=_delta_reasoning(message),
+            reasoning=reasoning,
         )
 
     def capabilities(self, model: str) -> ModelCapabilities:
@@ -202,6 +292,12 @@ class OpenAIProvider(ProviderClient):
         reasoning_parts: list[str] = []
         tool_accum: dict[int, dict[str, str]] = {}
         finish_reason = None
+        # Same inline-<think> handling as the non-streaming path, in state-machine form so
+        # a marker split across chunks still resolves. Instantiated only when the model
+        # actually uses this convention; otherwise content passes through untouched.
+        think_stripper = (
+            _ThinkTagStripper() if capabilities_for(model).inline_think_tags else None
+        )
 
         # Up to two param-fix retries: effort and max_tokens can BOTH need fixing.
         for _ in range(2):
@@ -225,8 +321,17 @@ class OpenAIProvider(ProviderClient):
                     yield StreamChunk(reasoning_delta=reasoning)
                 content = getattr(delta, "content", None)
                 if content:
-                    text_parts.append(content)
-                    yield StreamChunk(text_delta=content)
+                    if think_stripper is not None:
+                        text_out, reason_out = think_stripper.feed(content)
+                        if reason_out:
+                            reasoning_parts.append(reason_out)
+                            yield StreamChunk(reasoning_delta=reason_out)
+                        if text_out:
+                            text_parts.append(text_out)
+                            yield StreamChunk(text_delta=text_out)
+                    else:
+                        text_parts.append(content)
+                        yield StreamChunk(text_delta=content)
                 for tc in getattr(delta, "tool_calls", None) or []:
                     acc = tool_accum.setdefault(
                         getattr(tc, "index", 0), {"id": "", "name": "", "args": ""}
@@ -241,6 +346,17 @@ class OpenAIProvider(ProviderClient):
                             acc["args"] += fn.arguments
             if getattr(choice, "finish_reason", None):
                 finish_reason = choice.finish_reason
+
+        # Release any bytes still held by the stripper (a marker that never completed,
+        # or the tail after the last </think>).
+        if think_stripper is not None:
+            text_out, reason_out = think_stripper.flush()
+            if reason_out:
+                reasoning_parts.append(reason_out)
+                yield StreamChunk(reasoning_delta=reason_out)
+            if text_out:
+                text_parts.append(text_out)
+                yield StreamChunk(text_delta=text_out)
 
         tool_calls = []
         for index in sorted(tool_accum):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -454,3 +454,141 @@ def test_complete_picks_up_reasoning_content():
     provider = OpenAIProvider(client=_FakeClient(SimpleNamespace(choices=[choice])))
     turn = provider.complete(model="deepseek-v4-pro", messages=[{"role": "user", "content": "x"}])
     assert turn.text == "Answer" and turn.reasoning == "deep thought"
+
+
+# -- inline <think> tag stripping (MiniMax M2/M2.5, DeepSeek R1, thinking Ollamas) ----
+# These models leave reasoning_content empty and instead put the thinking inside
+# `content` wrapped in `<think>...</think>`. Peel it out so it lands on the same
+# reasoning sidecar the UI renders as "Thought process".
+
+
+def test_think_stripper_single_chunk():
+    from coworker.providers.openai_provider import _ThinkTagStripper
+
+    s = _ThinkTagStripper()
+    text, reason = s.feed("<think>reasoning here</think>the reply")
+    tail_text, tail_reason = s.flush()
+    assert reason == "reasoning here"
+    assert (text + tail_text) == "the reply"
+    assert tail_reason == ""
+
+
+def test_think_stripper_split_across_chunks():
+    """Real-world case: the SSE frame boundary lands inside a marker."""
+    from coworker.providers.openai_provider import _ThinkTagStripper
+
+    s = _ThinkTagStripper()
+    outs = [s.feed(part) for part in ("<thi", "nk>hmm</thi", "nk>done")]
+    text = "".join(t for t, _ in outs)
+    reason = "".join(r for _, r in outs)
+    tail_text, _ = s.flush()
+    assert reason == "hmm"
+    assert (text + tail_text) == "done"
+
+
+def test_think_stripper_no_tag_passthrough():
+    """A stream that never uses <think> must arrive at the user byte-for-byte."""
+    from coworker.providers.openai_provider import _ThinkTagStripper
+
+    s = _ThinkTagStripper()
+    text_parts, reason_parts = [], []
+    for part in ("Hello ", "world", "!"):
+        t, r = s.feed(part)
+        text_parts.append(t)
+        reason_parts.append(r)
+    tail_text, tail_reason = s.flush()
+    assert "".join(text_parts) + tail_text == "Hello world!"
+    assert "".join(reason_parts) + tail_reason == ""
+
+
+def test_think_stripper_unterminated_tail_becomes_reasoning():
+    from coworker.providers.openai_provider import _ThinkTagStripper
+
+    s = _ThinkTagStripper()
+    text, reason = s.feed("visible <think>still thinking when the stream died")
+    tail_text, tail_reason = s.flush()
+    assert text == "visible " and tail_text == ""
+    assert reason + tail_reason == "still thinking when the stream died"
+
+
+def test_extract_think_blocks_non_streaming():
+    from coworker.providers.openai_provider import _extract_think_blocks
+
+    text, reason = _extract_think_blocks("<think>a</think>hello <think>b</think>world")
+    assert text == "hello world"
+    assert reason == "a\nb"
+
+    text2, reason2 = _extract_think_blocks("no tags here")
+    assert text2 == "no tags here" and reason2 is None
+
+
+def test_stream_strips_inline_think_for_flagged_model():
+    """MiniMax M2.5 wire format: <think>...</think> arrives inside content, empty
+    reasoning_content. The stripper routes it to reasoning_delta so the UI shows it
+    as 'Thought process' instead of inline text."""
+    chunks = [
+        _chunk(content="<think>musing"),
+        _chunk(content=" more</think>Hi "),
+        _chunk(content="there!"),
+        _chunk(finish="stop"),
+    ]
+    provider = OpenAIProvider(client=_StreamClient(chunks))
+    out = list(provider.stream(model="MiniMax-M2.5", messages=[]))
+    reasoning = "".join(c.reasoning_delta for c in out if c.reasoning_delta)
+    text = "".join(c.text_delta for c in out if c.text_delta)
+    assert reasoning == "musing more"
+    assert text == "Hi there!"
+    final = out[-1].turn
+    assert final.text == "Hi there!" and final.reasoning == "musing more"
+
+
+def test_stream_does_not_strip_for_regular_models():
+    """Regression guard: on gpt-5.5 (and other non-flagged models), `<think>` in the
+    stream is preserved verbatim — a user could be asking about the tag in their code."""
+    chunks = [_chunk(content="use <think>x</think> tag"), _chunk(finish="stop")]
+    provider = OpenAIProvider(client=_StreamClient(chunks))
+    out = list(provider.stream(model="gpt-5.5", messages=[]))
+    text = "".join(c.text_delta for c in out if c.text_delta)
+    reasoning_deltas = [c.reasoning_delta for c in out if c.reasoning_delta]
+    assert text == "use <think>x</think> tag"
+    assert reasoning_deltas == []
+
+
+def test_complete_strips_inline_think_for_flagged_model():
+    message = SimpleNamespace(
+        content="<think>quick check</think>\n\nhi",
+        tool_calls=None,
+        reasoning_content=None,
+    )
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    provider = OpenAIProvider(client=_FakeClient(SimpleNamespace(choices=[choice])))
+    turn = provider.complete(model="MiniMax-M2.5", messages=[{"role": "user", "content": "hi"}])
+    assert turn.text == "hi"
+    assert turn.reasoning == "quick check"
+
+
+def test_complete_leaves_think_text_alone_for_regular_models():
+    message = SimpleNamespace(
+        content="use <think>x</think> in code",
+        tool_calls=None,
+        reasoning_content=None,
+    )
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    provider = OpenAIProvider(client=_FakeClient(SimpleNamespace(choices=[choice])))
+    turn = provider.complete(model="gpt-5.5", messages=[{"role": "user", "content": "hi"}])
+    assert turn.text == "use <think>x</think> in code"
+    assert turn.reasoning is None
+
+
+def test_capability_flag_for_known_inline_think_models():
+    """The capability probe must recognize MiniMax M2/M2.5, DeepSeek R1, and Ollama's
+    thinking variants so the stripper actually kicks in for them — and stay OFF for
+    the sibling models that use reasoning_content (regression guard)."""
+    assert capabilities_for("minimax:MiniMax-M2.5").inline_think_tags is True
+    assert capabilities_for("MiniMax-M2.5").inline_think_tags is True  # bare id path
+    assert capabilities_for("deepseek-r1").inline_think_tags is True
+    assert capabilities_for("ollama:qwen3-thinking:14b").inline_think_tags is True
+    # not this convention:
+    assert capabilities_for("deepseek:deepseek-v4-pro").inline_think_tags is False
+    assert capabilities_for("zai:glm-5.2").inline_think_tags is False
+    assert capabilities_for("gpt-5.5").inline_think_tags is False


### PR DESCRIPTION
Closes #111

MiniMax M2/M2.5 (and DeepSeek R1, Ollama thinking models) put their reasoning inline in `content` as `<think>...</think>` instead of the separate `reasoning_content` field the rest of the compat vendors use. Adds a small stripper in `openai_provider.py` that pulls those blocks out and routes them to `reasoning_delta`, so the UI's "Thought process" disclosure works the same way it already does for GLM/DeepSeek/Kimi.

Gated behind a new `ModelCapabilities.inline_think_tags` flag matched by a narrow prefix list (`minimax-m2`, `minimax-m3`, `deepseek-r`, `qwen3-thinking`, `qwq`), so a plain `gpt-5.5` reply that mentions `<think>` in user code is left alone.

## Before

<img width="853" height="758" alt="minimax-bug" src="https://github.com/user-attachments/assets/28909d3b-11ba-4872-a311-27d56c7be488" />

## After (MiniMax M2.5, same prompt, on this branch)

<img width="853" height="452" alt="after-fix-minimax" src="https://github.com/user-attachments/assets/a190fa2c-7fa4-449b-92fa-734cce9e8221" />

## Tests

10 new tests in `test_providers.py` covering the stripper (single-chunk, split marker across chunks, no-tag passthrough, unterminated tail), the non-streaming path, and a regression guard that `gpt-5.5` still streams literal `<think>` untouched. `pytest tests` = 869 pass, 1 skipped; the 7 pre-existing failures on `main` (Slack timeouts, Windows ripgrep, github_installs, ui refresh e2e) are unchanged.

Live-verified on MiniMax M2.5 (streaming + non-streaming) and re-tested on GLM Coding Plan to confirm the existing `reasoning_content` path is untouched.
