### PR TITLE
fix: handle Windows drive-letter paths in grep (ripgrep) output

### DIFF
--- a/coworker/tools/search.py
+++ b/coworker/tools/search.py
@@ -91,6 +91,14 @@ def search_tools(workspace: str) -> list:
                 "--line-number",
                 "--no-heading",
                 "--color=never",
+                # Always print the filename (even for a single-file target) and
+                # NUL-separate it from `line:text`, so parsing never has to guess
+                # where the path ends — a Windows drive-letter colon (C:\ws\a.py),
+                # or a colon inside the matched text, would otherwise be taken as a
+                # field separator (issue #17). Without --with-filename a single-file
+                # search emits no path and no NUL, and the parser would drop it.
+                "--with-filename",
+                "--null",
                 "--max-count",
                 str(n),
                 "-e",
@@ -135,18 +143,23 @@ def _rel(path: str, root: Path) -> str:
 
 
 def _parse_rg(stdout: str, root: Path, n: int) -> dict[str, Any]:
+    # `rg --null` emits each match as `<path>\0<line>:<text>`. Splitting the path off
+    # on the NUL byte first means the colon inside a Windows drive letter (C:\...) is
+    # never confused with the line/text separators — the old `split(":", 2)` parsed
+    # `C:\ws\a.py:12:def f()` as file="C", line="\ws\a.py", text="12:def f()".
     matches: list[dict[str, Any]] = []
     for line in stdout.splitlines():
-        parts = line.split(":", 2)
-        if len(parts) == 3:
-            f, ln, txt = parts
-            matches.append(
-                {
-                    "file": _rel(f, root),
-                    "line": int(ln) if ln.isdigit() else 0,
-                    "text": txt[:300],
-                }
-            )
+        path, sep, rest = line.partition("\0")
+        if not sep:
+            continue
+        ln, _, txt = rest.partition(":")
+        matches.append(
+            {
+                "file": _rel(path, root),
+                "line": int(ln) if ln.isdigit() else 0,
+                "text": txt[:300],
+            }
+        )
         if len(matches) >= n:
             break
     return {"count": len(matches), "matches": matches}

--- a/tests/test_code_tools.py
+++ b/tests/test_code_tools.py
@@ -13,7 +13,7 @@ import pytest
 
 from coworker.tools.files import file_tools
 from coworker.tools.git import git_tools
-from coworker.tools.search import _py_grep, search_tools
+from coworker.tools.search import _parse_rg, _py_grep, search_tools
 from coworker.web.fetch import _html_to_text, make_web_fetch_tool
 
 
@@ -39,6 +39,24 @@ def test_grep_finds_matches_and_respects_glob(tmp_path):
     assert all(m["file"].endswith(".py") for m in only_py["matches"])
     assert not any("node_modules" in m["file"] for m in only_py["matches"])
     assert only_py["matches"][0]["line"] == 1
+
+
+def test_parse_rg_handles_windows_drive_letter_paths():
+    # `rg --null` emits `<path>\0<line>:<text>`. A Windows absolute path leads with a
+    # drive-letter colon (C:\...); the old `split(":", 2)` mis-parsed it as file="C",
+    # line=0, text="12:...". Regression for issue #17 — asserts hold on every platform.
+    from pathlib import Path
+
+    stdout = "C:\\ws\\a.py\x0012:def hello():\n"
+    out = _parse_rg(stdout, Path("C:\\ws"), 100)
+    assert out["count"] == 1
+    m = out["matches"][0]
+    assert m["line"] == 12
+    assert m["text"] == "def hello():"
+    # the whole path survives (not truncated to the drive letter "C"); .endswith
+    # stays platform-independent — on Linux _rel can't relativize a `C:\` path, so it
+    # returns the raw string, which still ends with the filename.
+    assert m["file"].endswith("a.py")
 
 
 def test_ripgrep_uses_the_same_ignored_dirs_as_the_python_fallback(tmp_path, monkeypatch):


### PR DESCRIPTION
**Issue:**  https://github.com/andrewyng/openworker/issues/17

## What

Fixes `grep` returning corrupted results on Windows when ripgrep (`rg`) is on `PATH`. Closes #17.

## Root cause

`_parse_rg` parsed ripgrep output with `line.split(":", 2)`. The search path is absolute, and on Windows an absolute path starts with a drive letter, so:

```
C:\ws\a.py:12:def hello()
```

split into `["C", "\\ws\\a.py", "12:def hello()"]` — every match was reported as file `C`, line `0`, with the real line number swallowed into the matched text. Linux/macOS never hit this (no drive-letter colon), and CI doesn't either: it has no `rg`, so it uses the pure-Python fallback (`_py_grep`), which was already correct.

## Fix

Pass `--with-filename --null` so ripgrep always prints the path and NUL-separates it from `line:text`, then split the path off on the NUL byte — a byte that can't appear in a path — before parsing line/text. `--null` defeats the drive-letter colon; `--with-filename` keeps the format universal so a single-file target isn't silently dropped (see note). Portable: harmless on Linux/macOS, correct everywhere. No new dependencies.

## Tests

- The existing `test_grep_finds_matches_and_respects_glob` now passes on Windows-with-`rg` (it was the reproducer for this bug).
- New `test_parse_rg_handles_windows_drive_letter_paths` feeds a NUL-delimited drive-letter line straight through `_parse_rg`, so it runs on **every** platform (CI is Linux-without-`rg`, which otherwise never exercises this code path). I confirmed it fails against the old parser, so it's a real regression guard.

### Before / after (Windows 11, ripgrep 15.1.0)

```
$ pytest tests/test_code_tools.py::test_grep_finds_matches_and_respects_glob -q
>       assert "a.py" in files and "b.txt" in files
E       AssertionError: assert ('a.py' in {'C'})
1 failed in 1.81s
```

```
$ pytest tests/test_code_tools.py -q
...............                                          [100%]
15 passed in 1.69s
```

_(Terminal screenshot of the same before/after run attached in the comments.)_

## Notes

- `--with-filename` also removes a pre-existing silent-drop: when `path` names a single file (outside the documented "subdirectory" usage), ripgrep previously emitted no filename, so the parser returned `count=0` with no error. The pure-Python fallback (`_py_grep`) still doesn't support single-file targets (`os.walk` on a file yields nothing) — out of scope here and worth a separate issue if single-file search should be supported.
- Scope is otherwise limited to the ripgrep parser.
- Running the full suite on Windows surfaces 7 unrelated, pre-existing failures (slack-relay socket timeouts, a shell-cwd test, a curated-models assertion). I verified they fail identically on `main` without this change, so they're not introduced here.
