### PR TITLE
Create the sidecar resource dir in build.rs so a fresh clone builds

### DIFF
--- a/surfaces/gui/src-tauri/build.rs
+++ b/surfaces/gui/src-tauri/build.rs
@@ -1,3 +1,10 @@
 fn main() {
+    // tauri-build validates every `bundle.resources` path on every build, dev included, but
+    // `binaries/sidecar` is only staged by the release scripts and `/binaries` is gitignored —
+    // so a fresh checkout died on `resource path 'binaries/sidecar' doesn't exist`. Dev needs no
+    // packaged server (`server_bin()` falls back to the venv) and empty resource dirs are
+    // skipped, so a placeholder is enough.
+    std::fs::create_dir_all("binaries/sidecar").expect("create the sidecar resource dir");
+
     tauri_build::build()
 }


### PR DESCRIPTION
Fixes #131.

`tauri.conf.json` declares `"resources": { "binaries/sidecar": "sidecar" }`, and tauri-build
validates every declared resource path on each `cargo build` — dev as well as release. Only
`build_dmg.sh` and `build_windows.ps1` stage a server there, and `src-tauri/.gitignore` ignores
`/binaries`, so `npm run tauri dev` on a fresh clone dies before the shell starts:

```text
error: failed to run custom build command for `openworker-desktop v0.1.0 (.../surfaces/gui/src-tauri)`
resource path `binaries/sidecar` doesn't exist
```

`build.rs` now creates the empty directory first. Dev doesn't need a packaged sidecar —
`server_bin()` falls back to the venv server, as `surfaces/gui/README.md` describes — and
tauri-utils skips empty resource directories, so nothing changes in the bundle. The placeholder
stays gitignored.

The issue suggested fixing this in `setup_dev_env.sh` or `make desktop`. I used the build script
instead: there's no Makefile in the repo, and the bootstrap script is bash, so neither would help
anyone on Windows.

Checked on a fresh clone with no `binaries/` — fails as above without the patch, builds with it,
in both dev and release. Staging a populated sidecar still copies it into `target/debug/sidecar/`,
so release bundling is unaffected.

No screenshots on this one: it fails at build time and never opens a window.

Worth noting separately — nothing in CI compiles the Rust shell today, which is how this reached
main. Happy to add a `cargo build` step for `src-tauri` if you want one.
