### PR TITLE
Add Makefile for dev setup, server/GUI launch, and testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,84 @@
+# OpenWorker Makefile
+# Convenience tasks for local setup, development, testing, and packaging.
+
+.PHONY: help setup setup-gui setup-all server gui desktop test test-gui e2e test-all dmg clean check-python check-node check-venv
+
+PORT ?= 8765
+CWD ?= .
+VENV ?= .venv
+PYTHON ?= $(VENV)/bin/python
+SERVER ?= $(VENV)/bin/openworker-server
+PYTEST ?= $(VENV)/bin/pytest
+GUI_DIR ?= surfaces/gui
+
+## help: Display available Makefile targets
+help:
+	@echo "OpenWorker Development Commands:"
+	@echo ""
+	@sed -n 's/^## //p' $(MAKEFILE_LIST) | column -t -s ':' | sed 's/^/  /'
+
+## check-python: Check if python3 is installed
+check-python:
+	@command -v python3 >/dev/null 2>&1 || { echo "Error: python3 is required but not installed." >&2; exit 1; }
+
+## check-node: Check if node and npm are installed
+check-node:
+	@command -v node >/dev/null 2>&1 || { echo "Error: node is required but not installed." >&2; exit 1; }
+	@command -v npm >/dev/null 2>&1 || { echo "Error: npm is required but not installed." >&2; exit 1; }
+
+## check-venv: Check if Python virtual environment exists
+check-venv:
+	@if [ ! -d "$(VENV)" ]; then \
+		echo "Error: $(VENV) directory not found. Please run 'make setup' first." >&2; \
+		exit 1; \
+	fi
+
+## setup: One-time Python backend venv setup
+setup: check-python
+	@bash packaging/setup_dev_env.sh
+
+## setup-gui: One-time GUI npm dependencies installation
+setup-gui: check-node
+	@cd $(GUI_DIR) && npm install
+
+## setup-all: Run both backend setup and GUI setup
+setup-all: setup setup-gui
+
+## server: Start the local agent server (use CWD=/path PORT=8765 to override)
+server: check-venv
+	@$(SERVER) --cwd $(CWD) --port $(PORT)
+
+## gui: Start the React/Vite web UI in dev mode
+gui: check-node
+	@cd $(GUI_DIR) && npm run dev
+
+## desktop: Start the desktop app using Tauri dev
+desktop: check-node
+	@cd $(GUI_DIR) && npm run tauri dev
+
+## test: Run Python backend test suite
+test: check-venv
+	@$(PYTEST) tests -q
+
+## test-gui: Run GUI unit tests (vitest)
+test-gui: check-node
+	@cd $(GUI_DIR) && npm test
+
+## e2e: Run Playwright end-to-end tests
+e2e: check-node
+	@cd $(GUI_DIR) && npm run e2e
+
+## test-all: Run all tests (backend, GUI unit, and e2e)
+test-all: test test-gui e2e
+
+## dmg: Build macOS DMG package (macOS only)
+dmg:
+	@bash packaging/build_dmg.sh
+
+## clean: Remove virtualenv, node_modules, build artifacts, and caches
+clean:
+	@rm -rf $(VENV)
+	@rm -rf $(GUI_DIR)/node_modules $(GUI_DIR)/dist $(GUI_DIR)/src-tauri/target
+	@find . -type d -name "__pycache__" -exec rm -rf {} +
+	@find . -type d -name ".pytest_cache" -exec rm -rf {} +
+	@echo "Cleaned build artifacts, venv, and caches."

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ gui: check-node
 
 ## desktop: Start the desktop app using Tauri dev
 desktop: check-node check-rust check-venv
+	@mkdir -p $(GUI_DIR)/src-tauri/binaries/sidecar
 	@cd $(GUI_DIR) && npm run tauri dev
 
 ## test: Run Python backend test suite

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # OpenWorker Makefile
 # Convenience tasks for local setup, development, testing, and packaging.
 
-.PHONY: help setup setup-gui setup-all server gui desktop test test-gui e2e test-all dmg clean check-python check-node check-venv
+.PHONY: help setup setup-gui setup-all server gui desktop test test-gui e2e test-all dmg clean check-python check-node check-rust check-venv
 
 PORT ?= 8765
 CWD ?= .
@@ -25,6 +25,10 @@ check-python:
 check-node:
 	@command -v node >/dev/null 2>&1 || { echo "Error: node is required but not installed." >&2; exit 1; }
 	@command -v npm >/dev/null 2>&1 || { echo "Error: npm is required but not installed." >&2; exit 1; }
+
+## check-rust: Check if Rust/cargo is installed
+check-rust:
+	@command -v cargo >/dev/null 2>&1 || { echo "Error: Rust toolchain (cargo) is required but not installed. Install via https://rustup.rs" >&2; exit 1; }
 
 ## check-venv: Check if Python virtual environment exists
 check-venv:
@@ -53,7 +57,7 @@ gui: check-node
 	@cd $(GUI_DIR) && npm run dev
 
 ## desktop: Start the desktop app using Tauri dev
-desktop: check-node
+desktop: check-node check-rust check-venv
 	@cd $(GUI_DIR) && npm run tauri dev
 
 ## test: Run Python backend test suite
@@ -72,7 +76,7 @@ e2e: check-node
 test-all: test test-gui e2e
 
 ## dmg: Build macOS DMG package (macOS only)
-dmg:
+dmg: check-rust
 	@bash packaging/build_dmg.sh
 
 ## clean: Remove virtualenv, node_modules, build artifacts, and caches

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ OpenWorker is local-first. Everything lives on your machine: the agent loop, you
 
 Prerequisites: Python 3.10+, Node 20+, and (for the desktop shell) the Rust toolchain via [rustup](https://rustup.rs/).
 
+> **Quickstart with `make`**: Run `make setup-all` to set up both backend and GUI, then `make server` in one terminal and `make gui` (or `make desktop`) in another. Run `make help` to see all available targets.
+
 ```shell
 git clone https://github.com/andrewyng/openworker
 cd openworker
@@ -89,7 +91,7 @@ desktop app uses an in-memory launch token instead and never writes it to disk.
 
 To run the full desktop app instead of the browser UI, replace step 3 with `npm run tauri dev` (from `surfaces/gui/`) - the Tauri shell launches the window and supervises the server itself.
 
-Tests: `.venv/bin/pytest` (server), `npm test` and `npm run e2e` in `surfaces/gui` (GUI unit + hermetic end-to-end). Desktop bundles are built with `packaging/build_dmg.sh` / `packaging/build_windows.ps1`.
+Tests: `make test` (or `.venv/bin/pytest`), `make test-gui` (`npm test`), and `make e2e` (`npm run e2e` in `surfaces/gui`). Run `make test-all` for the full suite. Desktop bundles are built with `make dmg` (or `packaging/build_dmg.sh` / `packaging/build_windows.ps1`).
 
 ## Repository layout
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ OpenWorker is local-first. Everything lives on your machine: the agent loop, you
 
 Prerequisites: Python 3.10+, Node 20+, and (for the desktop shell) the Rust toolchain via [rustup](https://rustup.rs/).
 
-> **Quickstart with `make`**: Run `make setup-all` to set up both backend and GUI, then `make server` in one terminal and `make gui` (or `make desktop`) in another. Run `make help` to see all available targets.
+> **Quickstart with `make`** (macOS, Linux, WSL): Run `make setup-all` to set up both backend and GUI, then `make server` in one terminal and `make gui` (or `make desktop`) in another. Run `make help` to see all available targets. On native Windows (PowerShell/cmd), use the step-by-step commands below.
 
 ```shell
 git clone https://github.com/andrewyng/openworker


### PR DESCRIPTION
Closes #128
Related to #131

### Summary
Adds a root `Makefile` and updates `README.md` to streamline local development, testing, and setup workflows for OpenWorker.

### Changes
1. **Added `Makefile` at repository root**:
   - `make setup` / `make setup-gui` / `make setup-all`: One-time dev environment bootstrap
   - `make server` / `make gui` / `make desktop`: Start server or UI dev environments (with `make desktop` defensively creating `surfaces/gui/src-tauri/binaries/sidecar` to prevent Tauri dev build errors reported in #131)
   - `make test` / `make test-gui` / `make e2e` / `make test-all`: Run backend, GUI unit, and Playwright E2E test suites
   - `make dmg`: Build macOS DMG installer
   - `make clean`: Remove `.venv`, `node_modules`, build artifacts, and pytest/python caches
   - `make help`: Self-documenting target listing
   - Includes pre-flight checks (`check-python`, `check-node`, `check-rust`, `check-venv`) that output clear error messages if prerequisites or `.venv` are missing.

2. **Updated `README.md`**:
   - Added a "Quickstart with `make`" callout (specifying support for macOS, Linux, and WSL, while noting native Windows users can use the step-by-step commands below).
   - Updated the testing section with `make` command alternatives.

### Verification
- Tested `make help` (formatted output).
- Tested `make check-venv` (error handling when `.venv` is missing).
- Tested `make check-rust` (validating Rust/cargo presence).
- Tested `make setup` (successfully created `.venv` and installed dependencies).
- Tested `make setup-gui` (successfully ran `npm install`).
- Tested `make test` (889 backend tests passed).
- Tested `make test-gui` (68 GUI unit tests passed).
- Tested `make desktop` (successfully compiled and launched the desktop app with the sidecar server).