### PR TITLE
Add live-follow side sessions

### DIFF
--- a/coworker/agent.py
+++ b/coworker/agent.py
@@ -7,7 +7,7 @@ the skill catalog (progressive disclosure) + load_skill into a TurnEngine.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from .agents import Agent, AgentContext, code_agent
 from .automation import scheduling_tools
@@ -119,6 +119,9 @@ def build_engine(
     model_settings: Optional[dict[str, Any]] = None,
     memory_store: Optional[MemoryStore] = None,
     messages: Optional[list[dict[str, Any]]] = None,
+    inherited_messages_provider: Optional[
+        Callable[[], list[dict[str, Any]]]
+    ] = None,
     extra_tools: Optional[list[Any]] = None,
     secrets: Optional[SecretStore] = None,
     task_store: Optional[Any] = None,
@@ -320,6 +323,7 @@ def build_engine(
         ),
         model_settings=model_settings,
         messages=messages,
+        inherited_messages_provider=inherited_messages_provider,
         audit_sink=audit_sink,
         context_provider=context_provider,
         directory_requester=directory_requester,

--- a/coworker/conversations.py
+++ b/coworker/conversations.py
@@ -17,7 +17,7 @@ import threading
 from pathlib import Path
 from typing import Optional
 
-from .sessions import SessionRecord
+from .sessions import SessionBranch, SessionRecord
 
 
 def _load_roots(raw: Optional[str]) -> list[dict]:
@@ -74,6 +74,7 @@ class ConversationStore:
             CREATE TABLE IF NOT EXISTS sessions (
                 session_id TEXT PRIMARY KEY, workspace TEXT, model TEXT, mode TEXT,
                 title TEXT, agent TEXT DEFAULT 'code', n_msgs INTEGER DEFAULT 0, messages TEXT,
+                committed_n_msgs INTEGER DEFAULT 0,
                 extra_roots TEXT, pinned INTEGER DEFAULT 0, archived INTEGER DEFAULT 0,
                 origin TEXT, origin_label TEXT,
                 auto_title TEXT, renamed INTEGER DEFAULT 0,
@@ -82,7 +83,21 @@ class ConversationStore:
             CREATE TABLE IF NOT EXISTS workspaces (
                 path TEXT PRIMARY KEY, last_used TEXT DEFAULT CURRENT_TIMESTAMP
             );
+            CREATE TABLE IF NOT EXISTS session_branches (
+                child_session_id TEXT PRIMARY KEY,
+                parent_session_id TEXT NOT NULL,
+                mode TEXT NOT NULL DEFAULT 'follow',
+                base_message_count INTEGER NOT NULL DEFAULT 0,
+                state TEXT NOT NULL DEFAULT 'active',
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                merged_at TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_session_branches_parent
+                ON session_branches(parent_session_id);
             """)
+        columns_before_migration = {
+            row["name"] for row in self._conn.execute("PRAGMA table_info(sessions)")
+        }
         for ddl in (
             "ALTER TABLE sessions ADD COLUMN title TEXT",
             "ALTER TABLE sessions ADD COLUMN n_msgs INTEGER DEFAULT 0",
@@ -95,6 +110,7 @@ class ConversationStore:
             "ALTER TABLE sessions ADD COLUMN auto_title TEXT",
             "ALTER TABLE sessions ADD COLUMN renamed INTEGER DEFAULT 0",
             "ALTER TABLE sessions ADD COLUMN grants TEXT",
+            "ALTER TABLE sessions ADD COLUMN committed_n_msgs INTEGER DEFAULT 0",
         ):
             try:
                 self._conn.execute(ddl)
@@ -102,6 +118,14 @@ class ConversationStore:
                 pass
         self._conn.commit()
         self._backfill_counts()
+        if "committed_n_msgs" not in columns_before_migration:
+            # Sessions from versions before side chats were last saved at complete
+            # turn boundaries in normal operation. Run after the legacy inline-message
+            # migration above so its repaired ``n_msgs`` value is available.
+            self._conn.execute(
+                "UPDATE sessions SET committed_n_msgs = COALESCE(n_msgs, 0)"
+            )
+            self._conn.commit()
 
     # -- file helpers -----------------------------------------------------------
     def _file(self, sid: str) -> Path:
@@ -164,7 +188,7 @@ class ConversationStore:
             self._conn.commit()
 
     # -- API --------------------------------------------------------------------
-    def save(self, record: SessionRecord) -> None:
+    def save(self, record: SessionRecord, *, committed: bool = True) -> None:
         sid = record.session_id
         with self._lock:
             # lazily migrate a legacy inline blob into the .jsonl
@@ -191,12 +215,19 @@ class ConversationStore:
             title = record.title or title_from(record.messages)
             self._conn.execute(
                 """
-                INSERT INTO sessions (session_id, workspace, model, mode, title, agent, n_msgs, messages, extra_roots, grants, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, CURRENT_TIMESTAMP)
+                INSERT INTO sessions (
+                    session_id, workspace, model, mode, title, agent, n_msgs,
+                    committed_n_msgs, messages, extra_roots, grants, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, CURRENT_TIMESTAMP)
                 ON CONFLICT(session_id) DO UPDATE SET
                     workspace = excluded.workspace, model = excluded.model, mode = excluded.mode,
                     title = COALESCE(sessions.title, excluded.title), agent = excluded.agent,
                     n_msgs = excluded.n_msgs, messages = NULL, extra_roots = excluded.extra_roots,
+                    committed_n_msgs = CASE
+                        WHEN ? THEN excluded.n_msgs
+                        ELSE sessions.committed_n_msgs
+                    END,
                     grants = excluded.grants, updated_at = CURRENT_TIMESTAMP
                 """,
                 (
@@ -207,8 +238,10 @@ class ConversationStore:
                     title,
                     record.agent,
                     len(record.messages),
+                    len(record.messages) if committed else 0,
                     json.dumps(record.extra_roots or []),
                     json.dumps(record.grants or {}),
+                    1 if committed else 0,
                 ),
             )
             self._conn.commit()
@@ -236,6 +269,9 @@ class ConversationStore:
             title=_display_title(row),
             agent=row["agent"] or "code",
             message_count=len(messages),
+            committed_message_count=min(
+                len(messages), int(row["committed_n_msgs"] or 0)
+            ),
             updated_at=row["updated_at"],
             extra_roots=_load_roots(
                 row["extra_roots"] if "extra_roots" in row.keys() else None
@@ -278,6 +314,9 @@ class ConversationStore:
                 title=_display_title(r),
                 agent=r["agent"] or "code",
                 message_count=r["n_msgs"] or 0,
+                committed_message_count=min(
+                    int(r["n_msgs"] or 0), int(r["committed_n_msgs"] or 0)
+                ),
                 updated_at=r["updated_at"],
                 pinned=bool(r["pinned"]),
                 archived=bool(r["archived"]),
@@ -286,6 +325,13 @@ class ConversationStore:
             )
             for r in rows
         ]
+
+    def committed_messages(self, session_id: str) -> list[dict]:
+        """Return only the last fully completed provider-safe transcript prefix."""
+        record = self.load(session_id)
+        if record is None:
+            return []
+        return record.messages[: record.committed_message_count]
 
     def touch_workspace(self, path: str) -> None:
         with self._lock:
@@ -331,6 +377,10 @@ class ConversationStore:
 
     def delete(self, session_id: str) -> bool:
         with self._lock:
+            self._conn.execute(
+                "DELETE FROM session_branches WHERE child_session_id = ?",
+                (session_id,),
+            )
             cur = self._conn.execute(
                 "DELETE FROM sessions WHERE session_id = ?", (session_id,)
             )
@@ -339,6 +389,104 @@ class ConversationStore:
         if path.exists():
             path.unlink()
         return cur.rowcount > 0
+
+    # -- live-follow side sessions ---------------------------------------------
+    def create_branch(
+        self,
+        child_session_id: str,
+        parent_session_id: str,
+        *,
+        mode: str = "follow",
+        base_message_count: Optional[int] = None,
+    ) -> SessionBranch:
+        """Relate an existing child session to an existing parent.
+
+        Branch creation is intentionally separate from ``save`` so normal per-turn
+        session persistence cannot accidentally rewrite ancestry.
+        """
+        if mode != "follow":
+            raise ValueError("only follow-mode side sessions are currently supported")
+        if child_session_id == parent_session_id:
+            raise ValueError("a session cannot branch from itself")
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT session_id, n_msgs FROM sessions WHERE session_id IN (?, ?)",
+                (child_session_id, parent_session_id),
+            ).fetchall()
+            by_id = {row["session_id"]: row for row in rows}
+            if parent_session_id not in by_id:
+                raise KeyError(f"parent session not found: {parent_session_id}")
+            if child_session_id not in by_id:
+                raise KeyError(f"child session not found: {child_session_id}")
+            base = (
+                int(base_message_count)
+                if base_message_count is not None
+                else int(by_id[parent_session_id]["n_msgs"] or 0)
+            )
+            self._conn.execute(
+                """
+                INSERT INTO session_branches (
+                    child_session_id, parent_session_id, mode, base_message_count
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (child_session_id, parent_session_id, mode, max(0, base)),
+            )
+            self._conn.commit()
+        branch = self.branch_for(child_session_id)
+        assert branch is not None
+        return branch
+
+    def branch_for(self, child_session_id: str) -> Optional[SessionBranch]:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM session_branches WHERE child_session_id = ?",
+                (child_session_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return SessionBranch(
+            child_session_id=row["child_session_id"],
+            parent_session_id=row["parent_session_id"],
+            mode=row["mode"],
+            base_message_count=int(row["base_message_count"] or 0),
+            state=row["state"],
+            created_at=row["created_at"],
+            merged_at=row["merged_at"],
+        )
+
+    def branches_from(
+        self, parent_session_id: str, *, active_only: bool = False
+    ) -> list[SessionBranch]:
+        sql = "SELECT * FROM session_branches WHERE parent_session_id = ?"
+        if active_only:
+            sql += " AND state = 'active'"
+        sql += " ORDER BY created_at ASC"
+        with self._lock:
+            rows = self._conn.execute(sql, (parent_session_id,)).fetchall()
+        return [
+            SessionBranch(
+                child_session_id=row["child_session_id"],
+                parent_session_id=row["parent_session_id"],
+                mode=row["mode"],
+                base_message_count=int(row["base_message_count"] or 0),
+                state=row["state"],
+                created_at=row["created_at"],
+                merged_at=row["merged_at"],
+            )
+            for row in rows
+        ]
+
+    def has_active_children(self, session_id: str) -> bool:
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT 1 FROM session_branches
+                WHERE parent_session_id = ? AND state = 'active'
+                LIMIT 1
+                """,
+                (session_id,),
+            ).fetchone()
+        return row is not None
 
     def rename(self, session_id: str, title: str) -> bool:
         clean = " ".join((title or "").split())[:120]

--- a/coworker/engine.py
+++ b/coworker/engine.py
@@ -64,6 +64,9 @@ class TurnEngine:
         messages: Optional[list[dict[str, Any]]] = None,
         audit_sink: Optional[Callable[[dict[str, Any]], None]] = None,
         context_provider: Optional[Callable[[], str]] = None,
+        inherited_messages_provider: Optional[
+            Callable[[], list[dict[str, Any]]]
+        ] = None,
         directory_requester: Optional[
             Callable[[dict[str, Any]], "Awaitable[dict[str, Any]]"]
         ] = None,
@@ -91,6 +94,11 @@ class TurnEngine:
         # across providers, so dynamic per-turn context (e.g. the live directory list) rides on
         # the latest user turn. Returns "" when there's nothing to add.
         self.context_provider = context_provider
+        # Side sessions keep only their local transcript in ``self.messages``.
+        # The inherited parent history is fetched and frozen once per user turn,
+        # then prepended only to the provider feed (never persisted into the child).
+        self.inherited_messages_provider = inherited_messages_provider
+        self._inherited_messages: list[dict[str, Any]] = []
         # Handles the `request_directory` tool: emits a DIRECTORY_REQUESTED prompt, waits for the
         # user to grant/decline a folder out-of-band, applies the grant to this live session, and
         # returns the outcome. None on surfaces that can't prompt (the tool then no-ops).
@@ -156,6 +164,7 @@ class TurnEngine:
     async def run(
         self, user_input: "str | list", *, source: Optional[dict[str, Any]] = None
     ) -> AsyncIterator[Event]:
+        self._refresh_inherited_messages()
         # `user_input` is a string, or OpenAI content-parts (text + image_url) for attachments.
         # `source` (a MessageSource dict) is a display-only sidecar for connector messages: it
         # rides on the persisted user message + the TURN_START event, but is stripped before the
@@ -242,6 +251,7 @@ class TurnEngine:
         is the intended recovery path (owner-hit 2026-07-23)."""
         if not self._tail_is_retriable_error():
             return
+        self._refresh_inherited_messages()
         self._cancel.clear()
         yield Event(EventType.TURN_START, {"input": ""})
         async for event in self._loop():
@@ -256,6 +266,7 @@ class TurnEngine:
         pending = self._unanswered_trailing_tool_calls()
         if not pending:
             return
+        self._refresh_inherited_messages()
         self._cancel.clear()
         yield Event(EventType.TURN_START, {"input": "(resumed)"})
         async for event in self._handle_tool_calls(pending):
@@ -890,13 +901,25 @@ class TurnEngine:
         # (thinking text) — copying only messages that carry one. Whole `notice` messages
         # (error/interrupted/model-switch markers) are display-only too: dropped entirely.
         _SIDECARS = ("source", "_display", "ts", "reasoning")
+        # The child's system prompt remains authoritative. Parent system prompts are
+        # deliberately excluded: side sessions may have a different live mode and
+        # duplicating system messages mid-history is rejected by some providers.
+        local_system = [m for m in self.messages if m.get("role") == "system"]
+        local_thread = [m for m in self.messages if m.get("role") != "system"]
+        inherited_thread = [
+            m
+            for m in self._inherited_messages
+            if m.get("role") not in {"system", "notice"}
+        ]
+        feed = [*local_system, *inherited_thread, *local_thread]
+
         out = [
             (
                 {k: v for k, v in msg.items() if k not in _SIDECARS}
                 if any(s in msg for s in _SIDECARS)
                 else msg
             )
-            for msg in self.messages
+            for msg in feed
             if msg.get("role") != "notice"
         ]
         # PDF attachments (stored as `file` parts) are adapted to the ACTIVE model right
@@ -980,6 +1003,21 @@ class TurnEngine:
             out[i] = msg
             break
         return out
+
+    def _refresh_inherited_messages(self) -> None:
+        """Freeze live parent context for the duration of one child turn."""
+        if self.inherited_messages_provider is None:
+            self._inherited_messages = []
+            return
+        try:
+            inherited = self.inherited_messages_provider() or []
+        except Exception:
+            inherited = []
+        # Shallow-copy every canonical message so provider-side adaptation cannot
+        # mutate the parent's live engine history.
+        self._inherited_messages = [
+            dict(message) for message in inherited if isinstance(message, dict)
+        ]
 
 
 def _assistant_message(turn: AssistantTurn) -> dict[str, Any]:

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -593,6 +593,22 @@ def create_app(manager: SessionManager) -> FastAPI:
     def session_messages(session_id: str) -> dict[str, Any]:
         return {"messages": manager.session_messages(session_id)}
 
+    @app.post("/v1/sessions/{session_id}/branches")
+    def session_branch_create(session_id: str, body: dict | None = None) -> dict[str, Any]:
+        body = body or {}
+        return manager.create_side_session(
+            session_id, mode=str(body.get("mode") or "follow")
+        )
+
+    @app.get("/v1/sessions/{session_id}/branches")
+    def session_branches(session_id: str) -> dict[str, Any]:
+        return {"branches": manager.side_sessions(session_id)}
+
+    @app.get("/v1/sessions/{session_id}/branch")
+    def session_branch(session_id: str) -> dict[str, Any]:
+        branch = manager.side_session_info(session_id)
+        return {"branch": branch}
+
     @app.patch("/v1/sessions/{session_id}")
     def session_patch(session_id: str, body: dict) -> dict[str, Any]:
         body = body or {}
@@ -1722,7 +1738,7 @@ def create_app(manager: SessionManager) -> FastAPI:
                         session_id, {"type": event.type.value, "data": event.data}
                     )
                     if event.type.value in _CHECKPOINTS:
-                        manager.save(session_id, engine)
+                        manager.save(session_id, engine, committed=False)
             finally:
                 manager.mark_idle(session_id)
                 manager.save(session_id, engine)

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -384,6 +384,7 @@ class SessionManager:
 
         record = self.session_store.load(session_id)
         is_new_session = record is None
+        branch = self.session_store.branch_for(session_id)
         agent_name = (record.agent if record else agent) or "code"
         ag = get_agent(agent_name)
 
@@ -423,6 +424,11 @@ class SessionManager:
             provider=self.provider,
             memory_store=self.memory_store,
             messages=messages,
+            inherited_messages_provider=(
+                (lambda sid=session_id: self._inherited_history_for(sid))
+                if branch is not None and branch.state == "active"
+                else None
+            ),
             extra_tools=extra_tools,
             secrets=self.secrets,
             task_store=self.task_store,
@@ -827,7 +833,7 @@ class SessionManager:
         """Save the cached engine's thread (so a prompt's pending tool call survives a crash)."""
         engine = self._engines.get(session_id)
         if engine is not None:
-            self.save(session_id, engine)
+            self.save(session_id, engine, committed=False)
 
     async def resolve_inbox(self, item_id: str, resolution: str) -> bool:
         """Resolve an Inbox item from any surface (REST / Slack button / channel reply). If the
@@ -848,7 +854,8 @@ class SessionManager:
         engine = self.get_engine(item.session_id)
         if engine is None or not hasattr(engine, "resume"):
             return
-        self.mark_running(item.session_id)
+        if not self.try_mark_running(item.session_id):
+            return
         try:
             async for _event in engine.resume():
                 pass
@@ -3228,7 +3235,9 @@ class SessionManager:
             self.task_store.save(task)
         return {"ok": True, "run": run.to_dict()}
 
-    def save(self, session_id: str, engine: TurnEngine) -> None:
+    def save(
+        self, session_id: str, engine: TurnEngine, *, committed: bool = True
+    ) -> None:
         executor = getattr(engine, "executor", None)
         workspace = os.path.realpath(str(executor.cwd)) if executor else ""
         self.session_store.save(
@@ -3242,7 +3251,8 @@ class SessionManager:
                 agent=getattr(engine, "agent_name", "code"),
                 extra_roots=self._extra_roots_of(engine),
                 grants=_grants_of(engine),
-            )
+            ),
+            committed=committed,
         )
 
     @staticmethod
@@ -3524,6 +3534,104 @@ class SessionManager:
         record = self.session_store.load(session_id)
         return record.messages if record else []
 
+    def _inherited_history_for(self, child_session_id: str) -> list[dict[str, Any]]:
+        """Resolve the live parent history for one side session.
+
+        Nested side sessions inherit the effective history of their parent, not merely
+        the parent's local JSONL. Cycles are treated as corrupt metadata and cut off.
+        ``TurnEngine`` freezes the returned list once per child turn.
+        """
+
+        def effective(session_id: str, seen: set[str]) -> list[dict[str, Any]]:
+            if session_id in seen:
+                return []
+            seen = {*seen, session_id}
+            # Never inherit a checkpoint written halfway through a parent turn.
+            # Concurrent parent/child work is safe because this durable boundary
+            # advances only after the parent turn finishes.
+            local = self.session_store.committed_messages(session_id)
+            relation = self.session_store.branch_for(session_id)
+            if relation is None or relation.state != "active":
+                return list(local)
+            inherited = effective(relation.parent_session_id, seen)
+            return [
+                *inherited,
+                *(m for m in local if m.get("role") != "system"),
+            ]
+
+        relation = self.session_store.branch_for(child_session_id)
+        if relation is None or relation.state != "active":
+            return []
+        return effective(relation.parent_session_id, {child_session_id})
+
+    def create_side_session(
+        self, parent_session_id: str, *, mode: str = "follow"
+    ) -> dict[str, Any]:
+        """Create a durable discuss-mode child that follows the parent on every turn."""
+        import uuid
+
+        if parent_session_id.startswith("__"):
+            return {"ok": False, "error": "internal sessions cannot have side sessions"}
+        if mode != "follow":
+            return {"ok": False, "error": "only follow mode is currently supported"}
+        if self.is_running(parent_session_id) or self.inbox.pending(parent_session_id):
+            return {
+                "ok": False,
+                "error": "resolve the parent turn before opening a side session",
+            }
+        # A live but previously unused engine has no durable row yet. Persist it so
+        # ancestry always points at a real session.
+        self.persist_session(parent_session_id)
+        parent = self.session_store.load(parent_session_id)
+        if parent is None:
+            return {"ok": False, "error": "parent session not found"}
+
+        child_session_id = uuid.uuid4().hex[:12]
+        self.session_store.save(
+            SessionRecord(
+                session_id=child_session_id,
+                workspace=parent.workspace,
+                model=parent.model,
+                # The first release is intentionally read-only: a conversational side
+                # branch must not mutate the parent's workspace or external systems.
+                mode=Mode.DISCUSS.value,
+                messages=[],
+                title=f"Side chat · {parent.title or 'New session'}",
+                agent=parent.agent,
+                extra_roots=list(parent.extra_roots),
+            )
+        )
+        relation = self.session_store.create_branch(
+            child_session_id,
+            parent_session_id,
+            mode=mode,
+            base_message_count=parent.message_count,
+        )
+        return {
+            "ok": True,
+            "session": self._session_public(
+                self.session_store.load(child_session_id), relation=relation
+            ),
+            "branch": self._branch_public(relation),
+        }
+
+    def side_sessions(self, parent_session_id: str) -> list[dict[str, Any]]:
+        out = []
+        for relation in self.session_store.branches_from(parent_session_id):
+            record = self.session_store.load(relation.child_session_id)
+            if record is not None:
+                out.append(
+                    {
+                        "session": self._session_public(record, relation=relation),
+                        "branch": self._branch_public(relation),
+                    }
+                )
+        return out
+
+    def side_session_info(self, child_session_id: str) -> Optional[dict[str, Any]]:
+        relation = self.session_store.branch_for(child_session_id)
+        return self._branch_public(relation) if relation is not None else None
+
     def rename_session(self, session_id: str, title: str) -> dict[str, Any]:
         if session_id.startswith("__"):
             return {"ok": False, "error": "internal sessions cannot be renamed"}
@@ -3549,6 +3657,11 @@ class SessionManager:
     def delete_session(self, session_id: str) -> dict[str, Any]:
         if session_id.startswith("__"):
             return {"ok": False, "error": "internal sessions cannot be deleted here"}
+        if self.session_store.has_active_children(session_id):
+            return {
+                "ok": False,
+                "error": "delete active side sessions before deleting their parent",
+            }
         engine = self._engines.pop(session_id, None)
         if engine is not None:
             try:
@@ -3601,20 +3714,7 @@ class SessionManager:
         ws = self.resolve_workspace(workspace) if workspace else None
         return [
             {
-                "session_id": r.session_id,
-                "title": r.title or "New session",
-                "workspace": r.workspace,
-                "agent": r.agent,
-                "model": r.model,
-                "mode": r.mode,
-                "updated_at": r.updated_at,
-                "messages": r.message_count,
-                "pinned": r.pinned,
-                "archived": r.archived,
-                # §31: non-user origin ("slack") + display label — drives the sidebar's
-                # "From Slack" group and the row's platform icon.
-                "origin": r.origin,
-                "origin_label": r.origin_label,
+                **self._session_public(r),
                 # Attention = Inbox items awaiting this session (the amber count that bubbles
                 # session → persona → footer Inbox). Liveness = working (in-flight turn) /
                 # sleeping (a self-wake is pending) / idle — a count-less dot that never bubbles.
@@ -3629,6 +3729,51 @@ class SessionManager:
             for r in self.session_store.list(workspace=ws)
             if not r.session_id.startswith("__")  # hide internal threads
         ]
+
+    @staticmethod
+    def _branch_public(relation) -> dict[str, Any]:
+        return {
+            "child_session_id": relation.child_session_id,
+            "parent_session_id": relation.parent_session_id,
+            "mode": relation.mode,
+            "base_message_count": relation.base_message_count,
+            "state": relation.state,
+            "created_at": relation.created_at,
+            "merged_at": relation.merged_at,
+        }
+
+    def _session_public(self, record, *, relation=None) -> dict[str, Any]:
+        if record is None:
+            return {}
+        relation = (
+            relation
+            if relation is not None
+            else self.session_store.branch_for(record.session_id)
+        )
+        return {
+            "session_id": record.session_id,
+            "title": record.title or "New session",
+            "workspace": record.workspace,
+            "agent": record.agent,
+            "model": record.model,
+            "mode": record.mode,
+            "updated_at": record.updated_at,
+            "messages": record.message_count,
+            "pinned": record.pinned,
+            "archived": record.archived,
+            # §31: non-user origin ("slack") + display label — drives the sidebar's
+            # "From Slack" group and the row's platform icon.
+            "origin": record.origin,
+            "origin_label": record.origin_label,
+            "parent_session_id": (
+                relation.parent_session_id if relation is not None else None
+            ),
+            "branch_mode": relation.mode if relation is not None else None,
+            "branch_state": relation.state if relation is not None else None,
+            "branch_base_message_count": (
+                relation.base_message_count if relation is not None else None
+            ),
+        }
 
     def _session_liveness(self, session_id: str) -> str:
         if self.is_running(session_id):

--- a/coworker/sessions.py
+++ b/coworker/sessions.py
@@ -10,6 +10,25 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 
+@dataclass(frozen=True)
+class SessionBranch:
+    """A durable parent/child relationship between two conversation sessions.
+
+    The child's own transcript contains only branch-local messages. ``mode=follow``
+    means the latest parent history is inherited again at the start of every child
+    turn; ``base_message_count`` records where the branch was originally created for
+    provenance and for a future snapshot mode.
+    """
+
+    child_session_id: str
+    parent_session_id: str
+    mode: str = "follow"
+    base_message_count: int = 0
+    state: str = "active"
+    created_at: Optional[str] = None
+    merged_at: Optional[str] = None
+
+
 @dataclass
 class SessionRecord:
     session_id: str
@@ -20,6 +39,9 @@ class SessionRecord:
     title: Optional[str] = None
     agent: str = "code"
     message_count: int = 0
+    # Provider-safe inheritance boundary for live-follow side sessions. Checkpoint
+    # saves may advance ``message_count`` mid-turn; this advances only at turn end.
+    committed_message_count: int = 0
     updated_at: Optional[str] = None
     # Folders added to the session beyond its primary scratch dir, each {path, writable, label}.
     # The primary scratch is re-provisioned at engine build, so only these extras are persisted.

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -9,6 +9,7 @@ import {
   getSessions,
   announceAutomationsChanged,
   connectEvents,
+  createSideSession,
   getSettings,
   getPersonas,
   getInbox,
@@ -946,6 +947,48 @@ export function App() {
       setItems([]);
     }
   };
+  const openSideSession = async () => {
+    if (!activeInfo || running) return;
+    try {
+      const result = await createSideSession(sessionId);
+      if (!result.ok || !result.session) {
+        setItems((current) => [
+          ...current,
+          {
+            kind: "notice",
+            tone: "warn",
+            text: result.error || "Could not create the side chat.",
+          },
+        ]);
+        return;
+      }
+      setSessions((current) => [
+        result.session!,
+        ...current.filter((item) => item.session_id !== result.session!.session_id),
+      ]);
+      await selectSession(
+        result.session.session_id,
+        result.session.workspace || "",
+        result.session.agent,
+      );
+    } catch {
+      setItems((current) => [
+        ...current,
+        { kind: "notice", tone: "warn", text: "Could not create the side chat." },
+      ]);
+    }
+  };
+  const returnToParentSession = async () => {
+    const parentId = activeInfo?.parent_session_id;
+    if (!parentId) return;
+    let parent = sessions.find((item) => item.session_id === parentId);
+    if (!parent) {
+      const fresh = await getSessions().catch(() => []);
+      setSessions(fresh);
+      parent = fresh.find((item) => item.session_id === parentId);
+    }
+    if (parent) await selectSession(parent.session_id, parent.workspace || "", parent.agent);
+  };
   const switchAgent = async (name: string) => {
     setSurface("session");
     if (name === agent) return;
@@ -1376,6 +1419,18 @@ export function App() {
           {/* Right: session-settings icon (§23) + panel toggle. Model/mode/persona chrome is
               gone — the facts live in the subtitle, the controls in the composer (§22). */}
           <div className="main-topbar-side main-topbar-actions" onPointerDown={beginWindowDrag}>
+            {hasHistory && activeInfo && !sessionId.startsWith("__") && (
+              <button
+                className="topbar-icon-btn"
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={openSideSession}
+                disabled={running}
+                aria-label="Open side chat"
+                title="Open a side chat that follows this conversation"
+              >
+                <Icon name="branch" size={16} />
+              </button>
+            )}
             {agent === "cowork" && railHidden && artifactCount > 0 && (
               <button
                 className="topbar-artifacts-btn"
@@ -1405,6 +1460,28 @@ export function App() {
         </div>
         <div className={"main-workspace" + (railHidden ? " rail-hidden" : "")}>
           <div className="main-chat">
+            {activeInfo?.parent_session_id && (
+              <div
+                className="flex items-center gap-2 px-4 py-2 mb-1 rounded-lg text-[12.5px] border border-line bg-accentSoft/40"
+                data-testid="side-session-banner"
+              >
+                <Icon name="branch" size={14} className="text-accent shrink-0" />
+                <span className="truncate text-muted">
+                  Side chat · follows the latest completed context from{" "}
+                  <span className="text-ink font-medium">
+                    {sessions.find((item) => item.session_id === activeInfo.parent_session_id)?.title ||
+                      "the main conversation"}
+                  </span>
+                  {" "}· discuss mode
+                </span>
+                <button
+                  className="ml-auto shrink-0 text-accent font-medium hover:underline"
+                  onClick={returnToParentSession}
+                >
+                  ← Back to main
+                </button>
+              </div>
+            )}
             {/* Automation-run context (owner ask 2026-07-04): a __run__ session looked like any
                 other chat with no way back to the runs list. Lives INSIDE the chat column (which
                 is padded to clear the absolute glass topbar — rendering above .main-workspace put

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -149,6 +149,32 @@ export async function getSessionMessages(sessionId: string): Promise<Conversatio
   return (await res.json()).messages ?? [];
 }
 
+export interface CreateSideSessionResult {
+  ok: boolean;
+  error?: string;
+  session?: SessionInfo;
+  branch?: {
+    child_session_id: string;
+    parent_session_id: string;
+    mode: "follow";
+    state: "active" | "merged" | "abandoned";
+    base_message_count: number;
+    created_at?: string | null;
+  };
+}
+
+export async function createSideSession(parentSessionId: string): Promise<CreateSideSessionResult> {
+  const res = await fetch(
+    `${httpBase()}/v1/sessions/${encodeURIComponent(parentSessionId)}/branches`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode: "follow" }),
+    },
+  );
+  return res.json();
+}
+
 export async function renameSession(sessionId: string, title: string): Promise<{ ok: boolean; error?: string }> {
   const res = await fetch(`${httpBase()}/v1/sessions/${encodeURIComponent(sessionId)}`, {
     method: "PATCH",

--- a/surfaces/gui/src/components/Sidebar.test.tsx
+++ b/surfaces/gui/src/components/Sidebar.test.tsx
@@ -107,6 +107,38 @@ describe("Sidebar group/filter control", () => {
   });
 });
 
+describe("Side-session rows", () => {
+  it("marks a child conversation with the branch icon", async () => {
+    stubFetch([
+      { match: "/v1/personas", method: "GET", json: PERSONAS },
+      { match: "/v1/settings", method: "GET", json: { nav_layout: "flat" } },
+    ]);
+    render(
+      <Sidebar
+        {...baseProps}
+        sessions={[
+          ...SESSIONS,
+          {
+            session_id: "side-1",
+            title: "Side chat",
+            workspace: "",
+            agent: "cowork",
+            model: "m",
+            mode: "discuss",
+            updated_at: "2026-06-30",
+            messages: 1,
+            parent_session_id: "s-cowork-1",
+            branch_mode: "follow",
+            branch_state: "active",
+          },
+        ]}
+      />,
+    );
+    await screen.findByText("Side chat");
+    expect(screen.getByTestId("side-session-icon")).toBeTruthy();
+  });
+});
+
 describe("Chronological list row actions (⋮ menu)", () => {
   // The Recent list sorts by updated_at desc with store order breaking ties, so index 0 = s-ops-1.
   const openOpsMenu = () => fireEvent.click(screen.getAllByTestId("row-menu")[0]);

--- a/surfaces/gui/src/components/Sidebar.tsx
+++ b/surfaces/gui/src/components/Sidebar.tsx
@@ -566,6 +566,11 @@ export function Sidebar(props: Props) {
               }
             >
               {s.pinned && <Icon name="pin" size={11} className="text-faint shrink-0" />}
+              {s.parent_session_id && (
+                <span data-testid="side-session-icon">
+                  <Icon name="branch" size={11} className="text-accent shrink-0" />
+                </span>
+              )}
               <span className="truncate">{title}</span>
             </span>
             <span
@@ -633,8 +638,13 @@ export function Sidebar(props: Props) {
           />
         ) : (
           <>
-            <span className="min-w-0 flex-1 block truncate text-[13px] font-medium">
-              {title}
+            <span className="min-w-0 flex-1 flex items-center gap-1.5 truncate text-[13px] font-medium">
+              {s.parent_session_id && (
+                <span data-testid="side-session-icon">
+                  <Icon name="branch" size={11} className="text-accent shrink-0" />
+                </span>
+              )}
+              <span className="truncate">{title}</span>
             </span>
             <span
               className={

--- a/surfaces/gui/src/types.ts
+++ b/surfaces/gui/src/types.ts
@@ -60,6 +60,12 @@ export interface SessionInfo {
   // "From Slack" group and the row's platform icon.
   origin?: string;
   origin_label?: string;
+  // Live-follow side session metadata. The child stores only its local transcript;
+  // parent context is inherited again at the start of every turn.
+  parent_session_id?: string | null;
+  branch_mode?: "follow" | null;
+  branch_state?: "active" | "merged" | "abandoned" | null;
+  branch_base_message_count?: number | null;
 }
 
 // Attachments (images, PDFs, text files) sent with a user message.

--- a/tests/test_session_branches.py
+++ b/tests/test_session_branches.py
@@ -1,0 +1,194 @@
+"""Live-follow side sessions: durable ancestry and context composition."""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from coworker.conversations import ConversationStore
+from coworker.providers import AssistantTurn, ModelCapabilities, ProviderClient
+from coworker.server import SessionManager, create_app
+from coworker.sessions import SessionRecord
+
+
+class RecordingProvider(ProviderClient):
+    def __init__(self, replies: list[str]):
+        self.replies = list(replies)
+        self.calls: list[list[dict]] = []
+
+    def complete(self, *, model, messages, tools=None, **settings):
+        self.calls.append([dict(message) for message in messages])
+        return AssistantTurn(text=self.replies.pop(0), finish_reason="stop")
+
+    def capabilities(self, model):
+        return ModelCapabilities()
+
+
+def _record(tmp_path, session_id: str, messages: list[dict]) -> SessionRecord:
+    return SessionRecord(
+        session_id=session_id,
+        workspace=str(tmp_path),
+        model="gpt-5.5",
+        mode="interactive",
+        messages=messages,
+        title=session_id,
+        agent="chat",
+    )
+
+
+def test_branch_relationships_persist(tmp_path):
+    store = ConversationStore(tmp_path / "state")
+    for session_id in ("main", "child", "grandchild", "sibling"):
+        store.save(_record(tmp_path, session_id, []))
+
+    child = store.create_branch("child", "main")
+    store.create_branch("grandchild", "child")
+    store.create_branch("sibling", "main")
+
+    assert child.parent_session_id == "main"
+    assert child.mode == "follow"
+    assert store.branch_for("child") == child
+    assert [b.child_session_id for b in store.branches_from("main")] == [
+        "child",
+        "sibling",
+    ]
+    assert store.has_active_children("main") is True
+
+    assert store.delete("grandchild") is True
+    assert store.branch_for("grandchild") is None
+
+
+def test_side_session_follows_latest_parent_without_copying_history(tmp_path):
+    provider = RecordingProvider(["side one", "side two"])
+    manager = SessionManager(workspace=tmp_path, provider=provider)
+    parent_messages = [
+        {"role": "system", "content": "parent system"},
+        {"role": "user", "content": "main question"},
+        {"role": "assistant", "content": "main answer"},
+    ]
+    manager.session_store.save(_record(tmp_path, "main", parent_messages))
+
+    created = manager.create_side_session("main")
+    assert created["ok"] is True
+    child_id = created["session"]["session_id"]
+    assert created["branch"]["parent_session_id"] == "main"
+    assert created["session"]["mode"] == "discuss"
+    # Keep the manager's unrelated background auto-title call out of this provider trace.
+    manager.session_store.rename(child_id, "Side chat")
+
+    engine = manager.get_engine(child_id)
+    assert engine is not None
+
+    async def run(text: str) -> None:
+        assert manager.try_mark_running(child_id)
+        try:
+            async for _event in engine.run(text):
+                pass
+            manager.save(child_id, engine)
+        finally:
+            manager.mark_idle(child_id)
+
+    asyncio.run(run("side question one"))
+    first = provider.calls[0]
+    assert first[0]["role"] == "system"
+    assert "parent system" not in [m.get("content") for m in first]
+    assert [m.get("content") for m in first[1:3]] == [
+        "main question",
+        "main answer",
+    ]
+    assert first[-1]["content"].startswith("side question one")
+
+    parent = manager.session_store.load("main")
+    assert parent is not None
+    parent.messages.extend(
+        [
+            {"role": "user", "content": "new main fact"},
+            {"role": "assistant", "content": "new main answer"},
+        ]
+    )
+    manager.session_store.save(parent)
+
+    asyncio.run(run("side question two"))
+    second_contents = [m.get("content") for m in provider.calls[1]]
+    assert second_contents.index("new main fact") < second_contents.index(
+        "side question one"
+    )
+    assert second_contents[-1].startswith("side question two")
+
+    persisted_child = manager.session_store.load(child_id)
+    assert persisted_child is not None
+    local_contents = [m.get("content") for m in persisted_child.messages]
+    assert "main question" not in local_contents
+    assert "new main fact" not in local_contents
+    assert "side question one" in local_contents
+    assert "side question two" in local_contents
+
+
+def test_side_session_ignores_parent_mid_turn_checkpoint(tmp_path):
+    provider = RecordingProvider(["child answer"])
+    manager = SessionManager(workspace=tmp_path, provider=provider)
+    manager.session_store.save(
+        _record(
+            tmp_path,
+            "main",
+            [
+                {"role": "user", "content": "committed question"},
+                {"role": "assistant", "content": "committed answer"},
+            ],
+        )
+    )
+    child_id = manager.create_side_session("main")["session"]["session_id"]
+    manager.session_store.rename(child_id, "Side chat")
+
+    parent = manager.session_store.load("main")
+    assert parent is not None
+    parent.messages.append({"role": "user", "content": "half-finished parent turn"})
+    manager.session_store.save(parent, committed=False)
+
+    engine = manager.get_engine(child_id)
+    assert engine is not None
+
+    async def run() -> None:
+        async for _event in engine.run("child question"):
+            pass
+
+    asyncio.run(run())
+    contents = [message.get("content") for message in provider.calls[0]]
+    assert "committed question" in contents
+    assert "committed answer" in contents
+    assert "half-finished parent turn" not in contents
+
+
+def test_side_session_rest_api(tmp_path):
+    manager = SessionManager(
+        workspace=tmp_path, provider=RecordingProvider(["unused"])
+    )
+    manager.session_store.save(
+        _record(
+            tmp_path,
+            "main",
+            [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": "answer"},
+            ],
+        )
+    )
+    client = TestClient(create_app(manager))
+
+    created = client.post("/v1/sessions/main/branches", json={}).json()
+    assert created["ok"] is True
+    child_id = created["session"]["session_id"]
+    assert created["session"]["parent_session_id"] == "main"
+
+    branches = client.get("/v1/sessions/main/branches").json()["branches"]
+    assert [item["session"]["session_id"] for item in branches] == [child_id]
+
+    relation = client.get(f"/v1/sessions/{child_id}/branch").json()["branch"]
+    assert relation["parent_session_id"] == "main"
+
+    listed = {
+        item["session_id"]: item
+        for item in client.get("/v1/sessions").json()["sessions"]
+    }
+    assert listed[child_id]["parent_session_id"] == "main"


### PR DESCRIPTION
## Summary
- add durable parent/child side-session metadata
- inherit the latest completed parent context at the start of each child turn without copying it into the child transcript
- add side-session endpoints and GUI controls, including a parent-return action
- keep side sessions in Discuss mode for the first release

## Validation
- focused backend tests: 61 passed
- broader backend regression: 880 passed, 1 skipped
- GUI production build succeeded
- GUI tests: 69 passed
- manually verified the create, live-follow, and return-to-parent flow