### PR TITLE
feat: add browser and desktop voice discussion mode

### DIFF
--- a/coworker/engine.py
+++ b/coworker/engine.py
@@ -44,6 +44,12 @@ class PermissionRequest:
 
 Approver = Callable[[PermissionRequest], Awaitable[ApprovalOutcome]]
 
+_VOICE_DISCUSSION_CONTEXT = """This is a voice discussion turn.
+Treat unusual or ambiguous wording as a possible transcription error or homophone and use the
+conversation and workspace context to interpret it. Ask one brief clarification before a
+consequential action when ambiguity remains. Respond concisely and conversationally, and briefly
+narrate tool use so the user can follow along without watching the screen."""
+
 
 async def _deny_all(_request: PermissionRequest) -> ApprovalOutcome:
     return ApprovalOutcome.DENY
@@ -154,7 +160,11 @@ class TurnEngine:
 
     # -- main loop --------------------------------------------------------------
     async def run(
-        self, user_input: "str | list", *, source: Optional[dict[str, Any]] = None
+        self,
+        user_input: "str | list",
+        *,
+        source: Optional[dict[str, Any]] = None,
+        input_mode: Optional[str] = None,
     ) -> AsyncIterator[Event]:
         # `user_input` is a string, or OpenAI content-parts (text + image_url) for attachments.
         # `source` (a MessageSource dict) is a display-only sidecar for connector messages: it
@@ -168,11 +178,15 @@ class TurnEngine:
         }
         if source is not None:
             message["source"] = source
+        if input_mode == "voice_discussion":
+            message["input_mode"] = input_mode
         self.messages.append(message)
         self._cancel.clear()
         data: dict[str, Any] = {"input": user_input}
         if source is not None:
             data["source"] = source
+        if input_mode == "voice_discussion":
+            data["input_mode"] = input_mode
         yield Event(EventType.TURN_START, data)
         async for event in self._loop():
             yield event
@@ -878,18 +892,19 @@ class TurnEngine:
     def _outbound_messages(self) -> list[dict[str, Any]]:
         """`self.messages` prepared for the provider. The SOLE provider feed (see `_astream`).
 
-        Every message is stripped of the display-only sidecars — `source`, `_display`, and
-        `ts` — (providers reject unknown keys), unconditionally — whether or not a
+        Every message is stripped of the display-only sidecars — `source`, `_display`, `ts`, and
+        `input_mode` — (providers reject unknown keys), unconditionally — whether or not a
         `<system-context>` block is added. When a context
         provider yields a non-empty string, an ephemeral `<system-context>` block is appended to the
         last user message. Never mutates `self.messages`, so neither the strip nor the block is
         persisted/replayed.
         """
         # Strip the display-only sidecars — `source` (connector cards), `_display`
-        # (e.g. filter-hidden counts), `ts` (append-time timestamps), and `reasoning`
-        # (thinking text) — copying only messages that carry one. Whole `notice` messages
+        # (e.g. filter-hidden counts), `ts` (append-time timestamps), `reasoning`
+        # (thinking text), and trusted `input_mode` — copying only messages that carry one.
+        # Whole `notice` messages
         # (error/interrupted/model-switch markers) are display-only too: dropped entirely.
-        _SIDECARS = ("source", "_display", "ts", "reasoning")
+        _SIDECARS = ("source", "_display", "ts", "reasoning", "input_mode")
         out = [
             (
                 {k: v for k, v in msg.items() if k not in _SIDECARS}
@@ -963,6 +978,17 @@ class TurnEngine:
         context = (
             self.context_provider() if self.context_provider is not None else ""
         ) or ""
+        # The voice flag is trusted server metadata. It is persisted beside the user's visible
+        # text, then converted here into ephemeral provider guidance. This keeps prompt-like
+        # control text out of the transcript while applying it to every iteration of this turn.
+        voice_context = ""
+        for message in reversed(self.messages):
+            if message.get("role") != "user":
+                continue
+            if message.get("input_mode") == "voice_discussion":
+                voice_context = _VOICE_DISCUSSION_CONTEXT
+            break
+        context = "\n\n".join(part for part in (context, voice_context) if part)
         if not context:
             return out
         block = f"\n\n<system-context>\n{context}\n</system-context>"

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -1697,11 +1697,17 @@ def create_app(manager: SessionManager) -> FastAPI:
             "iteration_end",
         }
 
-        async def run_turn(content, *, retry: bool = False) -> None:
+        async def run_turn(
+            content, *, retry: bool = False, input_mode: Optional[str] = None
+        ) -> None:
             # The receive loop atomically claims this session before scheduling the task.
             # Keeping the claim outside prevents two back-to-back frames from both starting.
             try:
-                events = engine.retry() if retry else engine.run(content)
+                events = (
+                    engine.retry()
+                    if retry
+                    else engine.run(content, input_mode=input_mode)
+                )
                 async for event in events:
                     # Broadcast to every socket viewing this session (this socket included — it's a
                     # registered client), so a second view of the same session stays in sync too.
@@ -1727,13 +1733,17 @@ def create_app(manager: SessionManager) -> FastAPI:
             # or flush an in-progress assistant stream in the GUI.
             await ws.send_json({"type": "input_rejected", "data": {"error": reason}})
 
-        async def claim_turn(*, retry: bool = False, content=None) -> None:
+        async def claim_turn(
+            *, retry: bool = False, content=None, input_mode: Optional[str] = None
+        ) -> None:
             if not manager.try_mark_running(session_id):
                 await reject_input(
                     "This session is already running a turn. Wait for it to finish or stop it."
                 )
                 return
-            asyncio.create_task(run_turn(content, retry=retry))
+            asyncio.create_task(
+                run_turn(content, retry=retry, input_mode=input_mode)
+            )
 
         try:
             while True:
@@ -1886,10 +1896,16 @@ def create_app(manager: SessionManager) -> FastAPI:
                     if model is not None and not isinstance(model, str):
                         await reject_input("Invalid model: expected a string.")
                         continue
+                    input_mode = message.get("input_mode")
+                    if input_mode not in {None, "voice_discussion"}:
+                        await reject_input(
+                            "Invalid input mode: expected voice_discussion."
+                        )
+                        continue
                     await _apply_model(model)
                     if text or attachments:
                         content = build_user_content(text, attachments)
-                        await claim_turn(content=content)
+                        await claim_turn(content=content, input_mode=input_mode)
                 else:
                     await reject_input(f"Unknown WebSocket message type: {kind}.")
         except WebSocketDisconnect:

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -28,7 +28,15 @@ import {
   type SurfaceVisibility,
   type WorkspaceCommandTrust,
 } from "./api";
-import type { ApprovalDecision, Attachment, Item, SessionInfo, TodoItem, WsEvent } from "./types";
+import type {
+  ApprovalDecision,
+  Attachment,
+  Item,
+  SessionInfo,
+  TodoItem,
+  UserMessageMeta,
+  WsEvent,
+} from "./types";
 import { isProjectScoped } from "./personaScope";
 import { baseName } from "./paths";
 import { itemsFromMessages } from "./itemsFromMessages";
@@ -587,7 +595,15 @@ export function App() {
               const last = p[p.length - 1];
               return last && last.kind === "user" && last.text === d.input
                 ? p
-                : [...p, { kind: "user", text: d.input as string, ts: Date.now() / 1000 }];
+                : [
+                    ...p,
+                    {
+                      kind: "user",
+                      text: d.input as string,
+                      ts: Date.now() / 1000,
+                      ...(d.input_mode === "voice_discussion" ? { inputMode: d.input_mode } : {}),
+                    },
+                  ];
             });
           }
           break;
@@ -822,10 +838,19 @@ export function App() {
     return () => clearInterval(t);
   }, [surface, sessionId, browserRefreshKey, markUnattended]);
 
-  const send = (text: string, attachments?: Attachment[]) => {
-    setItems((p) => [...p, { kind: "user", text, attachments, ts: Date.now() / 1000 }]);
+  const send = (text: string, attachments?: Attachment[], meta?: UserMessageMeta) => {
+    setItems((p) => [
+      ...p,
+      {
+        kind: "user",
+        text,
+        attachments,
+        ts: Date.now() / 1000,
+        ...(meta?.inputMode ? { inputMode: meta.inputMode } : {}),
+      },
+    ]);
     // The visible model rides along with the message (single source of truth per turn).
-    sessionRef.current?.userMessage(text, attachments, model);
+    sessionRef.current?.userMessage(text, attachments, model, meta?.inputMode);
     followLatest(); // sending always re-engages stream-following, wherever the user had scrolled
   };
   // Resolving a LIVE prompt also resolves its parked Inbox mirror server-side, but the polled

--- a/surfaces/gui/src/api.auth.test.ts
+++ b/surfaces/gui/src/api.auth.test.ts
@@ -35,4 +35,16 @@ it("authenticates REST and session WebSocket calls with the launch token", async
   const session = new Session("s1", "/workspace", "code", { onEvent: vi.fn() });
   const socket = (session as unknown as { ws: FakeWebSocket }).ws;
   expect(socket.protocols).toEqual(["openworker", "launch-token"]);
+
+  session.userMessage("hello", undefined, "gpt-5.6-sol", "voice_discussion");
+  socket.readyState = FakeWebSocket.OPEN;
+  socket.onopen?.();
+  expect(socket.send).toHaveBeenCalledWith(
+    JSON.stringify({
+      type: "user_message",
+      text: "hello",
+      model: "gpt-5.6-sol",
+      input_mode: "voice_discussion",
+    }),
+  );
 });

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -1,4 +1,4 @@
-import type { SessionInfo, WsEvent } from "./types";
+import type { SessionInfo, UserInputMode, WsEvent } from "./types";
 
 declare const __COWORKER_DEV_TOKEN__: string;
 
@@ -1766,12 +1766,13 @@ export class Session {
    * exactly what the user sees — immune to set_model races across reconnects (a new cowork
    * session always reconnects once to adopt its scratch dir, which could drop a queued
    * set_model and leave the engine on a stale/resumed model; found 2026-07-04). */
-  userMessage(text: string, attachments?: unknown[], model?: string) {
+  userMessage(text: string, attachments?: unknown[], model?: string, inputMode?: UserInputMode) {
     this.send({
       type: "user_message",
       text,
       ...(model ? { model } : {}),
       ...(attachments?.length ? { attachments } : {}),
+      ...(inputMode ? { input_mode: inputMode } : {}),
     });
   }
 

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -6,14 +6,15 @@ import { Dropdown, type Option } from "./Dropdown";
 import { Icon } from "./Icon";
 import { Toggle } from "./Toggle";
 import {
-  cancelDictation,
-  getDictationLevel,
-  getDictationStatus,
-  isTauri,
-  startDictation,
-  stopDictation,
-  type DictationStatus,
-} from "../tauri";
+  cancelVoiceCapture,
+  getVoiceLevel,
+  getVoiceRuntime,
+  getVoiceStatus,
+  startVoiceCapture,
+  stopVoiceCapture,
+  type VoiceRuntime,
+  type VoiceStatus,
+} from "../voice";
 
 // Plan + Custom hidden for this release (owner ask 2026-07-22): Plan's approval flow isn't
 // polished enough to ship, and Custom (config.toml auto-allow rules) is a power-user mode
@@ -29,7 +30,7 @@ type VoiceCaptureMode = "dictation" | "discussion";
 const VOICE_MODE_KEY = "openwork-voice-capture-mode";
 const getVoiceCaptureMode = (): VoiceCaptureMode => {
   try {
-    return localStorage.getItem(VOICE_MODE_KEY) === "discussion" ? "discussion" : "dictation";
+    return window.localStorage.getItem(VOICE_MODE_KEY) === "discussion" ? "discussion" : "dictation";
   } catch {
     return "dictation";
   }
@@ -96,7 +97,7 @@ export function Composer(props: Props) {
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [dragging, setDragging] = useState(false);
   const [attachMenuOpen, setAttachMenuOpen] = useState(false);
-  const [dictation, setDictation] = useState<DictationStatus | null>(null);
+  const [dictation, setDictation] = useState<VoiceStatus | null>(null);
   const [dictationBusy, setDictationBusy] = useState<string | null>(null);
   const [dictationError, setDictationError] = useState<string | null>(null);
   const [dictationNotice, setDictationNotice] = useState<string | null>(null);
@@ -112,7 +113,7 @@ export function Composer(props: Props) {
   const changeVoiceMode = (mode: VoiceCaptureMode) => {
     setVoiceMode(mode);
     try {
-      localStorage.setItem(VOICE_MODE_KEY, mode);
+      window.localStorage.setItem(VOICE_MODE_KEY, mode);
     } catch {
       /* per-device preference is best effort */
     }
@@ -166,17 +167,16 @@ export function Composer(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.resetKey]);
 
-  // Dictation is intentionally native-only: the browser/dev build remains a local server client
-  // and never turns on the browser microphone or ships audio anywhere.
+  // Keep one composer contract for the local Tauri recorder and the browser's speech-recognition
+  // service. The adapter owns runtime-specific permission, capture, and transcription behavior.
   useEffect(() => {
-    if (!isTauri()) return;
     const refresh = (event?: Event) => {
-      const supplied = (event as CustomEvent<DictationStatus> | undefined)?.detail;
+      const supplied = (event as CustomEvent<VoiceStatus> | undefined)?.detail;
       if (supplied) {
         setDictation(supplied);
         return;
       }
-      void getDictationStatus().then((status) => status && setDictation(status));
+      void getVoiceStatus().then((status) => status && setDictation(status));
     };
     refresh();
     window.addEventListener("coworker:voice-input-changed", refresh);
@@ -205,7 +205,7 @@ export function Composer(props: Props) {
       return;
     }
     const timer = window.setInterval(() => {
-      getDictationLevel().then((level) => {
+      getVoiceLevel().then((level) => {
         if (typeof level === "number") setLevels((cur) => [...cur.slice(-13), level]);
       });
     }, 100);
@@ -217,10 +217,10 @@ export function Composer(props: Props) {
     const cancelOnEscape = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       event.preventDefault();
-      void cancelDictation()
+      void cancelVoiceCapture()
         .catch(() => undefined)
         .finally(() => {
-          void getDictationStatus().then((status) => status && setDictation(status));
+          void getVoiceStatus().then((status) => status && setDictation(status));
         });
     };
     window.addEventListener("keydown", cancelOnEscape);
@@ -321,7 +321,7 @@ export function Composer(props: Props) {
   };
 
   const toggleDictation = async () => {
-    if (!isTauri() || dictationBusy) return;
+    if (dictationBusy) return;
     setDictationError(null);
     setDictationNotice(null);
     try {
@@ -330,7 +330,7 @@ export function Composer(props: Props) {
         const shouldAutoSend =
           completedMode === "discussion" && autoSendVoiceTurn.current;
         setDictationBusy("Transcribing…");
-        const transcript = await stopDictation();
+        const transcript = await stopVoiceCapture();
         if (transcript === null) throw new Error("Could not transcribe your recording.");
         if (transcript.trim()) {
           if (shouldAutoSend) {
@@ -346,15 +346,16 @@ export function Composer(props: Props) {
         } else if (completedMode === "discussion") {
           throw new Error("No speech was detected. Try again and speak for a little longer.");
         }
-        setDictation(await getDictationStatus());
+        setDictation(await getVoiceStatus());
         if (!shouldAutoSend) textareaRef.current?.focus();
         return;
       }
 
-      const status = dictation || (await getDictationStatus());
+      const status = dictation || (await getVoiceStatus());
       if (!status) throw new Error("Voice dictation is unavailable.");
       if (!status.supported || !status.model_verified || !status.test_passed) {
-        props.onConfigureVoiceInput?.();
+        if (getVoiceRuntime() === "native") props.onConfigureVoiceInput?.();
+        else throw new Error(status.compatibility_reason || "Voice input is unavailable in this browser.");
         return;
       }
       if (voiceMode === "discussion" && props.modelReady === false) {
@@ -366,14 +367,14 @@ export function Composer(props: Props) {
       activeVoiceMode.current = voiceMode;
       autoSendVoiceTurn.current =
         voiceMode === "discussion" && !text.trim() && attachments.length === 0;
-      const recording = await startDictation();
+      const recording = await startVoiceCapture();
       if (!recording?.recording) throw new Error("Could not start the microphone.");
       setDictation(recording);
     } catch (error) {
       autoSendVoiceTurn.current = false;
       setDictationNotice(null);
       setDictationError(error instanceof Error ? error.message : "Voice dictation is unavailable.");
-      const status = await getDictationStatus();
+      const status = await getVoiceStatus();
       if (status) setDictation(status);
     } finally {
       setDictationBusy(null);
@@ -395,8 +396,17 @@ export function Composer(props: Props) {
   // composer isn't carrying a constant blue dot.
   const hasContent = text.trim().length > 0 || attachments.length > 0;
   const activeVoiceModeName = voiceModeName(activeVoiceMode.current);
+  const voiceRuntime = getVoiceRuntime();
+  const voiceUnavailable = voiceRuntime === "browser" && !!dictation && !dictation.supported;
+  const voiceUnavailableReason =
+    dictation?.compatibility_reason || "Voice input is unavailable in this browser.";
+  const voiceSetupLabel =
+    voiceRuntime === "native"
+      ? "Configure Voice Input in Settings"
+      : "Voice input unavailable in this browser";
   const voiceActionDisabled =
     !!dictationBusy ||
+    voiceUnavailable ||
     (!dictation?.recording &&
       voiceMode === "discussion" &&
       (!props.connected || props.running));
@@ -571,7 +581,7 @@ export function Composer(props: Props) {
 
           {/* Voice split control: the primary action records in the selected mode; the quiet
               chevron keeps editable Dictation and auto-submit Voice discussion one click apart. */}
-          {isTauri() && (
+          {dictation && (
             <div className="relative flex items-center">
               <button
                 className={
@@ -590,8 +600,12 @@ export function Composer(props: Props) {
                     : voiceReady
                       ? voiceMode === "discussion"
                         ? "Start voice discussion. The transcript sends when you stop."
-                        : "Start local voice dictation"
-                      : "Configure Voice Input in Settings")
+                        : voiceRuntime === "native"
+                          ? "Start local voice dictation"
+                          : "Start browser voice dictation"
+                      : voiceRuntime === "browser"
+                        ? voiceUnavailableReason
+                        : voiceSetupLabel)
                 }
                 aria-label={
                   dictation?.recording
@@ -600,7 +614,7 @@ export function Composer(props: Props) {
                       ? voiceMode === "discussion"
                         ? "Start voice discussion"
                         : "Start dictation"
-                      : "Configure Voice Input in Settings"
+                      : voiceSetupLabel
                 }
                 aria-disabled={
                   (!voiceReady && !dictation?.recording) ||
@@ -613,7 +627,8 @@ export function Composer(props: Props) {
                 <VoiceModePicker
                   mode={voiceMode}
                   onChange={changeVoiceMode}
-                  disabled={!!dictationBusy}
+                  disabled={!!dictationBusy || !dictation.supported}
+                  runtime={voiceRuntime}
                 />
               )}
             </div>
@@ -661,10 +676,12 @@ function VoiceModePicker({
   mode,
   onChange,
   disabled,
+  runtime,
 }: {
   mode: VoiceCaptureMode;
   onChange: (mode: VoiceCaptureMode) => void;
   disabled: boolean;
+  runtime: VoiceRuntime;
 }) {
   const [open, setOpen] = useState(false);
   const choose = (next: VoiceCaptureMode) => {
@@ -705,7 +722,10 @@ function VoiceModePicker({
               onClick={() => choose("discussion")}
             />
             <div className="mx-2 mt-1 border-t border-line px-0 pt-2 pb-1 text-[10.5px] leading-snug text-faint">
-              Clicking or typing in the composer keeps a discussion turn as an editable draft.
+              Clicking or typing in the composer keeps a discussion turn as an editable draft.{" "}
+              {runtime === "browser"
+                ? "Transcription is managed by your browser."
+                : "Desktop transcription stays on this device."}
             </div>
           </div>
         </>

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -705,7 +705,7 @@ function VoiceModePicker({
         <>
           <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
           <div
-            className="absolute z-40 bottom-full mb-1 right-0 w-[280px] rounded-xl border border-line bg-panel shadow-2xl p-1.5"
+            className="voice-mode-menu absolute z-40 bottom-full mb-1.5 right-0 w-[304px] rounded-xl border border-lineStrong bg-panel p-2"
             role="menu"
             aria-label="Voice input mode"
           >
@@ -721,7 +721,7 @@ function VoiceModePicker({
               description="Send the transcript automatically when you stop speaking."
               onClick={() => choose("discussion")}
             />
-            <div className="mx-2 mt-1 border-t border-line px-0 pt-2 pb-1 text-[10.5px] leading-snug text-faint">
+            <div className="mx-2.5 mt-1.5 border-t border-line px-0 pt-2.5 pb-1.5 text-[10.5px] leading-[1.45] text-faint">
               Clicking or typing in the composer keeps a discussion turn as an editable draft.{" "}
               {runtime === "browser"
                 ? "Transcription is managed by your browser."
@@ -748,27 +748,27 @@ function VoiceModeOption({
   return (
     <button
       className={
-        "w-full rounded-lg px-2.5 py-2 text-left hover:bg-paper " +
-        (checked ? "bg-accentSoft/60" : "")
+        "voice-mode-option w-full rounded-[10px] px-3 py-2.5 text-left " +
+        (checked ? "is-selected" : "")
       }
       role="menuitemradio"
       aria-checked={checked}
       onClick={onClick}
     >
-      <span className="flex items-center gap-2">
+      <span className="flex items-start gap-3">
         <span
-          className={
-            "grid h-5 w-5 shrink-0 place-items-center rounded-full border " +
-            (checked ? "border-accent bg-accent text-white" : "border-lineStrong text-faint")
-          }
+          className="voice-mode-indicator mt-px grid h-6 w-6 shrink-0 place-items-center rounded-full border"
+          data-testid={checked ? "voice-mode-selected-indicator" : undefined}
         >
-          {checked ? "✓" : <Icon name="mic" size={11} />}
+          {checked ? <Icon name="check" size={14} /> : <Icon name="mic" size={12} />}
         </span>
-        <span>
-          <span className={"block text-[13px] " + (checked ? "font-medium text-accent" : "text-ink")}>
+        <span className="min-w-0">
+          <span className="voice-mode-label block text-[13.5px] leading-[1.25]">
             {label}
           </span>
-          <span className="mt-0.5 block text-[11px] leading-snug text-faint">{description}</span>
+          <span className="voice-mode-description mt-1 block text-[11.5px] leading-[1.4]">
+            {description}
+          </span>
         </span>
       </span>
     </button>

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -12,6 +12,7 @@ import {
   getVoiceStatus,
   startVoiceCapture,
   stopVoiceCapture,
+  VOICE_INPUT_ERROR_EVENT,
   type VoiceRuntime,
   type VoiceStatus,
 } from "../voice";
@@ -109,6 +110,23 @@ export function Composer(props: Props) {
   const noticeTimer = useRef<number | null>(null);
   const activeVoiceMode = useRef<VoiceCaptureMode>("dictation");
   const autoSendVoiceTurn = useRef(false);
+  const captureEpoch = useRef(0);
+  const captureOriginKey = useRef<string | undefined>(undefined);
+  const previousResetKey = useRef(props.resetKey);
+  const voiceSendContext = useRef({
+    connected: props.connected,
+    running: props.running,
+    modelReady: props.modelReady,
+    resetKey: props.resetKey,
+    onSend: props.onSend,
+  });
+  voiceSendContext.current = {
+    connected: props.connected,
+    running: props.running,
+    modelReady: props.modelReady,
+    resetKey: props.resetKey,
+    onSend: props.onSend,
+  };
 
   const changeVoiceMode = (mode: VoiceCaptureMode) => {
     setVoiceMode(mode);
@@ -160,10 +178,25 @@ export function Composer(props: Props) {
   }, [props.prefill?.nonce]);
 
   // Clear the draft when the conversation changes, so a half-typed message / picked file doesn't
-  // bleed from one session into another.
+  // bleed from one session into another. Invalidate and cancel any capture owned by the previous
+  // conversation so a late transcript can never cross session boundaries.
   useEffect(() => {
+    const conversationChanged = previousResetKey.current !== props.resetKey;
+    previousResetKey.current = props.resetKey;
     setText("");
     setAttachments([]);
+    setDictationNotice(null);
+    setDictationError(null);
+    if (conversationChanged) {
+      captureEpoch.current += 1;
+      captureOriginKey.current = undefined;
+      autoSendVoiceTurn.current = false;
+      setDictationBusy(null);
+      setDictation((current) =>
+        current?.recording ? { ...current, recording: false } : current,
+      );
+      void cancelVoiceCapture().catch(() => undefined);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.resetKey]);
 
@@ -179,8 +212,25 @@ export function Composer(props: Props) {
       void getVoiceStatus().then((status) => status && setDictation(status));
     };
     refresh();
+    const reportError = (event: Event) => {
+      const message = (event as CustomEvent<string>).detail;
+      captureEpoch.current += 1;
+      captureOriginKey.current = undefined;
+      autoSendVoiceTurn.current = false;
+      setDictationBusy(null);
+      setDictationNotice(null);
+      setDictationError(message || "Browser voice input stopped unexpectedly.");
+    };
     window.addEventListener("coworker:voice-input-changed", refresh);
-    return () => window.removeEventListener("coworker:voice-input-changed", refresh);
+    window.addEventListener(VOICE_INPUT_ERROR_EVENT, reportError);
+    return () => {
+      window.removeEventListener("coworker:voice-input-changed", refresh);
+      window.removeEventListener(VOICE_INPUT_ERROR_EVENT, reportError);
+      captureEpoch.current += 1;
+      captureOriginKey.current = undefined;
+      autoSendVoiceTurn.current = false;
+      void cancelVoiceCapture().catch(() => undefined);
+    };
   }, []);
 
   useEffect(() => {
@@ -322,6 +372,7 @@ export function Composer(props: Props) {
 
   const toggleDictation = async () => {
     if (dictationBusy) return;
+    let operationEpoch = captureEpoch.current;
     setDictationError(null);
     setDictationNotice(null);
     try {
@@ -329,12 +380,25 @@ export function Composer(props: Props) {
         const completedMode = activeVoiceMode.current;
         const shouldAutoSend =
           completedMode === "discussion" && autoSendVoiceTurn.current;
+        operationEpoch = captureEpoch.current;
         setDictationBusy("Transcribing…");
         const transcript = await stopVoiceCapture();
+        const latest = voiceSendContext.current;
+        const captureIsCurrent =
+          operationEpoch === captureEpoch.current &&
+          captureOriginKey.current === latest.resetKey;
+        if (!captureIsCurrent) return;
+        const canAutoSend =
+          shouldAutoSend &&
+          latest.connected &&
+          !latest.running &&
+          latest.modelReady !== false;
+        autoSendVoiceTurn.current = false;
+        captureOriginKey.current = undefined;
         if (transcript === null) throw new Error("Could not transcribe your recording.");
         if (transcript.trim()) {
-          if (shouldAutoSend) {
-            props.onSend(transcript.trim(), undefined, { inputMode: "voice_discussion" });
+          if (canAutoSend) {
+            latest.onSend(transcript.trim(), undefined, { inputMode: "voice_discussion" });
             setText("");
             setAttachments([]);
           } else {
@@ -346,8 +410,9 @@ export function Composer(props: Props) {
         } else if (completedMode === "discussion") {
           throw new Error("No speech was detected. Try again and speak for a little longer.");
         }
-        setDictation(await getVoiceStatus());
-        if (!shouldAutoSend) textareaRef.current?.focus();
+        const latestStatus = await getVoiceStatus();
+        if (operationEpoch === captureEpoch.current) setDictation(latestStatus);
+        if (!canAutoSend) textareaRef.current?.focus();
         return;
       }
 
@@ -364,20 +429,32 @@ export function Composer(props: Props) {
       }
       if (voiceMode === "discussion" && (!props.connected || props.running)) return;
       setDictationBusy("Starting microphone…");
+      operationEpoch = captureEpoch.current + 1;
+      captureEpoch.current = operationEpoch;
+      captureOriginKey.current = voiceSendContext.current.resetKey;
       activeVoiceMode.current = voiceMode;
       autoSendVoiceTurn.current =
         voiceMode === "discussion" && !text.trim() && attachments.length === 0;
       const recording = await startVoiceCapture();
+      if (
+        operationEpoch !== captureEpoch.current ||
+        captureOriginKey.current !== voiceSendContext.current.resetKey
+      ) {
+        await cancelVoiceCapture().catch(() => undefined);
+        return;
+      }
       if (!recording?.recording) throw new Error("Could not start the microphone.");
       setDictation(recording);
     } catch (error) {
+      if (operationEpoch !== captureEpoch.current) return;
       autoSendVoiceTurn.current = false;
+      captureOriginKey.current = undefined;
       setDictationNotice(null);
       setDictationError(error instanceof Error ? error.message : "Voice dictation is unavailable.");
       const status = await getVoiceStatus();
-      if (status) setDictation(status);
+      if (status && operationEpoch === captureEpoch.current) setDictation(status);
     } finally {
-      setDictationBusy(null);
+      if (operationEpoch === captureEpoch.current) setDictationBusy(null);
     }
   };
 

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
-import type { Attachment } from "../types";
+import type { Attachment, UserMessageMeta } from "../types";
 import { isPdfFile, readFile } from "../attach";
 import { getSettings, inspectPdf } from "../api";
 import { Dropdown, type Option } from "./Dropdown";
@@ -24,6 +24,18 @@ const PERMISSION_OPTIONS: Option[] = [
   { value: "interactive", label: "Ask for approval", description: "Ask before edits and commands" },
   { value: "auto", label: "Full access", description: "Run everything without asking" },
 ];
+
+type VoiceCaptureMode = "dictation" | "discussion";
+const VOICE_MODE_KEY = "openwork-voice-capture-mode";
+const getVoiceCaptureMode = (): VoiceCaptureMode => {
+  try {
+    return localStorage.getItem(VOICE_MODE_KEY) === "discussion" ? "discussion" : "dictation";
+  } catch {
+    return "dictation";
+  }
+};
+const voiceModeName = (mode: VoiceCaptureMode) =>
+  mode === "discussion" ? "Voice discussion" : "Dictation";
 
 // No hardcoded model fallback: until the server supplies the list (a few seconds after a
 // cold app boot), the picker renders a disabled "Loading models…" chip. A baked-in list
@@ -58,7 +70,7 @@ interface Props {
   modelReady?: boolean;
   onConnectModel?: () => void;
   onConfigureVoiceInput?: () => void;
-  onSend: (text: string, attachments?: Attachment[]) => void;
+  onSend: (text: string, attachments?: Attachment[], meta?: UserMessageMeta) => void;
   onInterrupt: () => void;
   onModeChange: (mode: string) => void;
   onModelChange: (model: string) => void;
@@ -87,11 +99,33 @@ export function Composer(props: Props) {
   const [dictation, setDictation] = useState<DictationStatus | null>(null);
   const [dictationBusy, setDictationBusy] = useState<string | null>(null);
   const [dictationError, setDictationError] = useState<string | null>(null);
+  const [dictationNotice, setDictationNotice] = useState<string | null>(null);
+  const [voiceMode, setVoiceMode] = useState<VoiceCaptureMode>(getVoiceCaptureMode);
   const [recordingSeconds, setRecordingSeconds] = useState(0);
   const [attachNotice, setAttachNotice] = useState<string | null>(null);
   const fileInput = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const noticeTimer = useRef<number | null>(null);
+  const activeVoiceMode = useRef<VoiceCaptureMode>("dictation");
+  const autoSendVoiceTurn = useRef(false);
+
+  const changeVoiceMode = (mode: VoiceCaptureMode) => {
+    setVoiceMode(mode);
+    try {
+      localStorage.setItem(VOICE_MODE_KEY, mode);
+    } catch {
+      /* per-device preference is best effort */
+    }
+  };
+
+  // Voice discussion is auto-submit by default. Touching the editable composer while recording
+  // is the deliberate escape hatch from issue #71: keep the transcript as a draft instead.
+  const keepVoiceTurnAsDraft = () => {
+    if (activeVoiceMode.current === "discussion" && autoSendVoiceTurn.current) {
+      autoSendVoiceTurn.current = false;
+      setDictationNotice("Auto-send cancelled. This voice turn will stay in the composer.");
+    }
+  };
 
   // Rejected-attachment notice: visible ~8s, then clears (or on ✕).
   const showAttachNotice = (message: string) => {
@@ -200,6 +234,7 @@ export function Composer(props: Props) {
   // size limit is REJECTED with a visible notice — never attached, never silently dropped.
   // The rationale is token cost: a big PDF re-rides every turn of the conversation.
   const addFiles = async (files: FileList | File[]) => {
+    keepVoiceTurnAsDraft();
     const list = Array.from(files);
     let maxPages = 20;
     let maxMb = 10;
@@ -288,16 +323,31 @@ export function Composer(props: Props) {
   const toggleDictation = async () => {
     if (!isTauri() || dictationBusy) return;
     setDictationError(null);
+    setDictationNotice(null);
     try {
       if (dictation?.recording) {
+        const completedMode = activeVoiceMode.current;
+        const shouldAutoSend =
+          completedMode === "discussion" && autoSendVoiceTurn.current;
         setDictationBusy("Transcribing…");
         const transcript = await stopDictation();
         if (transcript === null) throw new Error("Could not transcribe your recording.");
         if (transcript.trim()) {
-          setText((draft) => (draft.trim() ? `${draft.trimEnd()} ${transcript.trim()}` : transcript.trim()));
+          if (shouldAutoSend) {
+            props.onSend(transcript.trim(), undefined, { inputMode: "voice_discussion" });
+            setText("");
+            setAttachments([]);
+          } else {
+            setText((draft) => (draft.trim() ? `${draft.trimEnd()} ${transcript.trim()}` : transcript.trim()));
+            if (completedMode === "discussion") {
+              setDictationNotice("Voice transcript kept as an editable draft.");
+            }
+          }
+        } else if (completedMode === "discussion") {
+          throw new Error("No speech was detected. Try again and speak for a little longer.");
         }
         setDictation(await getDictationStatus());
-        textareaRef.current?.focus();
+        if (!shouldAutoSend) textareaRef.current?.focus();
         return;
       }
 
@@ -307,11 +357,21 @@ export function Composer(props: Props) {
         props.onConfigureVoiceInput?.();
         return;
       }
+      if (voiceMode === "discussion" && props.modelReady === false) {
+        props.onConnectModel?.();
+        return;
+      }
+      if (voiceMode === "discussion" && (!props.connected || props.running)) return;
       setDictationBusy("Starting microphone…");
+      activeVoiceMode.current = voiceMode;
+      autoSendVoiceTurn.current =
+        voiceMode === "discussion" && !text.trim() && attachments.length === 0;
       const recording = await startDictation();
       if (!recording?.recording) throw new Error("Could not start the microphone.");
       setDictation(recording);
     } catch (error) {
+      autoSendVoiceTurn.current = false;
+      setDictationNotice(null);
       setDictationError(error instanceof Error ? error.message : "Voice dictation is unavailable.");
       const status = await getDictationStatus();
       if (status) setDictation(status);
@@ -334,6 +394,12 @@ export function Composer(props: Props) {
   // The send button is accent only when there's something to send — subtle grey otherwise, so the
   // composer isn't carrying a constant blue dot.
   const hasContent = text.trim().length > 0 || attachments.length > 0;
+  const activeVoiceModeName = voiceModeName(activeVoiceMode.current);
+  const voiceActionDisabled =
+    !!dictationBusy ||
+    (!dictation?.recording &&
+      voiceMode === "discussion" &&
+      (!props.connected || props.running));
 
   return (
     <div className="composer-wrap px-6 pb-5 pt-4">
@@ -342,6 +408,11 @@ export function Composer(props: Props) {
       {dictationError && (
         <div className="max-w-3xl mx-auto mb-2 px-1 text-[12px] text-red-600" role="alert">
           {dictationError}
+        </div>
+      )}
+      {dictationNotice && (
+        <div className="max-w-3xl mx-auto mb-2 px-1 text-[12px] text-muted" role="status">
+          {dictationNotice}
         </div>
       )}
 
@@ -392,7 +463,12 @@ export function Composer(props: Props) {
           className="w-full block px-3.5 pt-3.5 pb-1.5 text-[14.5px]"
           placeholder={props.placeholder || "Ask the coworker…  (drop or paste files)"}
           value={text}
-          onChange={(e) => setText(e.target.value)}
+          onPointerDown={keepVoiceTurnAsDraft}
+          onChange={(e) => {
+            keepVoiceTurnAsDraft();
+            setDictationNotice(null);
+            setText(e.target.value);
+          }}
           onKeyDown={onKey}
           onPaste={onPaste}
           rows={1}
@@ -440,6 +516,11 @@ export function Composer(props: Props) {
               polled ~10Hz, scrolling left) + elapsed time (§37). */}
           {dictation?.recording ? (
             <div className="voice-wave-row flex-1 flex items-center gap-2 ml-1" aria-hidden="true">
+              {activeVoiceMode.current === "discussion" && (
+                <span className="shrink-0 rounded-full bg-accentSoft px-2 py-0.5 text-[10.5px] font-medium text-accent">
+                  Voice discussion
+                </span>
+              )}
               <span className="voice-wave-line" />
               <span className="voice-wave-bars">
                 {Array.from({ length: 14 }, (_, index) => {
@@ -488,30 +569,54 @@ export function Composer(props: Props) {
             </button>
           ))}
 
-          {/* mic — immediately before send (owner call, DMG #28 walkthrough) */}
+          {/* Voice split control: the primary action records in the selected mode; the quiet
+              chevron keeps editable Dictation and auto-submit Voice discussion one click apart. */}
           {isTauri() && (
-            <button
-              className={
-                iconBtn +
-                (dictation?.recording ? " bg-red-50 text-red-600 hover:bg-red-100" : "") +
-                (dictationBusy ? " opacity-60" : "") +
-                (!voiceReady && !dictation?.recording ? " opacity-40" : "")
-              }
-              onClick={() => void toggleDictation()}
-              disabled={!!dictationBusy}
-              title={
-                dictationBusy ||
-                (dictation?.recording
-                  ? "Stop recording and transcribe"
-                  : voiceReady
-                    ? "Start local voice dictation"
-                    : "Configure Voice Input in Settings")
-              }
-              aria-label={dictation?.recording ? "Stop dictation" : voiceReady ? "Start dictation" : "Configure Voice Input in Settings"}
-              aria-disabled={!voiceReady && !dictation?.recording}
-            >
-              <Icon name={dictation?.recording ? "stop" : "mic"} size={16} />
-            </button>
+            <div className="relative flex items-center">
+              <button
+                className={
+                  iconBtn +
+                  (dictation?.recording ? " bg-red-50 text-red-600 hover:bg-red-100" : "") +
+                  (!dictation?.recording && voiceMode === "discussion" ? " bg-accentSoft text-accent" : "") +
+                  (voiceActionDisabled ? " opacity-60" : "") +
+                  (!voiceReady && !dictation?.recording ? " opacity-40" : "")
+                }
+                onClick={() => void toggleDictation()}
+                disabled={voiceActionDisabled}
+                title={
+                  dictationBusy ||
+                  (dictation?.recording
+                    ? `Stop ${activeVoiceModeName.toLowerCase()} and transcribe`
+                    : voiceReady
+                      ? voiceMode === "discussion"
+                        ? "Start voice discussion. The transcript sends when you stop."
+                        : "Start local voice dictation"
+                      : "Configure Voice Input in Settings")
+                }
+                aria-label={
+                  dictation?.recording
+                    ? `Stop ${activeVoiceModeName.toLowerCase()}`
+                    : voiceReady
+                      ? voiceMode === "discussion"
+                        ? "Start voice discussion"
+                        : "Start dictation"
+                      : "Configure Voice Input in Settings"
+                }
+                aria-disabled={
+                  (!voiceReady && !dictation?.recording) ||
+                  (voiceMode === "discussion" && props.modelReady === false)
+                }
+              >
+                <Icon name={dictation?.recording ? "stop" : "mic"} size={16} />
+              </button>
+              {!dictation?.recording && (
+                <VoiceModePicker
+                  mode={voiceMode}
+                  onChange={changeVoiceMode}
+                  disabled={!!dictationBusy}
+                />
+              )}
+            </div>
           )}
 
           {/* send / stop */}
@@ -540,9 +645,113 @@ export function Composer(props: Props) {
         </div>
       </div>
       <span className="sr-only" role="status" aria-live="polite">
-        {dictation?.recording ? `Listening, ${recordingTime}` : dictationBusy || ""}
+        {dictation?.recording
+          ? `${activeVoiceModeName} listening, ${recordingTime}${
+              activeVoiceMode.current === "discussion" && autoSendVoiceTurn.current
+                ? ". Transcript will send when stopped."
+                : ""
+            }`
+          : dictationBusy || ""}
       </span>
     </div>
+  );
+}
+
+function VoiceModePicker({
+  mode,
+  onChange,
+  disabled,
+}: {
+  mode: VoiceCaptureMode;
+  onChange: (mode: VoiceCaptureMode) => void;
+  disabled: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const choose = (next: VoiceCaptureMode) => {
+    onChange(next);
+    setOpen(false);
+  };
+  return (
+    <>
+      <button
+        className="h-7 w-4 -ml-1 grid place-items-center rounded-r-md text-faint hover:bg-paper hover:text-ink disabled:opacity-50"
+        aria-label="Voice input mode"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={`Voice input mode: ${voiceModeName(mode)}`}
+        disabled={disabled}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <Icon name="chevronDown" size={10} />
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} />
+          <div
+            className="absolute z-40 bottom-full mb-1 right-0 w-[280px] rounded-xl border border-line bg-panel shadow-2xl p-1.5"
+            role="menu"
+            aria-label="Voice input mode"
+          >
+            <VoiceModeOption
+              checked={mode === "dictation"}
+              label="Dictation"
+              description="Transcribe into the composer so you can edit before sending."
+              onClick={() => choose("dictation")}
+            />
+            <VoiceModeOption
+              checked={mode === "discussion"}
+              label="Voice discussion"
+              description="Send the transcript automatically when you stop speaking."
+              onClick={() => choose("discussion")}
+            />
+            <div className="mx-2 mt-1 border-t border-line px-0 pt-2 pb-1 text-[10.5px] leading-snug text-faint">
+              Clicking or typing in the composer keeps a discussion turn as an editable draft.
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+function VoiceModeOption({
+  checked,
+  label,
+  description,
+  onClick,
+}: {
+  checked: boolean;
+  label: string;
+  description: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      className={
+        "w-full rounded-lg px-2.5 py-2 text-left hover:bg-paper " +
+        (checked ? "bg-accentSoft/60" : "")
+      }
+      role="menuitemradio"
+      aria-checked={checked}
+      onClick={onClick}
+    >
+      <span className="flex items-center gap-2">
+        <span
+          className={
+            "grid h-5 w-5 shrink-0 place-items-center rounded-full border " +
+            (checked ? "border-accent bg-accent text-white" : "border-lineStrong text-faint")
+          }
+        >
+          {checked ? "✓" : <Icon name="mic" size={11} />}
+        </span>
+        <span>
+          <span className={"block text-[13px] " + (checked ? "font-medium text-accent" : "text-ink")}>
+            {label}
+          </span>
+          <span className="mt-0.5 block text-[11px] leading-snug text-faint">{description}</span>
+        </span>
+      </span>
+    </button>
   );
 }
 

--- a/surfaces/gui/src/components/Composer.voice.test.tsx
+++ b/surfaces/gui/src/components/Composer.voice.test.tsx
@@ -1,8 +1,9 @@
-// §37 voice input — the composer's side of the contract, driven through a mocked
-// __TAURI__ global (the mic is native-only; the browser build renders no mic at all).
+// §37 voice input — one composer contract backed by either native Tauri dictation
+// or the browser's speech-recognition API.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Composer } from "./Composer";
+import { resetBrowserVoiceCaptureForTests } from "../voice";
 
 const READY = {
   recording: false,
@@ -20,6 +21,49 @@ const NOT_READY = { ...READY, model_verified: false, test_passed: false };
 const RECORDING = { ...READY, recording: true };
 
 let invoke: ReturnType<typeof vi.fn>;
+let browserRecognition: MockSpeechRecognition | null;
+let getUserMedia: ReturnType<typeof vi.fn>;
+
+class MockSpeechRecognition {
+  continuous = false;
+  interimResults = false;
+  lang = "";
+  onstart: (() => void) | null = null;
+  onresult: ((event: any) => void) | null = null;
+  onerror: ((event: any) => void) | null = null;
+  onend: (() => void) | null = null;
+
+  constructor() {
+    browserRecognition = this;
+  }
+
+  start() {
+    this.onstart?.();
+  }
+
+  stop() {
+    const result = { 0: { transcript: "hello from the browser" }, length: 1, isFinal: true };
+    this.onresult?.({ resultIndex: 0, results: { 0: result, length: 1 } });
+    this.onend?.();
+  }
+
+  abort() {
+    this.onend?.();
+  }
+}
+
+const installBrowserVoice = () => {
+  delete (globalThis as any).__TAURI__;
+  browserRecognition = null;
+  (globalThis as any).webkitSpeechRecognition = MockSpeechRecognition;
+  getUserMedia = vi.fn(async () => ({
+    getTracks: () => [{ stop: vi.fn() }],
+  }));
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia },
+  });
+};
 
 const props = (extra: Partial<Parameters<typeof Composer>[0]> = {}) => ({
   mode: "interactive",
@@ -34,7 +78,7 @@ const props = (extra: Partial<Parameters<typeof Composer>[0]> = {}) => ({
 });
 
 beforeEach(() => {
-  localStorage.removeItem("openwork-voice-capture-mode");
+  window.localStorage.removeItem("openwork-voice-capture-mode");
   invoke = vi.fn(async (cmd: string) => {
     if (cmd === "get_dictation_status") return READY;
     if (cmd === "start_dictation") return RECORDING;
@@ -42,19 +86,75 @@ beforeEach(() => {
     return null;
   });
   (globalThis as any).__TAURI__ = { core: { invoke }, event: { listen: async () => () => {} } };
+  browserRecognition = null;
+  getUserMedia = vi.fn();
 });
 
 afterEach(() => {
+  resetBrowserVoiceCaptureForTests();
   cleanup();
-  localStorage.removeItem("openwork-voice-capture-mode");
+  window.localStorage.removeItem("openwork-voice-capture-mode");
   delete (globalThis as any).__TAURI__;
+  delete (globalThis as any).SpeechRecognition;
+  delete (globalThis as any).webkitSpeechRecognition;
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: undefined,
+  });
 });
 
 describe("Composer voice input (§37)", () => {
-  it("renders no mic at all outside the desktop app", () => {
+  it("keeps a visible disabled mic when browser speech recognition is unavailable", async () => {
     delete (globalThis as any).__TAURI__;
     render(<Composer {...props()} />);
-    expect(screen.queryByLabelText(/dictation|Voice Input/)).toBeNull();
+    const mic = await screen.findByLabelText("Voice input unavailable in this browser");
+    expect(mic.hasAttribute("disabled")).toBe(true);
+    expect(mic.getAttribute("title")).toContain("does not provide speech recognition");
+  });
+
+  it("uses browser speech recognition to create an editable dictation draft", async () => {
+    installBrowserVoice();
+    render(<Composer {...props()} />);
+
+    fireEvent.click(await screen.findByLabelText("Start dictation"));
+    expect(getUserMedia).toHaveBeenCalledWith({ audio: true });
+    await waitFor(() => expect(browserRecognition).not.toBeNull());
+    expect(browserRecognition?.continuous).toBe(true);
+    expect(browserRecognition?.interimResults).toBe(true);
+
+    fireEvent.click(await screen.findByLabelText("Stop dictation"));
+    const box = screen.getByPlaceholderText(/Ask the coworker/) as HTMLTextAreaElement;
+    await waitFor(() => expect(box.value).toBe("hello from the browser"));
+  });
+
+  it("auto-submits a browser voice discussion with trusted metadata", async () => {
+    installBrowserVoice();
+    const onSend = vi.fn();
+    render(<Composer {...props({ onSend })} />);
+
+    fireEvent.click(await screen.findByLabelText("Voice input mode"));
+    expect(screen.getByText(/Transcription is managed by your browser/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /Voice discussion/ }));
+    fireEvent.click(screen.getByLabelText("Start voice discussion"));
+    fireEvent.click(await screen.findByLabelText("Stop voice discussion"));
+
+    await waitFor(() =>
+      expect(onSend).toHaveBeenCalledWith(
+        "hello from the browser",
+        undefined,
+        { inputMode: "voice_discussion" },
+      ),
+    );
+  });
+
+  it("surfaces browser microphone permission failures without wedging the mic", async () => {
+    installBrowserVoice();
+    getUserMedia.mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
+    render(<Composer {...props()} />);
+
+    fireEvent.click(await screen.findByLabelText("Start dictation"));
+    expect((await screen.findByRole("alert")).textContent).toContain("Microphone access was blocked");
+    expect(screen.getByLabelText("Start dictation").hasAttribute("disabled")).toBe(false);
   });
 
   it("not ready → muted mic deep-links to Settings instead of recording", async () => {
@@ -120,7 +220,7 @@ describe("Composer voice input (§37)", () => {
         { inputMode: "voice_discussion" },
       ),
     );
-    expect(localStorage.getItem("openwork-voice-capture-mode")).toBe("discussion");
+    expect(window.localStorage.getItem("openwork-voice-capture-mode")).toBe("discussion");
   });
 
   it("editing during voice discussion cancels auto-send and keeps an editable draft", async () => {

--- a/surfaces/gui/src/components/Composer.voice.test.tsx
+++ b/surfaces/gui/src/components/Composer.voice.test.tsx
@@ -134,6 +134,9 @@ describe("Composer voice input (§37)", () => {
 
     fireEvent.click(await screen.findByLabelText("Voice input mode"));
     expect(screen.getByText(/Transcription is managed by your browser/)).toBeTruthy();
+    const selectedIndicator = screen.getByTestId("voice-mode-selected-indicator");
+    expect(selectedIndicator.querySelector("svg")).toBeTruthy();
+    expect(selectedIndicator.textContent).toBe("");
     fireEvent.click(screen.getByRole("menuitemradio", { name: /Voice discussion/ }));
     fireEvent.click(screen.getByLabelText("Start voice discussion"));
     fireEvent.click(await screen.findByLabelText("Stop voice discussion"));

--- a/surfaces/gui/src/components/Composer.voice.test.tsx
+++ b/surfaces/gui/src/components/Composer.voice.test.tsx
@@ -1,7 +1,7 @@
 // §37 voice input — one composer contract backed by either native Tauri dictation
 // or the browser's speech-recognition API.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Composer } from "./Composer";
 import { resetBrowserVoiceCaptureForTests } from "../voice";
 
@@ -32,6 +32,7 @@ class MockSpeechRecognition {
   onresult: ((event: any) => void) | null = null;
   onerror: ((event: any) => void) | null = null;
   onend: (() => void) | null = null;
+  abortCalls = 0;
 
   constructor() {
     browserRecognition = this;
@@ -48,6 +49,12 @@ class MockSpeechRecognition {
   }
 
   abort() {
+    this.abortCalls += 1;
+    this.onend?.();
+  }
+
+  fail(error: string) {
+    this.onerror?.({ error });
     this.onend?.();
   }
 }
@@ -160,6 +167,20 @@ describe("Composer voice input (§37)", () => {
     expect(screen.getByLabelText("Start dictation").hasAttribute("disabled")).toBe(false);
   });
 
+  it("surfaces browser recognition failures that happen after recording starts", async () => {
+    installBrowserVoice();
+    render(<Composer {...props()} />);
+
+    fireEvent.click(await screen.findByLabelText("Start dictation"));
+    await screen.findByLabelText("Stop dictation");
+    act(() => browserRecognition?.fail("network"));
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "speech recognition service could not be reached",
+    );
+    expect(screen.getByLabelText("Start dictation").hasAttribute("disabled")).toBe(false);
+  });
+
   it("not ready → muted mic deep-links to Settings instead of recording", async () => {
     invoke.mockImplementation(async (cmd: string) =>
       cmd === "get_dictation_status" ? NOT_READY : null,
@@ -241,5 +262,61 @@ describe("Composer voice input (§37)", () => {
     await waitFor(() => expect(box.value).toBe("Please check hello from the mic"));
     expect(onSend).not.toHaveBeenCalled();
     expect(screen.getByText("Voice transcript kept as an editable draft.")).toBeTruthy();
+  });
+
+  it("keeps a completed discussion as a draft if the connection drops while recording", async () => {
+    const onSend = vi.fn();
+    const view = render(<Composer {...props({ onSend, resetKey: "session-a" })} />);
+
+    fireEvent.click(await screen.findByLabelText("Voice input mode"));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /Voice discussion/ }));
+    fireEvent.click(screen.getByLabelText("Start voice discussion"));
+    await screen.findByLabelText("Stop voice discussion");
+
+    view.rerender(
+      <Composer {...props({ onSend, connected: false, resetKey: "session-a" })} />,
+    );
+    fireEvent.click(screen.getByLabelText("Stop voice discussion"));
+
+    const box = screen.getByPlaceholderText(/Ask the coworker/) as HTMLTextAreaElement;
+    await waitFor(() => expect(box.value).toBe("hello from the mic"));
+    expect(onSend).not.toHaveBeenCalled();
+    expect(screen.getByText("Voice transcript kept as an editable draft.")).toBeTruthy();
+  });
+
+  it("cancels an active browser capture when the conversation changes", async () => {
+    installBrowserVoice();
+    const firstSend = vi.fn();
+    const secondSend = vi.fn();
+    const view = render(
+      <Composer {...props({ onSend: firstSend, resetKey: "session-a" })} />,
+    );
+
+    fireEvent.click(await screen.findByLabelText("Voice input mode"));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /Voice discussion/ }));
+    fireEvent.click(screen.getByLabelText("Start voice discussion"));
+    await screen.findByLabelText("Stop voice discussion");
+    const activeRecognition = browserRecognition;
+
+    view.rerender(
+      <Composer {...props({ onSend: secondSend, resetKey: "session-b" })} />,
+    );
+
+    await waitFor(() => expect(activeRecognition?.abortCalls).toBe(1));
+    expect(firstSend).not.toHaveBeenCalled();
+    expect(secondSend).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText("Stop voice discussion")).toBeNull();
+  });
+
+  it("releases an active browser capture when the composer unmounts", async () => {
+    installBrowserVoice();
+    const view = render(<Composer {...props({ resetKey: "session-a" })} />);
+
+    fireEvent.click(await screen.findByLabelText("Start dictation"));
+    await screen.findByLabelText("Stop dictation");
+    const activeRecognition = browserRecognition;
+    view.unmount();
+
+    expect(activeRecognition?.abortCalls).toBe(1);
   });
 });

--- a/surfaces/gui/src/components/Composer.voice.test.tsx
+++ b/surfaces/gui/src/components/Composer.voice.test.tsx
@@ -34,6 +34,7 @@ const props = (extra: Partial<Parameters<typeof Composer>[0]> = {}) => ({
 });
 
 beforeEach(() => {
+  localStorage.removeItem("openwork-voice-capture-mode");
   invoke = vi.fn(async (cmd: string) => {
     if (cmd === "get_dictation_status") return READY;
     if (cmd === "start_dictation") return RECORDING;
@@ -45,6 +46,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  localStorage.removeItem("openwork-voice-capture-mode");
   delete (globalThis as any).__TAURI__;
 });
 
@@ -100,5 +102,41 @@ describe("Composer voice input (§37)", () => {
     fireEvent.click(await screen.findByLabelText("Start dictation"));
     expect((await screen.findByRole("alert")).textContent).toContain("No microphone is available.");
     expect(screen.getByLabelText("Start dictation").hasAttribute("disabled")).toBe(false);
+  });
+
+  it("voice discussion auto-submits the completed transcript with trusted metadata", async () => {
+    const onSend = vi.fn();
+    render(<Composer {...props({ onSend })} />);
+
+    fireEvent.click(await screen.findByLabelText("Voice input mode"));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /Voice discussion/ }));
+    fireEvent.click(screen.getByLabelText("Start voice discussion"));
+    fireEvent.click(await screen.findByLabelText("Stop voice discussion"));
+
+    await waitFor(() =>
+      expect(onSend).toHaveBeenCalledWith(
+        "hello from the mic",
+        undefined,
+        { inputMode: "voice_discussion" },
+      ),
+    );
+    expect(localStorage.getItem("openwork-voice-capture-mode")).toBe("discussion");
+  });
+
+  it("editing during voice discussion cancels auto-send and keeps an editable draft", async () => {
+    const onSend = vi.fn();
+    render(<Composer {...props({ onSend })} />);
+
+    fireEvent.click(await screen.findByLabelText("Voice input mode"));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /Voice discussion/ }));
+    fireEvent.click(screen.getByLabelText("Start voice discussion"));
+
+    const box = screen.getByPlaceholderText(/Ask the coworker/) as HTMLTextAreaElement;
+    fireEvent.change(box, { target: { value: "Please check" } });
+    fireEvent.click(await screen.findByLabelText("Stop voice discussion"));
+
+    await waitFor(() => expect(box.value).toBe("Please check hello from the mic"));
+    expect(onSend).not.toHaveBeenCalled();
+    expect(screen.getByText("Voice transcript kept as an editable draft.")).toBeTruthy();
   });
 });

--- a/surfaces/gui/src/components/Icon.tsx
+++ b/surfaces/gui/src/components/Icon.tsx
@@ -41,6 +41,7 @@ export type IconName =
   | "table"
   | "mic"
   | "stop"
+  | "check"
   | "x";
 
 export function Icon({
@@ -161,6 +162,14 @@ export function Icon({
       return (
         <svg {...s} fill="currentColor" stroke="none">
           <rect x="6.5" y="6.5" width="11" height="11" rx="1.5" />
+        </svg>
+      );
+    case "check":
+      // Tabler check. Kept in the shared 24px line-icon system so compact selected
+      // states align optically instead of relying on a font-dependent Unicode glyph.
+      return (
+        <svg {...s}>
+          <path d="m5 12 5 5L20 7" />
         </svg>
       );
     case "x":

--- a/surfaces/gui/src/components/SettingsView.tsx
+++ b/surfaces/gui/src/components/SettingsView.tsx
@@ -39,6 +39,7 @@ import { ModelsTab } from "./ManageTabs";
 import { GalleryModal } from "./GalleryModal";
 import { PersonasTab } from "./PersonasTab";
 import { showPersonas } from "../flags";
+import { getVoiceStatus } from "../voice";
 
 // Settings, restructured (Option 2) into a full-page surface that mirrors IntegrationsView's shell:
 // a left sub-nav (Appearance · Files · Models · Personas) + centered panel, replacing the old
@@ -185,6 +186,17 @@ function VoiceInputSection() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [desktop]);
 
+  useEffect(() => {
+    if (desktop) return;
+    let active = true;
+    void getVoiceStatus().then((initial) => {
+      if (active && initial) setStatus(initial);
+    });
+    return () => {
+      active = false;
+    };
+  }, [desktop]);
+
   const download = async () => {
     setError(null);
     setProgress({ downloaded_bytes: 0, total_bytes: status?.model_bytes || 0 });
@@ -259,11 +271,50 @@ function VoiceInputSection() {
     <section>
       <PanelHead
         title="Voice input"
-        sub="Speak naturally in the composer. Recordings and transcripts stay on this device."
+        sub={
+          desktop
+            ? "Speak naturally in the composer. Recordings and transcripts stay on this device."
+            : "Speak naturally in the composer using your browser’s speech recognition service."
+        }
       />
 
       {!desktop ? (
-        <div className={CARD + " p-4 text-[13px] text-muted"}>Voice Input setup is available in the OpenWorker desktop app.</div>
+        <div className={CARD}>
+          <div className="p-4 flex items-start gap-3">
+            <Icon
+              name="mic"
+              size={18}
+              className={status?.supported ? "text-green-600 mt-0.5" : "text-muted mt-0.5"}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="text-[13.5px] font-medium">
+                {!status
+                  ? "Checking browser voice input…"
+                  : status.supported
+                    ? "Browser voice input is ready"
+                    : "Browser voice input is unavailable"}
+              </div>
+              <div className="mt-1 text-[12px] leading-relaxed text-muted">
+                {status?.supported
+                  ? "Start from the microphone in the composer. Your browser will request microphone permission the first time."
+                  : status?.compatibility_reason || "Checking browser compatibility…"}
+              </div>
+              <div className="mt-3 rounded-lg border border-line bg-paper px-3 py-2 text-[11.5px] leading-relaxed text-muted">
+                Browser transcription may use a speech service managed by your browser vendor. Use the desktop app when you need fully local Whisper transcription.
+              </div>
+            </div>
+            {status && (
+              <span
+                className={
+                  "shrink-0 rounded-full px-2 py-1 text-[11.5px] " +
+                  (status.supported ? "bg-green-50 text-green-700" : "bg-red-50 text-red-600")
+                }
+              >
+                {status.supported ? "● Compatible" : "Unsupported"}
+              </span>
+            )}
+          </div>
+        </div>
       ) : (
         <div className="space-y-4">
           <div className="rounded-xl border border-green-200 bg-green-50/70 px-4 py-3 text-[12.5px] text-green-800">

--- a/surfaces/gui/src/components/Transcript.test.tsx
+++ b/surfaces/gui/src/components/Transcript.test.tsx
@@ -81,6 +81,17 @@ describe("TurnGroup (Transcript §33)", () => {
     expect(container.querySelector("details.stepgroup")).toBeNull();
     expect(screen.getByText("Hello there.")).toBeTruthy();
   });
+
+  it("labels voice discussion turns without changing their visible transcript", () => {
+    render(
+      <Transcript
+        items={[{ kind: "user", text: "check the release", inputMode: "voice_discussion" }]}
+        onApprove={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Voice discussion")).toBeTruthy();
+    expect(screen.getByText("check the release")).toBeTruthy();
+  });
 });
 
 describe("live turns (§33 flicker fix)", () => {

--- a/surfaces/gui/src/components/Transcript.tsx
+++ b/surfaces/gui/src/components/Transcript.tsx
@@ -387,6 +387,12 @@ export function Transcript({ items, running, streamingText, onRetry }: Props) {
             return (
               <div className="group self-end max-w-[78%] flex flex-col items-end" key={bi}>
                 <div className="bubble-user px-3.5 py-2.5 rounded-[14px_14px_4px_14px] bg-solid text-onSolid text-[14.5px] leading-relaxed whitespace-pre-wrap">
+                  {item.inputMode === "voice_discussion" && (
+                    <span className="mb-1 flex items-center gap-1 text-[10.5px] leading-none text-onSolid/70">
+                      <Icon name="mic" size={11} />
+                      Voice discussion
+                    </span>
+                  )}
                   {item.attachments && item.attachments.length > 0 && (
                     <div className="bubble-attachments">
                       {item.attachments.map((a, i) =>

--- a/surfaces/gui/src/itemsFromMessages.test.ts
+++ b/surfaces/gui/src/itemsFromMessages.test.ts
@@ -49,6 +49,18 @@ describe("itemsFromMessages timestamps", () => {
   });
 });
 
+describe("itemsFromMessages voice metadata", () => {
+  it("keeps the trusted voice discussion marker beside the visible transcript", () => {
+    const items = itemsFromMessages([
+      { role: "user", content: "hello from the mic", input_mode: "voice_discussion" },
+    ] as any);
+
+    expect(items).toEqual([
+      { kind: "user", text: "hello from the mic", inputMode: "voice_discussion" },
+    ]);
+  });
+});
+
 describe("itemsFromMessages notices", () => {
   it("replays persisted error/interrupted markers; only errors are retriable", () => {
     const items = itemsFromMessages([

--- a/surfaces/gui/src/itemsFromMessages.ts
+++ b/surfaces/gui/src/itemsFromMessages.ts
@@ -35,6 +35,7 @@ export function itemsFromMessages(messages: ConversationMessage[]): Item[] {
       const user = userItemFromContent(m.content);
       // `ts` (unix seconds) is the server's canonical-message stamp; older sessions have none.
       if (typeof m.ts === "number") user.ts = m.ts;
+      if (m.input_mode === "voice_discussion") user.inputMode = m.input_mode;
       if (user.text || user.attachments?.length) items.push(user);
     } else if (m.role === "assistant") {
       if (m.content || m.reasoning)

--- a/surfaces/gui/src/styles.css
+++ b/surfaces/gui/src/styles.css
@@ -94,6 +94,79 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/* Voice mode picker: compact radio-card rows with an optically centered icon check.
+   The selected surface uses the app's single cobalt accent and stays legible in both themes. */
+.voice-mode-menu {
+  box-shadow:
+    0 20px 52px rgba(8, 12, 20, 0.24),
+    0 3px 12px rgba(8, 12, 20, 0.12);
+}
+.voice-mode-option {
+  position: relative;
+  border: 1px solid transparent;
+  color: var(--ink);
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    transform 120ms ease;
+}
+.voice-mode-option:hover {
+  background: color-mix(in srgb, var(--paper) 82%, var(--panel));
+}
+.voice-mode-option:active {
+  transform: translateY(1px) scale(0.995);
+}
+.voice-mode-option:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 72%, transparent);
+  outline-offset: 1px;
+}
+.voice-mode-option.is-selected {
+  border-color: color-mix(in srgb, var(--accent) 22%, var(--line));
+  background: color-mix(in srgb, var(--accent-soft) 78%, var(--panel));
+}
+.voice-mode-indicator {
+  border-color: var(--line-strong);
+  background: color-mix(in srgb, var(--panel) 72%, var(--paper));
+  color: var(--faint);
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease,
+    transform 150ms ease;
+}
+.voice-mode-option:hover .voice-mode-indicator {
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--line-strong));
+  color: var(--muted);
+}
+.voice-mode-option.is-selected .voice-mode-indicator {
+  border-color: color-mix(in srgb, var(--accent) 86%, white);
+  background: var(--accent);
+  color: #f8fbff;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.3),
+    0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.voice-mode-label {
+  font-weight: 500;
+}
+.voice-mode-option.is-selected .voice-mode-label {
+  color: var(--accent);
+  font-weight: 600;
+}
+.voice-mode-description {
+  color: var(--faint);
+}
+.voice-mode-option.is-selected .voice-mode-description {
+  color: color-mix(in srgb, var(--muted) 88%, var(--accent));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .voice-mode-option,
+  .voice-mode-indicator {
+    transition: none;
+  }
+}
+
 .app {
   display: grid;
   grid-template-columns: 264px 1fr;

--- a/surfaces/gui/src/types.ts
+++ b/surfaces/gui/src/types.ts
@@ -71,11 +71,18 @@ export interface Attachment {
   text?: string; // text files
 }
 
+// Trusted input metadata. This is carried beside the visible transcript text and stripped
+// before provider conversion; the server turns it into ephemeral voice-aware guidance.
+export type UserInputMode = "voice_discussion";
+export interface UserMessageMeta {
+  inputMode?: UserInputMode;
+}
+
 // Transcript items
 // `ts` = unix seconds (the server's canonical-message stamp; live items stamp locally).
 // Optional: sessions saved before the server stamped timestamps have none.
 export type Item =
-  | { kind: "user"; text: string; attachments?: Attachment[]; ts?: number }
+  | { kind: "user"; text: string; attachments?: Attachment[]; ts?: number; inputMode?: UserInputMode }
   // A connector-delivered inbound message (Slack/Salesforce/…), rendered as a structured card
   // (ConnectorMessageCard) instead of a plain user bubble. Generalizes to any connector via the
   // registry — no per-connector special-casing.

--- a/surfaces/gui/src/voice.ts
+++ b/surfaces/gui/src/voice.ts
@@ -1,0 +1,392 @@
+import {
+  cancelDictation,
+  getDictationLevel,
+  getDictationStatus,
+  isTauri,
+  startDictation,
+  stopDictation,
+  type DictationStatus,
+} from "./tauri";
+
+export type VoiceRuntime = "native" | "browser";
+export type VoiceStatus = DictationStatus;
+
+type BrowserSpeechAlternative = { transcript: string };
+type BrowserSpeechResult = {
+  readonly isFinal: boolean;
+  readonly length: number;
+  [index: number]: BrowserSpeechAlternative;
+};
+type BrowserSpeechResultList = {
+  readonly length: number;
+  [index: number]: BrowserSpeechResult;
+};
+type BrowserSpeechEvent = {
+  readonly resultIndex: number;
+  readonly results: BrowserSpeechResultList;
+};
+type BrowserSpeechErrorEvent = {
+  readonly error: string;
+  readonly message?: string;
+};
+type BrowserSpeechRecognition = {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onstart: (() => void) | null;
+  onresult: ((event: BrowserSpeechEvent) => void) | null;
+  onerror: ((event: BrowserSpeechErrorEvent) => void) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+};
+type BrowserSpeechRecognitionConstructor = new () => BrowserSpeechRecognition;
+
+type BrowserAudioContext = AudioContext & {
+  close(): Promise<void>;
+};
+
+type BrowserVoiceSession = {
+  recognition: BrowserSpeechRecognition;
+  desired: boolean;
+  recognitionActive: boolean;
+  stopRequested: boolean;
+  cancelRequested: boolean;
+  finalTranscript: string;
+  interimTranscript: string;
+  stream: MediaStream;
+  audioContext: BrowserAudioContext | null;
+  analyser: AnalyserNode | null;
+  levelData: Uint8Array<ArrayBuffer> | null;
+  restartTimer: number | null;
+  startSettled: boolean;
+  resolveStart: (status: VoiceStatus) => void;
+  rejectStart: (error: Error) => void;
+  resolveStop: ((transcript: string) => void) | null;
+  rejectStop: ((error: Error) => void) | null;
+  terminalError: Error | null;
+};
+
+let browserSession: BrowserVoiceSession | null = null;
+
+export const getVoiceRuntime = (): VoiceRuntime => (isTauri() ? "native" : "browser");
+
+const speechRecognitionConstructor = (): BrowserSpeechRecognitionConstructor | null => {
+  const root = globalThis as typeof globalThis & {
+    SpeechRecognition?: BrowserSpeechRecognitionConstructor;
+    webkitSpeechRecognition?: BrowserSpeechRecognitionConstructor;
+  };
+  return root.SpeechRecognition || root.webkitSpeechRecognition || null;
+};
+
+const browserAudioContextConstructor = () => {
+  const root = globalThis as typeof globalThis & {
+    webkitAudioContext?: typeof AudioContext;
+  };
+  return globalThis.AudioContext || root.webkitAudioContext || null;
+};
+
+const browserCompatibility = () => {
+  if (!speechRecognitionConstructor()) {
+    return "This browser does not provide speech recognition. Try the latest Chrome, Edge, or Safari.";
+  }
+  if (!navigator.mediaDevices?.getUserMedia) {
+    return "Microphone access is unavailable. Open OpenWorker from a secure local or HTTPS address.";
+  }
+  return null;
+};
+
+const browserStatus = (): VoiceStatus => {
+  const compatibilityReason = browserCompatibility();
+  const supported = compatibilityReason === null;
+  return {
+    recording: !!browserSession?.desired,
+    model_installed: supported,
+    model_verified: supported,
+    test_passed: supported,
+    download_in_progress: false,
+    model_name: "Browser speech recognition",
+    model_bytes: 0,
+    supported,
+    device_summary: supported
+      ? "Browser speech recognition · microphone permission required"
+      : "Browser voice input unavailable",
+    compatibility_reason: compatibilityReason,
+  };
+};
+
+const publishBrowserStatus = () => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<VoiceStatus>("coworker:voice-input-changed", {
+      detail: browserStatus(),
+    }),
+  );
+};
+
+const speechError = (event: BrowserSpeechErrorEvent): Error => {
+  switch (event.error) {
+    case "not-allowed":
+    case "service-not-allowed":
+      return new Error("Microphone access was blocked. Allow it in your browser’s site settings and try again.");
+    case "audio-capture":
+      return new Error("No working microphone is available to this browser.");
+    case "network":
+      return new Error("The browser speech recognition service could not be reached.");
+    case "language-not-supported":
+      return new Error("The browser speech recognition service does not support this language.");
+    case "no-speech":
+      return new Error("No speech was detected. Try again and speak for a little longer.");
+    case "aborted":
+      return new Error("Voice input was cancelled.");
+    default:
+      return new Error(event.message || "Browser voice input stopped unexpectedly.");
+  }
+};
+
+const cleanupBrowserMedia = (session: BrowserVoiceSession) => {
+  if (session.restartTimer !== null) window.clearTimeout(session.restartTimer);
+  session.restartTimer = null;
+  session.stream.getTracks().forEach((track) => track.stop());
+  void session.audioContext?.close().catch(() => undefined);
+};
+
+const settleBrowserSession = (session: BrowserVoiceSession) => {
+  if (browserSession !== session) return;
+  session.desired = false;
+  session.recognitionActive = false;
+  cleanupBrowserMedia(session);
+  browserSession = null;
+  publishBrowserStatus();
+
+  if (!session.startSettled) {
+    session.startSettled = true;
+    session.rejectStart(session.terminalError || new Error("Could not start browser voice input."));
+  }
+  if (session.resolveStop) {
+    const transcript = `${session.finalTranscript} ${session.interimTranscript}`.trim();
+    const reject = session.rejectStop;
+    const resolve = session.resolveStop;
+    session.resolveStop = null;
+    session.rejectStop = null;
+    if (session.terminalError && !session.cancelRequested) reject?.(session.terminalError);
+    else resolve(session.cancelRequested ? "" : transcript);
+  }
+};
+
+const restartBrowserRecognition = (session: BrowserVoiceSession) => {
+  if (browserSession !== session || !session.desired) return;
+  session.restartTimer = window.setTimeout(() => {
+    session.restartTimer = null;
+    if (browserSession !== session || !session.desired) return;
+    try {
+      session.recognition.start();
+    } catch {
+      session.terminalError = new Error("Browser voice input stopped unexpectedly.");
+      settleBrowserSession(session);
+    }
+  }, 150);
+};
+
+const configureBrowserRecognition = (session: BrowserVoiceSession) => {
+  const recognition = session.recognition;
+  recognition.continuous = true;
+  recognition.interimResults = true;
+  recognition.lang = navigator.language || "en-US";
+
+  recognition.onstart = () => {
+    if (browserSession !== session) return;
+    session.recognitionActive = true;
+    if (!session.startSettled) {
+      session.startSettled = true;
+      session.resolveStart(browserStatus());
+    }
+    publishBrowserStatus();
+  };
+
+  recognition.onresult = (event) => {
+    if (browserSession !== session) return;
+    let interim = "";
+    for (let index = event.resultIndex; index < event.results.length; index += 1) {
+      const result = event.results[index];
+      const transcript = result[0]?.transcript || "";
+      if (result.isFinal) session.finalTranscript = `${session.finalTranscript} ${transcript}`.trim();
+      else interim += transcript;
+    }
+    session.interimTranscript = interim.trim();
+  };
+
+  recognition.onerror = (event) => {
+    if (browserSession !== session) return;
+    if (event.error === "aborted" && session.cancelRequested) return;
+    if (event.error === "no-speech" && session.desired && !session.stopRequested) return;
+    session.terminalError = speechError(event);
+  };
+
+  recognition.onend = () => {
+    if (browserSession !== session) return;
+    session.recognitionActive = false;
+    if (session.stopRequested || session.cancelRequested || session.terminalError) {
+      settleBrowserSession(session);
+      return;
+    }
+    restartBrowserRecognition(session);
+  };
+};
+
+const startBrowserVoice = async (): Promise<VoiceStatus> => {
+  if (browserSession?.desired) return browserStatus();
+  const Recognition = speechRecognitionConstructor();
+  const compatibilityReason = browserCompatibility();
+  if (!Recognition || compatibilityReason) throw new Error(compatibilityReason || "Browser voice input is unavailable.");
+
+  let stream: MediaStream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch (error) {
+    if (error instanceof DOMException && (error.name === "NotAllowedError" || error.name === "SecurityError")) {
+      throw new Error("Microphone access was blocked. Allow it in your browser’s site settings and try again.");
+    }
+    if (error instanceof DOMException && error.name === "NotFoundError") {
+      throw new Error("No working microphone is available to this browser.");
+    }
+    throw new Error("The browser could not start the microphone.");
+  }
+
+  const AudioContextConstructor = browserAudioContextConstructor();
+  let audioContext: BrowserAudioContext | null = null;
+  let analyser: AnalyserNode | null = null;
+  let levelData: Uint8Array<ArrayBuffer> | null = null;
+  if (AudioContextConstructor) {
+    try {
+      audioContext = new AudioContextConstructor() as BrowserAudioContext;
+      analyser = audioContext.createAnalyser();
+      analyser.fftSize = 256;
+      levelData = new Uint8Array(analyser.fftSize);
+      audioContext.createMediaStreamSource(stream).connect(analyser);
+      void audioContext.resume().catch(() => undefined);
+    } catch {
+      void audioContext?.close().catch(() => undefined);
+      audioContext = null;
+      analyser = null;
+      levelData = null;
+    }
+  }
+
+  return new Promise<VoiceStatus>((resolve, reject) => {
+    const session: BrowserVoiceSession = {
+      recognition: new Recognition(),
+      desired: true,
+      recognitionActive: false,
+      stopRequested: false,
+      cancelRequested: false,
+      finalTranscript: "",
+      interimTranscript: "",
+      stream,
+      audioContext,
+      analyser,
+      levelData,
+      restartTimer: null,
+      startSettled: false,
+      resolveStart: resolve,
+      rejectStart: reject,
+      resolveStop: null,
+      rejectStop: null,
+      terminalError: null,
+    };
+    browserSession = session;
+    configureBrowserRecognition(session);
+    try {
+      session.recognition.start();
+    } catch {
+      session.terminalError = new Error("Could not start browser voice input.");
+      settleBrowserSession(session);
+    }
+  });
+};
+
+const stopBrowserVoice = async (): Promise<string> => {
+  const session = browserSession;
+  if (!session?.desired) return "";
+  session.desired = false;
+  session.stopRequested = true;
+  return new Promise<string>((resolve, reject) => {
+    session.resolveStop = resolve;
+    session.rejectStop = reject;
+    if (session.restartTimer !== null) {
+      window.clearTimeout(session.restartTimer);
+      session.restartTimer = null;
+    }
+    if (session.recognitionActive) {
+      session.restartTimer = window.setTimeout(() => settleBrowserSession(session), 5000);
+      try {
+        session.recognition.stop();
+      } catch {
+        settleBrowserSession(session);
+      }
+    } else {
+      settleBrowserSession(session);
+    }
+  });
+};
+
+const cancelBrowserVoice = async (): Promise<void> => {
+  const session = browserSession;
+  if (!session) return;
+  session.desired = false;
+  session.cancelRequested = true;
+  if (session.restartTimer !== null) {
+    window.clearTimeout(session.restartTimer);
+    session.restartTimer = null;
+  }
+  if (session.recognitionActive) {
+    try {
+      session.recognition.abort();
+    } catch {
+      // The deterministic settlement below still releases the microphone.
+    }
+  }
+  settleBrowserSession(session);
+};
+
+const browserVoiceLevel = (): number | null => {
+  const session = browserSession;
+  if (!session?.analyser || !session.levelData) return null;
+  session.analyser.getByteTimeDomainData(session.levelData);
+  let sumSquares = 0;
+  for (const sample of session.levelData) {
+    const normalized = (sample - 128) / 128;
+    sumSquares += normalized * normalized;
+  }
+  return Math.min(1, Math.sqrt(sumSquares / session.levelData.length) * 4);
+};
+
+export const getVoiceStatus = () =>
+  getVoiceRuntime() === "native" ? getDictationStatus() : Promise.resolve(browserStatus());
+
+export const getVoiceLevel = () =>
+  getVoiceRuntime() === "native" ? getDictationLevel() : Promise.resolve(browserVoiceLevel());
+
+export const startVoiceCapture = () =>
+  getVoiceRuntime() === "native" ? startDictation() : startBrowserVoice();
+
+export const stopVoiceCapture = () =>
+  getVoiceRuntime() === "native" ? stopDictation() : stopBrowserVoice();
+
+export const cancelVoiceCapture = () =>
+  getVoiceRuntime() === "native" ? cancelDictation() : cancelBrowserVoice();
+
+export const resetBrowserVoiceCaptureForTests = () => {
+  const session = browserSession;
+  if (!session) return;
+  session.desired = false;
+  session.cancelRequested = true;
+  try {
+    session.recognition.abort();
+  } catch {
+    // Test doubles do not always implement a complete recognition lifecycle.
+  }
+  cleanupBrowserMedia(session);
+  browserSession = null;
+};

--- a/surfaces/gui/src/voice.ts
+++ b/surfaces/gui/src/voice.ts
@@ -70,6 +70,8 @@ type BrowserVoiceSession = {
 
 let browserSession: BrowserVoiceSession | null = null;
 
+export const VOICE_INPUT_ERROR_EVENT = "coworker:voice-input-error";
+
 export const getVoiceRuntime = (): VoiceRuntime => (isTauri() ? "native" : "browser");
 
 const speechRecognitionConstructor = (): BrowserSpeechRecognitionConstructor | null => {
@@ -121,6 +123,15 @@ const publishBrowserStatus = () => {
   window.dispatchEvent(
     new CustomEvent<VoiceStatus>("coworker:voice-input-changed", {
       detail: browserStatus(),
+    }),
+  );
+};
+
+const publishBrowserError = (error: Error) => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<string>(VOICE_INPUT_ERROR_EVENT, {
+      detail: error.message,
     }),
   );
 };
@@ -228,7 +239,15 @@ const configureBrowserRecognition = (session: BrowserVoiceSession) => {
     if (browserSession !== session) return;
     session.recognitionActive = false;
     if (session.stopRequested || session.cancelRequested || session.terminalError) {
+      const unobservedError =
+        session.terminalError &&
+        session.startSettled &&
+        !session.stopRequested &&
+        !session.cancelRequested
+          ? session.terminalError
+          : null;
       settleBrowserSession(session);
+      if (unobservedError) publishBrowserError(unobservedError);
       return;
     }
     restartBrowserRecognition(session);

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,8 +20,10 @@ class ScriptedProvider(ProviderClient):
 
     def __init__(self, turns):
         self._turns = list(turns)
+        self.calls = []
 
     def complete(self, *, model, messages, tools=None, **settings):
+        self.calls.append([dict(message) for message in messages])
         return self._turns.pop(0)
 
     def capabilities(self, model):
@@ -323,6 +325,44 @@ def test_ws_simple_turn(tmp_path):
         assert "turn_end" in types
 
 
+def test_ws_voice_discussion_metadata_is_trusted_and_provider_safe(tmp_path):
+    provider = ScriptedProvider([_text("spoken-friendly answer")])
+    manager = SessionManager(workspace=tmp_path, provider=provider)
+    client = TestClient(create_app(manager))
+
+    with client.websocket_connect("/ws/session/voice") as ws:
+        assert ws.receive_json()["type"] == "ready"
+        ws.send_json(
+            {
+                "type": "user_message",
+                "text": "check the brake build",
+                "input_mode": "voice_discussion",
+            }
+        )
+        turn_start = None
+        while True:
+            event = ws.receive_json()
+            if event["type"] == "turn_start":
+                turn_start = event
+            if event["type"] == "turn_done":
+                break
+
+    assert turn_start is not None
+    assert turn_start["data"]["input_mode"] == "voice_discussion"
+
+    messages = client.get("/v1/sessions/voice/messages").json()["messages"]
+    user_message = [m for m in messages if m.get("role") == "user"][-1]
+    assert user_message["input_mode"] == "voice_discussion"
+    assert user_message["content"] == "check the brake build"
+
+    provider_user = [
+        m for m in provider.calls[0] if m.get("role") == "user"
+    ][-1]
+    assert "input_mode" not in provider_user
+    assert "<system-context>" in provider_user["content"]
+    assert "voice discussion turn" in provider_user["content"]
+
+
 def test_ws_rejects_oversized_message(tmp_path):
     from coworker.server import app as app_mod
     from coworker.attachments import MAX_ATTACHMENTS
@@ -372,6 +412,7 @@ def test_ws_rejects_malformed_payloads_without_killing_socket(tmp_path):
                 "attachments": [{"kind": "image", "data_url": "https://example.com/x"}],
             },
             {"type": "set_model", "model": {"unexpected": True}},
+            {"type": "user_message", "text": "x", "input_mode": "untrusted"},
             {"type": "unknown"},
         ]
         for payload in invalid:


### PR DESCRIPTION
- Add one voice control for browser and Tauri with editable Dictation and auto-submit Voice discussion.
- Keep browser-managed transcription explicit, desktop Whisper local, and trusted voice metadata available for concise replies.
- Bind capture to its originating conversation, preserve the transcript as a draft when auto-send becomes unsafe, and surface late recognition failures.
- Checks: 79 GUI tests, 879 backend tests with 1 skipped, production build, local browser walkthrough, and `git diff --check`.

<img width="1920" height="1080" alt="OpenWorker browser and desktop voice input reviewer walkthrough" src="https://github.com/user-attachments/assets/47b07ebc-4d77-4579-a53c-fb9e4cb45257" />
