### PR TITLE
Fix navigation state after hiding artifact preview

### DIFF
--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -785,6 +785,22 @@ export async function mockApi(page: import("@playwright/test").Page) {
       }
       return json({ roots });
     }
+    if (/\/v1\/sessions\/[^/]+\/artifacts\/read/.test(p)) {
+      return json({ kind: "markdown", content: "# Sample Artifact" });
+    }
+    if (/\/v1\/sessions\/[^/]+\/artifacts/.test(p)) {
+      return json({
+        artifacts: [
+          {
+            path: "sample.md",
+            name: "sample.md",
+            kind: "markdown",
+            size: 120,
+            modified_at: 1700000000,
+          },
+        ],
+      });
+    }
     if (/\/v1\/sessions\/[^/]+\/messages$/.test(p)) return json({ messages: [] });
     if (/\/v1\/sessions\/[^/]+\/unattended$/.test(p)) {
       const id = decodeURIComponent(p.split("/").slice(-2)[0]);

--- a/surfaces/gui/e2e/nav-collapse.spec.ts
+++ b/surfaces/gui/e2e/nav-collapse.spec.ts
@@ -20,12 +20,13 @@ test("collapse hides the sidebar and reclaims the width; reveal button docks it 
   await expect(app).not.toHaveClass(/nav-collapsed/);
 });
 
-test("⌘B toggles the sidebar collapse", async ({ page }) => {
+test("⌘B / Ctrl+B toggles the sidebar collapse", async ({ page }) => {
   await page.goto("/");
   const app = page.locator(".app");
-  await page.keyboard.press("Meta+b");
+  await page.locator("body").focus();
+  await page.keyboard.press("Control+b");
   await expect(app).toHaveClass(/nav-collapsed/);
-  await page.keyboard.press("Meta+b");
+  await page.keyboard.press("Control+b");
   await expect(app).not.toHaveClass(/nav-collapsed/);
 });
 
@@ -48,4 +49,29 @@ test("RECENT header group/filter popover: switch grouping + see coworker filters
 
   // Filter-by-coworker checkboxes are present (none checked by default → all shown).
   await expect(menu).toContainText("None checked shows all.");
+});
+
+test("hiding side panel while artifact preview is open restores nav collapse state (#135)", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const app = page.locator(".app");
+  await expect(page.locator(".sidebar")).toBeVisible();
+  await expect(app).not.toHaveClass(/nav-collapsed/);
+
+  // Open artifact preview from the right rail
+  await page.getByRole("button", { name: "sample.md" }).click();
+
+  // Left nav auto-collapses
+  await expect(app).toHaveClass(/nav-collapsed/);
+
+  // Hide the side panel via topbar toggle
+  await page.getByRole("button", { name: "Hide side panel" }).click();
+
+  // Nav should restore to uncollapsed
+  await expect(app).not.toHaveClass(/nav-collapsed/);
+
+  // Reveal affordance button or sidebar brand button works to toggle nav
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+  await expect(app).toHaveClass(/nav-collapsed/);
 });

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -231,6 +231,10 @@ export function App() {
   // While an artifact preview is open we auto-collapse the nav (#3). Remember the pre-preview
   // collapse state so we can restore it on close — unless the user re-opened the nav meanwhile.
   const navBeforePreview = useRef<boolean | null>(null);
+  const navCollapsedRef = useRef(navCollapsed);
+  useEffect(() => {
+    navCollapsedRef.current = navCollapsed;
+  }, [navCollapsed]);
   const setNavCollapsedPersist = useCallback((v: boolean) => {
     setNavCollapsed(v);
     try { localStorage.setItem(NAV_COLLAPSED_KEY, v ? "1" : "0"); } catch { /* best effort */ }
@@ -244,14 +248,14 @@ export function App() {
   // user manually toggled meanwhile). The collapse is transient — it never overwrites the pref.
   const onArtifactPreview = useCallback((open: boolean) => {
     if (open) {
-      if (navBeforePreview.current === null) navBeforePreview.current = navCollapsed;
+      if (navBeforePreview.current === null) navBeforePreview.current = navCollapsedRef.current;
       setNavPeek(false);
       setNavCollapsed(true);
     } else if (navBeforePreview.current !== null) {
       setNavCollapsed(navBeforePreview.current);
       navBeforePreview.current = null;
     }
-  }, [navCollapsed]);
+  }, []);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "b") {

--- a/surfaces/gui/src/components/RightRail.test.tsx
+++ b/surfaces/gui/src/components/RightRail.test.tsx
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { RightRail } from "./RightRail";
+import type { ArtifactInfo } from "../api";
+
+const ARTIFACT: ArtifactInfo = {
+  path: "test-doc.md",
+  name: "test-doc.md",
+  kind: "markdown",
+  size: 100,
+  modified_at: 1000,
+};
+
+function stubApi() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      if (url.includes("/artifacts/read")) {
+        return {
+          ok: true,
+          json: async () => ({ kind: "markdown", content: "# Test Document" }),
+        } as Response;
+      }
+      if (url.includes("/artifacts")) {
+        return {
+          ok: true,
+          json: async () => ({ artifacts: [ARTIFACT] }),
+        } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    })
+  );
+}
+
+const defaultProps = {
+  active: true,
+  sessionId: "s1",
+  refreshKey: 0,
+  toolNames: [],
+  todo: [],
+  running: false,
+  showArtifacts: true,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("RightRail artifact preview & navigation collapse sync (#135)", () => {
+  it("notifies onPreviewChange when an artifact is selected and when rail is hidden", async () => {
+    stubApi();
+    const onPreviewChange = vi.fn();
+
+    const { rerender } = render(
+      <RightRail {...defaultProps} onPreviewChange={onPreviewChange} />
+    );
+
+    // Click on the artifact to select it
+    const row = await screen.findByText("test-doc.md");
+    fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(onPreviewChange).toHaveBeenCalledWith(true);
+    });
+
+    // Hiding the side panel (active = false) must notify onPreviewChange(false)
+    rerender(
+      <RightRail {...defaultProps} active={false} onPreviewChange={onPreviewChange} />
+    );
+
+    await waitFor(() => {
+      expect(onPreviewChange).toHaveBeenLastCalledWith(false);
+    });
+  });
+
+  it("clears selected artifact when rail becomes inactive so reopening rail does not restore stale preview", async () => {
+    stubApi();
+    const onPreviewChange = vi.fn();
+
+    const { rerender } = render(
+      <RightRail {...defaultProps} onPreviewChange={onPreviewChange} />
+    );
+
+    const row = await screen.findByText("test-doc.md");
+    fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(screen.getByText("Artifacts")).toBeTruthy();
+      expect(onPreviewChange).toHaveBeenLastCalledWith(true);
+    });
+
+    // Hide rail
+    rerender(
+      <RightRail {...defaultProps} active={false} onPreviewChange={onPreviewChange} />
+    );
+
+    await waitFor(() => {
+      expect(onPreviewChange).toHaveBeenLastCalledWith(false);
+    });
+
+    // Reopen rail (active = true)
+    rerender(
+      <RightRail {...defaultProps} active={true} onPreviewChange={onPreviewChange} />
+    );
+
+    // Should return to artifact list, not artifact viewer, and preview state remains false
+    await waitFor(() => {
+      expect(screen.getByText("test-doc.md")).toBeTruthy();
+      expect(onPreviewChange).toHaveBeenLastCalledWith(false);
+    });
+  });
+
+  it("does not re-emit preview true when onPreviewChange callback identity changes while inactive", async () => {
+    stubApi();
+    const onPreviewChange1 = vi.fn();
+    const onPreviewChange2 = vi.fn();
+
+    const { rerender } = render(
+      <RightRail {...defaultProps} onPreviewChange={onPreviewChange1} />
+    );
+
+    const row = await screen.findByText("test-doc.md");
+    fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(onPreviewChange1).toHaveBeenCalledWith(true);
+    });
+
+    // Hide rail
+    rerender(
+      <RightRail {...defaultProps} active={false} onPreviewChange={onPreviewChange1} />
+    );
+
+    // Change callback identity
+    rerender(
+      <RightRail {...defaultProps} active={false} onPreviewChange={onPreviewChange2} />
+    );
+
+    expect(onPreviewChange2).not.toHaveBeenCalledWith(true);
+  });
+
+  it("closing artifact preview with Back button calls onPreviewChange(false)", async () => {
+    stubApi();
+    const onPreviewChange = vi.fn();
+
+    render(<RightRail {...defaultProps} onPreviewChange={onPreviewChange} />);
+
+    const row = await screen.findByText("test-doc.md");
+    fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(onPreviewChange).toHaveBeenLastCalledWith(true);
+    });
+
+    const backBtn = await screen.findByTitle("Back");
+    fireEvent.click(backBtn);
+
+    await waitFor(() => {
+      expect(onPreviewChange).toHaveBeenLastCalledWith(false);
+    });
+  });
+});

--- a/surfaces/gui/src/components/RightRail.tsx
+++ b/surfaces/gui/src/components/RightRail.tsx
@@ -104,10 +104,19 @@ export function RightRail({
     readArtifact(sessionId, selected.path).then(setContent).catch(() => setContent(null));
   }, [selected?.path, sessionId]);
 
-  // Notify the app when a preview opens/closes (drives the left-nav auto-collapse).
+  // Switching conversations or hiding/deactivating the rail closes any open artifact.
   useEffect(() => {
-    onPreviewChange?.(!!selected);
-  }, [!!selected, onPreviewChange]);
+    if (!active) {
+      setSelected(null);
+      setContent(null);
+    }
+  }, [active]);
+
+  // Notify the app when a preview opens/closes (drives the left-nav auto-collapse).
+  const previewOpen = active && !!selected;
+  useEffect(() => {
+    onPreviewChange?.(previewOpen);
+  }, [previewOpen, onPreviewChange]);
 
   const reloadSelected = () => {
     if (!selected) return Promise.resolve();


### PR DESCRIPTION
## Summary

- synchronize artifact-preview visibility with the right-rail lifecycle
- prevent stale preview state from overriding manual navigation toggles
- add regression coverage for hiding the panel while an artifact is open

Fixes #135.

## Root cause

When an artifact preview was opened in `RightRail`, `selected` state was maintained internally. Hiding the right side panel set `active=false`, but `RightRail`'s `useEffect` only watched `[!!selected, onPreviewChange]`, ignoring `active`. Consequently, hiding the side panel never invoked `onPreviewChange(false)` to restore `navCollapsed` in `App.tsx`. Furthermore, `onArtifactPreview` in `App.tsx` depended on `[navCollapsed]`, causing its identity to change whenever `navCollapsed` toggled. When a user subsequently attempted to manually expand the left navigation, the identity change of `onArtifactPreview` re-triggered `RightRail`'s `useEffect`, which re-emitted `onPreviewChange(true)` due to stale `selected` state, forcing the navigation to immediately re-collapse.

## Changes

- **`surfaces/gui/src/components/RightRail.tsx`**:
  - Added an effect on `[active]` to reset `selected` and `content` state when the side panel is deactivated or hidden.
  - Derived `previewOpen = active && !!selected` so `onPreviewChange` accurately reflects visible application state and notifies `false` when hidden.
- **`surfaces/gui/src/App.tsx`**:
  - Stabilized `onArtifactPreview` identity with an empty dependency array `[]` using a `navCollapsedRef` to track `navCollapsed` state across renders without identity instability.
- **Tests**:
  - Added unit regression tests in `surfaces/gui/src/components/RightRail.test.tsx` verifying preview state notification on hide/reopen, back button, and callback identity changes.
  - Added end-to-end regression test in `surfaces/gui/e2e/nav-collapse.spec.ts`.

## Before

Before fix: hiding the side panel while an artifact preview was open left the left sidebar permanently stuck in a collapsed state, and manual toggles were immediately overridden.

## After

After fix: hiding the side panel cleanly restores the left sidebar to its pre-preview state, and manual sidebar toggles remain stable.

## Testing

- `npm test`: Passed 13 test files (72 unit tests total).
- `npx vitest run src/components/RightRail.test.tsx`: Passed 4 focused unit regression tests.
- `npm run build`: Build succeeded cleanly without TypeScript or Vite errors.
- `npx playwright test e2e/nav-collapse.spec.ts`: Passed all 4 e2e test cases.