### PR TITLE
Prevent IME confirmation from opening search results

### DIFF
--- a/surfaces/gui/src/components/SearchModal.test.tsx
+++ b/surfaces/gui/src/components/SearchModal.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { SessionInfo } from "../types";
+import { SearchModal } from "./SearchModal";
+
+const sessions: SessionInfo[] = [
+  {
+    session_id: "s1",
+    title: "Beijing launch notes",
+    workspace: "",
+    agent: "chat",
+    model: "gpt-5.6-sol",
+    mode: "interactive",
+    updated_at: "2026-07-25T10:00:00Z",
+    messages: 2,
+  },
+];
+
+afterEach(cleanup);
+
+describe("SearchModal keyboard selection", () => {
+  it("does not open a chat when Enter confirms an active IME composition", () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(<SearchModal sessions={sessions} onSelect={onSelect} onClose={onClose} />);
+
+    const input = screen.getByPlaceholderText("Search chats");
+    fireEvent.change(input, { target: { value: "北京" } });
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+    fireEvent.keyDown(input, { key: "Enter", keyCode: 229 });
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect((input as HTMLInputElement).value).toBe("北京");
+  });
+
+  it("still opens the highlighted chat on a normal Enter", () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(<SearchModal sessions={sessions} onSelect={onSelect} onClose={onClose} />);
+
+    fireEvent.keyDown(screen.getByPlaceholderText("Search chats"), { key: "Enter" });
+
+    expect(onSelect).toHaveBeenCalledWith("s1", "", "chat");
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/surfaces/gui/src/components/SearchModal.tsx
+++ b/surfaces/gui/src/components/SearchModal.tsx
@@ -63,6 +63,10 @@ export function SearchModal({
   };
 
   const onKey = (e: React.KeyboardEvent) => {
+    // Enter confirms the highlighted candidate while a CJK IME is composing. Let the input
+    // method handle that keystroke instead of opening the highlighted chat and closing search.
+    // keyCode 229 covers older WebKit and Windows IMEs that report "being processed".
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
     if (e.key === "Escape") {
       e.preventDefault();
       onClose();


### PR DESCRIPTION
- Fix a bug where confirming CJK IME text with Enter prematurely opens the highlighted search result
- Ignore Enter while a CJK IME is composing, including legacy `keyCode 229` events
- Preserve normal Enter selection for the highlighted chat
- Checks: 70 frontend tests pass; `npm run build` passes

### UI evidence
<img width="1280" height="720" alt="search-modal-ime-annotated" src="https://github.com/user-attachments/assets/a39e335c-069c-4016-b284-bff5f55adee5" />
