### PR TITLE
Fall back to another usable model when the default provider's key is removed

### DIFF
--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1560,7 +1560,31 @@ class SessionManager:
             return {"ok": False, "error": f"unknown provider: {name}"}
         self.secrets.delete(f"provider:{name}")
         self._refresh_provider(name)
+        # The removed provider was backing the active default: pinning `self.model` to a now-dead
+        # id left `model_ready` false and the composer stuck on "No model" even with another
+        # provider already usable (owner-hit #105). Fall back to whatever the picker already
+        # offers, same as it would show up if the user opened the dropdown themselves.
+        if self._model_provider(self.model) == name:
+            fallback = next(
+                (
+                    m
+                    for m in self._curated_models()
+                    if m != self.model and self._model_selectable(m)
+                ),
+                None,
+            )
+            if fallback:
+                self.set_default_model(fallback)
         return {"ok": True, "provider": name}
+
+    def _model_selectable(self, model: str) -> bool:
+        """Whether a model id is actually usable right now — its provider is configured
+        (or, for keyless Ollama, actually answering). Shared by `get_settings`'s picker
+        filter and `remove_provider`'s default-fallback search so both agree."""
+        provider = self._model_provider(model)
+        if provider == "ollama":
+            return self._ollama_alive()
+        return self._provider_configured(provider)
 
     def verify_provider(
         self, name: str, fields: Optional[dict[str, Any]]
@@ -1742,13 +1766,7 @@ class SessionManager:
         # (it's hidden behind the "No model" state until a provider is connected anyway).
         # Ollama is keyless, so "configured" is meaningless there — its models show only
         # while a local Ollama answers (cached liveness probe).
-        def _selectable(m: str) -> bool:
-            provider = self._model_provider(m)
-            if provider == "ollama":
-                return self._ollama_alive()
-            return self._provider_configured(provider)
-
-        selectable = [m for m in self._curated_models() if _selectable(m)]
+        selectable = [m for m in self._curated_models() if self._model_selectable(m)]
         if self.model not in selectable:
             selectable.insert(0, self.model)
         from ..providers.matrix import model_labels

--- a/tests/test_provider_router.py
+++ b/tests/test_provider_router.py
@@ -563,3 +563,44 @@ def test_manager_key_hygiene_stamps(tmp_path, monkeypatch):
     mgr2 = SessionManager(data_dir=tmp_path)
     provs2 = {p["name"]: p for p in mgr2.get_providers()}
     assert provs2["deepseek"]["last_used_at"] == first
+
+
+def test_remove_provider_falls_back_to_another_usable_default(tmp_path, monkeypatch):
+    """Removing the provider backing the active default must not strand the composer on a
+    dead model id (issue #105: "impossible to change models" after disconnecting OpenAI
+    while Ollama was already usable). It should fall back to another already-selectable
+    model instead of leaving model_ready false with nothing else offered."""
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    from coworker.server.manager import SessionManager
+
+    monkeypatch.setattr(SessionManager, "_ollama_alive", lambda self: True)
+    mgr = SessionManager(data_dir=tmp_path)
+
+    mgr.set_provider("openai", {"api_key": "sk-x"})
+    mgr.add_model("ollama:llama3.3")  # as if the user had already pulled + connected it
+    assert mgr.model == "gpt-5.6-sol"  # openai was configured first, so it stayed default
+    before = mgr.get_settings()
+    assert before["model_ready"] is True
+    assert "ollama:llama3.3" in before["models"]
+
+    mgr.remove_provider("openai")
+    assert mgr.model == "ollama:llama3.3"  # fell back instead of staying pinned to a dead id
+    after = mgr.get_settings()
+    assert after["model"] == "ollama:llama3.3"
+    assert after["model_ready"] is True
+
+
+def test_remove_provider_with_no_fallback_leaves_honest_not_ready_state(tmp_path, monkeypatch):
+    """When nothing else is usable, removal must still succeed and just report the honest
+    'no model connected' state — no crash, no phantom fallback."""
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    from coworker.server.manager import SessionManager
+
+    mgr = SessionManager(data_dir=tmp_path)
+    mgr.set_provider("openai", {"api_key": "sk-x"})
+    assert mgr.get_settings()["model_ready"] is True
+
+    res = mgr.remove_provider("openai")
+    assert res["ok"] is True
+    assert mgr.model == "gpt-5.6-sol"  # nothing else configured — nowhere to fall back to
+    assert mgr.get_settings()["model_ready"] is False


### PR DESCRIPTION
## Summary

Fixes the "impossible to change models" issue: removing a provider's key (e.g. disconnecting OpenAI to switch to Ollama) left the app stuck with no way to pick a different model, even though another provider was already configured.

## Root cause

`remove_provider()` (`coworker/server/manager.py`) deletes the provider's stored key/profile but never touched `self.model`. If the removed provider was backing the active default model, `self.model` stayed pinned to that now-dead id.

That matters because of two things downstream:

- `get_settings()`'s `model_ready` field is computed purely from whether `self.model`'s provider is configured — so it flips to `false` and stays there.
- In the GUI, `Composer.tsx`'s model dropdown only renders when `modelReady` is true; when it's false, the dropdown is replaced entirely by a "No model — connect a model" chip that routes to Settings. So once you're in this state, you can't even see or pick the model you already connected (e.g. Ollama) from the composer — you have to know to go dig through Settings ▸ Models and manually "Make default" on the other model first.

I traced this against a live `SessionManager`: after `set_provider("openai", ...)` then `remove_provider("openai")` with Ollama already configured and alive, `mgr.model` stayed on the OpenAI id and `model_ready` was `false`, even though Ollama was sitting right there in `get_settings()["models"]`.

## Fix

When the removed provider was backing the default, `remove_provider()` now picks another already-selectable model (using the same selectability check `get_settings()` uses for the picker — factored out into `_model_selectable()` so both stay in agreement) and calls the existing `set_default_model()` to switch to it. If nothing else is usable, it leaves the honest "no model connected" state, same as before — no phantom fallback.

This is a backend-only fix; the frontend behavior (hiding the picker when nothing is ready) is correct once the backend stops reporting a false "not ready."

## Testing

- `.venv/bin/pytest -q` — 891 passed (889 existing + 2 new), 1 skipped (pre-existing, unrelated)
- Ran the full suite 5 times total to rule out flakiness from the new tests; one unrelated one-off flake in `test_ui_refresh_e2e.py` reproduced on a single run and passed cleanly in isolation and in every other full run — not caused by this change.
- New regression tests in `tests/test_provider_router.py`:
  - `test_remove_provider_falls_back_to_another_usable_default` — configures OpenAI + an already-connected Ollama model, removes OpenAI, asserts the default switches to the Ollama model and `model_ready` is `true`.
  - `test_remove_provider_with_no_fallback_leaves_honest_not_ready_state` — removing the only configured provider still succeeds and correctly reports `model_ready: false`, no crash, no fabricated fallback.

Fixes #105.
