### PR TITLE
Add OpenRouter as a model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Under the hood:
 
 Model access is yours: pick a provider, paste your key, switch anytime. Supported out of the box:
 
-**OpenAI · Anthropic · Google Gemini · Inkling (Thinking Machines) · GLM (Z.ai) · DeepSeek · Kimi (Moonshot) · Qwen · MiniMax · Mistral · Grok (xAI)** - plus open-weight models via **Together** and **Fireworks**, and fully local models via **Ollama**.
+**OpenAI · Anthropic · Google Gemini · Inkling (Thinking Machines) · GLM (Z.ai) · DeepSeek · Kimi (Moonshot) · Qwen · MiniMax · Mistral · Grok (xAI)** - plus open-weight models via **Together**, **Fireworks**, and **OpenRouter**, and fully local models via **Ollama**.
 
 A curated model list marks what we've verified for tool-calling work. Adding any model string works at your own risk.
 

--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -11,9 +11,9 @@ falls back to the conservative heuristics in ``capabilities.py`` at their own ri
 degraded results. Ids verified against vendor/reseller catalogs on 2026-07-04; refresh the
 reseller rows when catalogs rotate (they rename on every model generation).
 
-Resellers: Together + Fireworks for now. TODO: add Groq and OpenRouter entries here AND their
-descriptors in ``registry.py`` once the current provider surface is tested — deliberately
-deferred to bound how much needs verifying at once.
+Resellers: Together, Fireworks, and OpenRouter. TODO: add Groq entries here AND its descriptor
+in ``registry.py`` once the current provider surface is tested — deliberately deferred to
+bound how much needs verifying at once.
 """
 
 from __future__ import annotations
@@ -111,6 +111,14 @@ MATRIX: dict[str, ModelEntry] = {
     ),
     "fireworks:accounts/fireworks/models/llama4-maverick-instruct-basic": ModelEntry(
         "Llama 4 Maverick · via Fireworks"
+    ),
+    # OpenRouter uses each vendor's own lowercase slug (distinct from Together/Fireworks'
+    # HF-style repo paths) — ids verified against openrouter.ai/models 2026-07-26.
+    "openrouter:z-ai/glm-5.2": ModelEntry("GLM-5.2 · via OpenRouter"),
+    "openrouter:deepseek/deepseek-v4-pro": ModelEntry("DeepSeek V4 Pro · via OpenRouter"),
+    "openrouter:moonshotai/kimi-k2.6": ModelEntry("Kimi K2.6 · via OpenRouter"),
+    "openrouter:meta-llama/llama-4-maverick": ModelEntry(
+        "Llama 4 Maverick · via OpenRouter"
     ),
 }
 

--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -316,9 +316,18 @@ DESCRIPTORS: list[ProviderDescriptor] = [
         endpoint_help="Prefilled with the Meta Model API endpoint (public preview, US-only as of 2026-07).",
     ),
     # Resellers: many labs' models behind one key, using THEIR model namespaces (the curated
-    # ids + display labels live in providers/matrix.py). TODO: add Groq and OpenRouter here
-    # (+ their matrix rows) once the current provider surface is tested — deliberately
-    # deferred to bound how much needs verifying at once (owner call, 2026-07-04).
+    # ids + display labels live in providers/matrix.py). TODO: add Groq here (+ its matrix
+    # rows) once the current provider surface is tested — deliberately deferred to bound
+    # how much needs verifying at once (owner call, 2026-07-04).
+    _compat(
+        "openrouter",
+        "OpenRouter",
+        base_url="https://openrouter.ai/api/v1",
+        recommended_model="z-ai/glm-5.2",
+        env_key="OPENROUTER_API_KEY",
+        endpoint_help="Prefilled with OpenRouter's endpoint. Model ids use OpenRouter's own "
+        "vendor/model namespace (see openrouter.ai/models).",
+    ),
     _compat(
         "together",
         "Together AI",

--- a/surfaces/gui/src/providers/ProviderSetup.tsx
+++ b/surfaces/gui/src/providers/ProviderSetup.tsx
@@ -22,6 +22,7 @@ export const KEY_HELP: Record<string, { url: string; label: string }> = {
   gemini: { url: "https://aistudio.google.com/apikey", label: "aistudio.google.com" },
   fireworks: { url: "https://fireworks.ai/account/api-keys", label: "fireworks.ai" },
   together: { url: "https://api.together.xyz/settings/api-keys", label: "together.xyz" },
+  openrouter: { url: "https://openrouter.ai/keys", label: "openrouter.ai" },
   zai: { url: "https://z.ai/manage-apikey/apikey-list", label: "z.ai" },
   kimi: { url: "https://platform.moonshot.ai/console/api-keys", label: "platform.moonshot.ai" },
   deepseek: { url: "https://platform.deepseek.com/api_keys", label: "platform.deepseek.com" },

--- a/surfaces/gui/src/providers/logos.ts
+++ b/surfaces/gui/src/providers/logos.ts
@@ -19,6 +19,7 @@ import qwen from "./logos/qwen.svg";
 import minimax from "./logos/minimax.svg";
 import xai from "./logos/xai.svg";
 import meta from "./logos/meta.svg";
+import openrouter from "./logos/openrouter.svg";
 
 export const PROVIDER_LOGOS: Record<string, string> = {
   anthropic,
@@ -28,6 +29,7 @@ export const PROVIDER_LOGOS: Record<string, string> = {
   ollama,
   fireworks,
   together,
+  openrouter,
   zai,
   kimi,
   deepseek,
@@ -45,6 +47,7 @@ export const PROVIDER_ORDER = [
   "ollama",
   "fireworks",
   "together",
+  "openrouter",
   "zai",
   "kimi",
   "deepseek",

--- a/surfaces/gui/src/providers/logos/openrouter.svg
+++ b/surfaces/gui/src/providers/logos/openrouter.svg
@@ -1,0 +1,1 @@
+<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>OpenRouter</title><path d="M18.654 3.87a5.087 5.087 0 110 10.174L23.7 19.09c.64.641.187 1.737-.72 1.737H8.48a8.479 8.479 0 010-16.958h10.175zM8.479 7.26a5.087 5.087 0 100 10.176 5.087 5.087 0 000-10.175z"></path></svg>

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -381,6 +381,7 @@ def test_matrix_answers_capabilities_for_reseller_ids():
         "together:zai-org/GLM-5.2",
         "together:meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
         "fireworks:accounts/fireworks/models/kimi-k2p6",
+        "openrouter:z-ai/glm-5.2",
     ):
         caps = capabilities_for(mid)
         assert caps.tools and caps.parallel_tool_calls and caps.streaming
@@ -392,6 +393,7 @@ def test_matrix_labels_and_custom_model_fallback():
     labels = model_labels()
     assert labels["together:zai-org/GLM-5.2"] == "GLM-5.2 · via Together"
     assert labels["zai:glm-5.2"] == "GLM-5.2 · Z AI"
+    assert labels["openrouter:z-ai/glm-5.2"] == "GLM-5.2 · via OpenRouter"
     # Deliberately small: agent-capable current models only (owner call, 2026-07-04).
     assert len(MATRIX) < 40
     assert all(e.caps.tools for e in MATRIX.values())
@@ -402,12 +404,13 @@ def test_matrix_labels_and_custom_model_fallback():
 
 
 def test_reseller_descriptors_and_matrix_stay_in_lockstep():
-    """Together/Fireworks suggested models derive from the matrix, and each descriptor's
-    recommended model must be one of them (set_provider's auto-add depends on it)."""
+    """Together/Fireworks/OpenRouter suggested models derive from the matrix, and each
+    descriptor's recommended model must be one of them (set_provider's auto-add depends
+    on it)."""
     from coworker.providers.matrix import models_for_provider
     from coworker.providers.registry import get_descriptor
 
-    for name in ("together", "fireworks"):
+    for name in ("together", "fireworks", "openrouter"):
         d = get_descriptor(name)
         assert d is not None and d.needs_key
         curated = models_for_provider(name)


### PR DESCRIPTION
## Summary

Adds OpenRouter as a provider, following the exact pattern used for Together and Fireworks. Users can now add an OpenRouter key in Settings ▸ Models and pick from a small curated set of tool-calling models, same as any other reseller.

This covers the OpenRouter half of #22. See "Not included" below for why Codex subscription support isn't part of this PR.

## Why this shape

`registry.py` and `matrix.py` already carried a TODO for this exact addition:

```python
# TODO: add Groq and OpenRouter here (+ their matrix rows) once the current
# provider surface is tested — deliberately deferred to bound how much needs
# verifying at once (owner call, 2026-07-04).
```

So this isn't a new pattern, just filling in one of the two deferred entries (Groq is still open). `openai_provider.py` already special-cases OpenRouter's `reasoning` field name in streamed deltas too, so the compat layer was already half-anticipating this.

## What's included

- `registry.py`: an `openrouter` descriptor via the existing `_compat()` builder — key + prefilled, editable endpoint (`https://openrouter.ai/api/v1`), `OPENROUTER_API_KEY` env fallback.
- `matrix.py`: four curated tool-calling models, using OpenRouter's own lowercase `vendor/model` slugs (`z-ai/glm-5.2`, `deepseek/deepseek-v4-pro`, `moonshotai/kimi-k2.6`, `meta-llama/llama-4-maverick`) — deliberately the same small "verified, agent-capable only" set the matrix keeps for every other reseller.
- GUI: logo (vendored from the MIT-licensed lobe-icons set, same as every other provider mark) + a `KEY_HELP` entry pointing at openrouter.ai/keys, so the onboarding/Settings gallery card looks and behaves like every other provider.
- README: added OpenRouter to the "Bring your own model" line.
- Tests: extended `tests/test_providers.py`'s reseller/matrix coverage to include OpenRouter alongside Together/Fireworks.

## Not included: Codex subscription support

I looked for any existing scaffolding for subscription/OAuth-based model auth (as opposed to API keys) and there isn't any — everything under `coworker/providers/` is API-key or env-var based. The closest precedent is the OAuth/PKCE broker pattern in `coworker/cloud.py`, but that's used for OpenWorker Cloud sign-in and connector auth, never for a model provider.

Wiring up a ChatGPT/Codex-subscription login would mean a new auth mode on `ProviderDescriptor` (today it's just `needs_key: bool`), a new OAuth flow modeled on that broker pattern, and reverse-engineering whatever undocumented flow the Codex CLI/ChatGPT subscription actually uses. That's a real design decision (new auth paradigm, ToS considerations) rather than a "fill in the TODO" change, so I've left it out rather than guessing at an implementation. Happy to take a pass at it in a follow-up if a maintainer can weigh in on the intended auth flow first.

## Testing

- `.venv/bin/pytest -q` — 889 passed, 1 skipped (pre-existing, unrelated)
- `npx tsc --noEmit` (surfaces/gui) — no errors
- `npx vitest run` (surfaces/gui) — 61 passed, 7 pre-existing failures unrelated to this change (confirmed identical on unmodified `main`)
- Manually ran the real backend + GUI dev servers and clicked through Settings ▸ Models: the OpenRouter card shows up in the right spot with its logo, the key field, the "Create one at openrouter.ai" link, the prefilled endpoint, and the four curated models listed under "Included models"

Fixes #22 (OpenRouter part).
