### PR TITLE
Show a connection error when Settings cannot load

### DIFF
--- a/surfaces/gui/e2e/settings.spec.ts
+++ b/surfaces/gui/e2e/settings.spec.ts
@@ -26,6 +26,19 @@ test("Settings opens as a full page and navigates sections", async ({ page }) =>
   await expect(page.getByTestId("set-provider-openai")).toBeVisible();
 });
 
+test("Models explains when the agent server cannot be reached", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("account-row").click();
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+
+  await page.route("**/v1/settings", (route) => route.abort("failed"));
+  await page.getByRole("button", { name: "Models", exact: true }).click();
+
+  await expect(page.getByText("Couldn't reach the agent server")).toBeVisible();
+  await expect(page.getByText("Make sure OpenWorker is running, then try again.")).toBeVisible();
+  await expect(page.getByTestId("settings-retry")).toBeVisible();
+});
+
 // The launch flag brings the Personas tab back (the gallery/persona suites rely on it).
 test("Settings: Personas tab returns behind the launch flag", async ({ page }) => {
   await page.addInitScript(() => localStorage.setItem("ocw.flag.personas", "1"));

--- a/surfaces/gui/src/components/ManageTabs.tsx
+++ b/surfaces/gui/src/components/ManageTabs.tsx
@@ -77,11 +77,34 @@ const EXAMPLE = `{
 // per-provider ModelChecklist / read-only model preview (form view).
 export function ModelsTab() {
   const [settings, setSettings] = useState<ModelSettings | null>(null);
-  const refreshSettings = () => getSettings().then(setSettings).catch(() => setSettings(null));
+  const [settingsError, setSettingsError] = useState(false);
+  const refreshSettings = () => {
+    setSettingsError(false);
+    getSettings()
+      .then(setSettings)
+      .catch(() => {
+        setSettings(null);
+        setSettingsError(true);
+      });
+  };
   const ps = useProviderSetup({ onSaved: refreshSettings });
   useEffect(() => {
     refreshSettings();
   }, []);
+
+  if (settingsError) {
+    return (
+      <div className="text-[13px] text-muted space-y-3">
+        <div>
+          <p className="text-ink font-medium">Couldn&apos;t reach the agent server</p>
+          <p className="mt-1">Make sure OpenWorker is running, then try again.</p>
+        </div>
+        <button className={BTN_BORDERED} onClick={refreshSettings} data-testid="settings-retry">
+          Retry
+        </button>
+      </div>
+    );
+  }
 
   if (!settings) return <div className="text-[13px] text-muted">Loading…</div>;
 


### PR DESCRIPTION
Fixes #43

The Models tab used the same empty state for both its initial request and a failed request to `/v1/settings`. When the agent server was unavailable, that left the tab showing “Loading…” indefinitely.

This shows a clear connection message instead, with a Retry button for when the server is available again. The browser test covers the failed-request path.

Checks:
- `npx playwright test e2e/settings.spec.ts`
- `npm run build`
- `npm test`