### PR TITLE
Show release notes + current version in the update UI

### DIFF
--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -495,6 +495,14 @@ struct UpdateInfo {
     notes: String,
 }
 
+/// The version currently running — the baseline the update check compares against.
+/// Read from the bundle metadata (tauri.conf.json `version`) so the "you're on vX"
+/// line and the check can never drift apart.
+#[tauri::command]
+fn app_version(app: tauri::AppHandle) -> String {
+    app.package_info().version.to_string()
+}
+
 #[tauri::command]
 async fn check_for_update(app: tauri::AppHandle) -> Result<Option<UpdateInfo>, String> {
     use tauri_plugin_updater::UpdaterExt;
@@ -619,6 +627,7 @@ pub fn run() {
             mark_dictation_test_passed,
             delete_dictation_model,
             dictation_level,
+            app_version,
             check_for_update,
             download_update,
             clear_pending_update,

--- a/surfaces/gui/src/components/SettingsView.tsx
+++ b/surfaces/gui/src/components/SettingsView.tsx
@@ -18,6 +18,7 @@ import {
   getAutostart,
   getDictationStatus,
   getKeepAwake,
+  appVersion,
   checkForUpdate,
   installUpdate,
   isTauri,
@@ -31,6 +32,7 @@ import {
   verifyDictationModel,
   type DictationDownloadProgress,
   type DictationStatus,
+  type UpdateInfo,
 } from "../tauri";
 import { useThemePref } from "../theme";
 import { Icon } from "./Icon";
@@ -458,9 +460,9 @@ function AppearanceSection() {
           <button className={BTN_BORDERED} onClick={runSetupAgain}>
             Run setup again
           </button>
-          {desktop && <UpdateInline />}
         </div>
         <div className={FIELD_HELP}>Replays the first-run setup: model, first automation, tips.</div>
+        {desktop && <UpdateInline />}
       </div>
     </section>
   );
@@ -521,16 +523,28 @@ function TrustedWorkspacesCard() {
   );
 }
 
+// The manual update control (desktop only). The app also checks on its own — see
+// UpdateBanner — but this lets the user check on demand, see the version they're on,
+// and, when a release is offered, read exactly what it contains (the changelog the
+// release manifest ships) before choosing to install.
 function UpdateInline() {
   const [state, setState] = useState<"idle" | "checking" | "none" | "found" | "installing" | "error">("idle");
-  const [version, setVersion] = useState("");
+  const [update, setUpdate] = useState<UpdateInfo | null>(null);
+  const [current, setCurrent] = useState("");
+
+  // The version we're running now — the baseline "you're on vX" line.
+  useEffect(() => {
+    appVersion()
+      .then((v) => v && setCurrent(v))
+      .catch(() => {});
+  }, []);
 
   const check = async () => {
     setState("checking");
     try {
       const u = await checkForUpdate();
       if (u) {
-        setVersion(u.version);
+        setUpdate(u);
         setState("found");
       } else {
         setState("none");
@@ -549,32 +563,65 @@ function UpdateInline() {
     }
   };
 
+  const notes = update?.notes.trim() ?? "";
+
   return (
-    <span className="inline-flex items-center gap-2.5">
-      {state === "found" ? (
-        <button className={BTN_BORDERED} onClick={install} data-testid="settings-update-install">
-          Update to v{version} and restart
-        </button>
-      ) : (
-        <button
-          className={BTN_BORDERED}
-          onClick={check}
-          disabled={state === "checking" || state === "installing"}
-          data-testid="settings-update-check"
-        >
-          {state === "checking" ? "Checking…" : "Check for updates"}
-        </button>
+    <div className="mt-4 pt-4 border-t border-line" data-testid="settings-update">
+      <div className={FIELD_LABEL}>Software updates</div>
+      {current && (
+        <div className="text-[12px] text-muted mt-1" data-testid="settings-update-current">
+          You're on OpenWorker v{current}.
+        </div>
       )}
-      {(state === "none" || state === "error" || state === "installing") && (
-        <span className="text-[12px] text-muted">
-          {state === "none"
-            ? "You're on the latest version."
-            : state === "error"
-              ? "Couldn't check right now — try again later."
-              : "Downloading — OpenWorker restarts by itself when it's ready."}
-        </span>
+      <div className="flex items-center gap-2.5 mt-2.5">
+        {state === "found" && update ? (
+          <button className={BTN_BORDERED} onClick={install} data-testid="settings-update-install">
+            Update to v{update.version} and restart
+          </button>
+        ) : (
+          <button
+            className={BTN_BORDERED}
+            onClick={check}
+            disabled={state === "checking" || state === "installing"}
+            data-testid="settings-update-check"
+          >
+            {state === "checking" ? "Checking…" : "Check for updates"}
+          </button>
+        )}
+        {(state === "none" || state === "error" || state === "installing") && (
+          <span className="text-[12px] text-muted">
+            {state === "none"
+              ? "You're on the latest version."
+              : state === "error"
+                ? "Couldn't check right now — try again later."
+                : "Downloading — OpenWorker restarts by itself when it's ready."}
+          </span>
+        )}
+      </div>
+      {state === "found" && update && (
+        <div className="mt-3" data-testid="settings-update-notes">
+          <div className="text-[12px] font-medium text-ink">What's new in v{update.version}</div>
+          {notes ? (
+            <div className="mt-1.5 max-h-48 overflow-auto rounded-lg border border-line bg-paper px-3 py-2 text-[12px] text-muted whitespace-pre-wrap leading-relaxed">
+              {notes}
+            </div>
+          ) : (
+            <div className="text-[12px] text-muted mt-1">
+              This release doesn't list detailed notes — see it on{" "}
+              <a
+                className="text-accent hover:underline"
+                href="https://github.com/andrewyng/openworker/releases/latest"
+                target="_blank"
+                rel="noreferrer"
+              >
+                GitHub Releases
+              </a>
+              .
+            </div>
+          )}
+        </div>
       )}
-    </span>
+    </div>
   );
 }
 

--- a/surfaces/gui/src/components/UpdateBanner.test.tsx
+++ b/surfaces/gui/src/components/UpdateBanner.test.tsx
@@ -46,6 +46,22 @@ describe("UpdateBanner", () => {
     expect(btn.disabled).toBe(false);
   });
 
+  it("renders the release notes (what the update contains) when present", async () => {
+    available = { version: "1.2.0", notes: "- Faster startup\n- Fixed calendar sync" };
+    render(<UpdateBanner />);
+    await advance(FIRST_CHECK_MS);
+    expect(screen.getByTestId("update-notes").textContent).toContain("Faster startup");
+    expect(screen.getByTestId("update-notes").textContent).toContain("Fixed calendar sync");
+  });
+
+  it("omits the notes block when the release ships no notes", async () => {
+    available = { version: "1.2.0", notes: "" };
+    render(<UpdateBanner />);
+    await advance(FIRST_CHECK_MS);
+    expect(screen.getByTestId("update-banner")).toBeTruthy();
+    expect(screen.queryByTestId("update-notes")).toBeNull();
+  });
+
   it("Later hides the banner and a same-version re-check keeps it hidden", async () => {
     render(<UpdateBanner />);
     await advance(FIRST_CHECK_MS);

--- a/surfaces/gui/src/components/UpdateBanner.tsx
+++ b/surfaces/gui/src/components/UpdateBanner.tsx
@@ -92,6 +92,16 @@ export function UpdateBanner() {
       <div className="text-[12px] text-muted mt-0.5">
         OpenWorker v{update.version} is ready to install.
       </div>
+      {update.notes.trim() && (
+        // What the update contains (the release's changelog). Scrolls rather than
+        // pushing the buttons off-screen when a release ships a long note.
+        <div
+          className="mt-2 max-h-28 overflow-auto rounded-lg border border-line bg-paper px-2.5 py-2 text-[11.5px] text-muted whitespace-pre-wrap leading-relaxed"
+          data-testid="update-notes"
+        >
+          {update.notes.trim()}
+        </div>
+      )}
       {phase === "error" && (
         <div className="text-[11.5px] text-warnInk mt-1.5">
           The update couldn't be installed — it will be offered again next launch.

--- a/surfaces/gui/src/tauri.ts
+++ b/surfaces/gui/src/tauri.ts
@@ -106,8 +106,13 @@ export async function listenDictationDownloadProgress(
 
 export type UpdateInfo = { version: string; notes: string };
 
+/** The version currently installed — the baseline shown next to the update check
+ * ("You're on OpenWorker vX"). null in the browser build. */
+export const appVersion = () => invoke<string | null>("app_version");
+
 /** Ask the shell whether a newer release exists (verified manifest; see lib.rs).
- * null = up to date, unreachable endpoint, or not the desktop app. */
+ * null = up to date, unreachable endpoint, or not the desktop app.
+ * The returned `notes` are the release's changelog — what the update contains. */
 export const checkForUpdate = () => invoke<UpdateInfo | null>("check_for_update");
 
 /** Pre-fetch + verify the update bytes in the background so the install is instant.


### PR DESCRIPTION
## What & why

The desktop updater already checked for and installed releases, but it never surfaced **what a new version contains**, and there was no clear "which version am I on" baseline. The release changelog (`notes`) was fetched from the update manifest and then discarded in both update surfaces.

This PR closes that gap.

## Changes

- **`app_version` command + `appVersion()` binding** — exposes the currently-running version to the UI.
- **Settings → "Setup & updates"** — the manual update control now:
  - shows **"You're on OpenWorker vX.Y.Z"** as a baseline,
  - reports up-to-date vs. update-available on demand,
  - renders a scrollable **"What's new in vX"** section with the release changelog when an update is offered, falling back to a GitHub Releases link when a release ships no notes.
- **Auto-update banner** — now renders the release notes inline so the user can see what's in the update before clicking "Restart to update".

These surfaces render only in the desktop (Tauri) build; the browser dev shell is unaffected by design.

## Testing

- Added `UpdateBanner` tests for notes-present and notes-absent cases.
- All update-related unit tests pass; `tsc --noEmit` is clean; `cargo check` passes.
- Note: pre-existing `Sidebar.test.tsx` failures are unrelated to this change (they fail identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)