### PR TITLE
fix(secrets): create tmp files pre-restricted to close permission race

### DIFF
--- a/coworker/secrets.py
+++ b/coworker/secrets.py
@@ -88,6 +88,31 @@ def _restrict_to_user(path: Path, *, is_dir: bool) -> None:
     os.chmod(path, 0o700 if is_dir else 0o600)
 
 
+def _write_restricted(tmp: Path, content: str) -> None:
+    """Write `content` to `tmp`, never letting it exist at default (world/group-readable)
+    permissions.
+
+    POSIX: create the fd with mode 0600 up front via `os.open` — there's no window where
+    the file exists with the umask's default mode, unlike `Path.write_text()` followed by
+    a separate `chmod`. Windows has no creation-time mode bits, so we still fall back to a
+    post-write ACL restriction there (best-effort, same as before).
+    """
+    if _IS_WINDOWS:
+        tmp.write_text(content, encoding="utf-8")
+        _restrict_to_user(tmp, is_dir=False)
+        return
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+    except BaseException:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
 def write_private_text(path: str | Path, content: str) -> Path:
     """Atomically write a user-only text file using the SecretStore's OS protections."""
     target = Path(path).expanduser()
@@ -97,8 +122,7 @@ def write_private_text(path: str | Path, content: str) -> Path:
     except OSError:
         pass
     tmp = target.with_name(target.name + ".tmp")
-    tmp.write_text(content, encoding="utf-8")
-    _restrict_to_user(tmp, is_dir=False)
+    _write_restricted(tmp, content)
     os.replace(tmp, target)
     return target
 
@@ -188,6 +212,5 @@ class SecretStore:
         except OSError:
             pass
         tmp = self.path.with_name(self.path.name + ".tmp")
-        tmp.write_text(json.dumps(store, indent=2), encoding="utf-8")
-        _restrict_to_user(tmp, is_dir=False)
+        _write_restricted(tmp, json.dumps(store, indent=2))
         os.replace(tmp, self.path)

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -79,6 +79,40 @@ def test_secrets_file_is_restricted(tmp_path):
         assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
 
 
+def test_secrets_tmp_file_never_world_readable(tmp_path, monkeypatch):
+    """Regression test: the .tmp file used during an atomic write must be created already
+    restricted (0600), not written-then-chmod'd. A separate chmod-after-write leaves a window
+    where the plaintext secrets file has the process's default (often world/group-readable)
+    umask permissions. This asserts the file is 0600 the instant it's created, by checking its
+    mode inside a wrapped `os.open` before any subsequent chmod could run."""
+    if sys.platform == "win32":
+        return  # POSIX-only: Windows has no creation-time mode bits, see _restrict_to_user
+
+    observed_modes = []
+    real_open = os.open
+
+    def spy_open(path, flags, mode=0o777, *, dir_fd=None):
+        fd = (
+            real_open(path, flags, mode, dir_fd=dir_fd)
+            if dir_fd is not None
+            else real_open(path, flags, mode)
+        )
+        if str(path).endswith(".tmp"):
+            observed_modes.append(stat.S_IMODE(os.fstat(fd).st_mode))
+        return fd
+
+    monkeypatch.setattr(os, "open", spy_open)
+
+    path = tmp_path / "secrets.json"
+    SecretStore(path).put("x", {"a": 1})
+
+    assert observed_modes, "expected the .tmp file to be created via os.open"
+    assert all(m == 0o600 for m in observed_modes), (
+        f"tmp file was created at {[oct(m) for m in observed_modes]}, "
+        "not 0600 — it must never exist at default umask permissions"
+    )
+
+
 def test_delete(tmp_path):
     store = SecretStore(tmp_path / "secrets.json")
     store.put("x", {"a": 1})


### PR DESCRIPTION
- Fixed a security issue where temporary secrets files were briefly created with default permissions before being restricted.
- On shared systems, this could expose plaintext secrets or tokens to other users for a short time.
- Added a new helper, `_write_restricted()`, which creates temporary files with `0600` permissions from the beginning on POSIX systems.
- This removes the window where the file could be created with insecure permissions.
- Windows behavior remains unchanged, as it continues using the existing ACL-based permission handling.
- Added a regression test, `test_secrets_tmp_file_never_world_readable`, to ensure temporary files are always created with secure permissions.
- No functional changes were made—`put`, `get`, `delete`, and `write_private_text` continue to work exactly as before.