### PR TITLE
Add fastCRW as a web_search provider

### DIFF
--- a/coworker/config.py
+++ b/coworker/config.py
@@ -37,7 +37,8 @@ class Config:
     auto_allow: list[str] = field(default_factory=list)
     host: str = "127.0.0.1"
     port: int = 8765
-    # Web search provider: "duckduckgo" (keyless default) | "tavily" | "brave" (need a key).
+    # Web search provider: "duckduckgo" (keyless default) | "tavily" | "brave" |
+    # "fastcrw" (the last three need a key).
     web_search_provider: str = "duckduckgo"
     # OpenWorker Cloud (sign-in + managed connectors). Config, never constants:
     # dev/staging/BYO-VPC deployments point these at their own instances.

--- a/coworker/web/__init__.py
+++ b/coworker/web/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .providers import (
     BraveProvider,
     DuckDuckGoProvider,
+    FastCRWProvider,
     SearchResult,
     TavilyProvider,
     WebSearchProvider,
@@ -20,6 +21,7 @@ __all__ = [
     "DuckDuckGoProvider",
     "TavilyProvider",
     "BraveProvider",
+    "FastCRWProvider",
     "build_provider",
     "provider_names",
     "make_web_search_tool",

--- a/coworker/web/providers.py
+++ b/coworker/web/providers.py
@@ -1,8 +1,8 @@
 """Web search providers — a keyless default + pluggable third-party services.
 
-`duckduckgo` works with no API key (our "starting version of our own"). `tavily` and `brave`
-give better results but need a key (configured via the SecretStore / env). All providers
-return a uniform `list[SearchResult]`; the heavy client libs are lazy-imported.
+`duckduckgo` works with no API key (our "starting version of our own"). `tavily`, `brave`,
+and `fastcrw` give better results but need a key (configured via the SecretStore / env). All
+providers return a uniform `list[SearchResult]`; the heavy client libs are lazy-imported.
 """
 
 from __future__ import annotations
@@ -108,10 +108,63 @@ class BraveProvider(WebSearchProvider):
         ]
 
 
+class FastCRWProvider(WebSearchProvider):
+    """fastCRW web search (https://docs.fastcrw.com) via the hosted /v1 API."""
+
+    name = "fastcrw"
+    requires_key = True
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+        import httpx
+
+        resp = httpx.post(
+            "https://api.fastcrw.com/v1/search",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            # No `scrapeOptions`: it would scrape every hit for page content that
+            # SearchResult discards. `limit` maxes out at 20.
+            json={"query": query, "limit": max_results},
+            timeout=_TIMEOUT,
+        )
+        try:
+            data = resp.json()
+        except ValueError:  # a gateway's HTML error page, not a fastCRW envelope
+            data = {}
+        if not isinstance(data, dict) or data.get("success") is not True:
+            # fastCRW reports a bad key, quota and disabled search as
+            # {"success": false, "error": ...}, and can do so with a 200. Raise so the
+            # tool surfaces the message rather than the empty list a .get() chain would
+            # produce, which reads to the user as "no results for that query".
+            err = data if isinstance(data, dict) else {}
+            raise RuntimeError(err.get("error") or f"HTTP {resp.status_code}")
+        rows = data.get("data")
+        if not isinstance(rows, list):
+            # `data` is a required array. Anything else is a response we don't understand,
+            # and treating it as "no results" would be the same silent lie as above.
+            raise RuntimeError(f"unexpected response shape (HTTP {resp.status_code})")
+        results = [
+            SearchResult(
+                # `or ""` rather than a .get() default: JSON null is a present key.
+                title=r.get("title") or "",
+                url=r.get("url") or "",
+                # `snippet` is fastCRW's alias of `description`; either may be sent.
+                snippet=r.get("description") or r.get("snippet") or "",
+            )
+            for r in rows
+            if isinstance(r, dict) and r.get("url")  # a hit with no URL is not a hit
+        ]
+        if rows and not results:
+            raise RuntimeError(f"unexpected result shape (HTTP {resp.status_code})")
+        return results
+
+
 _PROVIDERS = {
     "duckduckgo": DuckDuckGoProvider,
     "tavily": TavilyProvider,
     "brave": BraveProvider,
+    "fastcrw": FastCRWProvider,
 }
 
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -8,6 +8,13 @@ model = "gpt-5.5"            # default model id (override per session in the UI/
 mode = "interactive"         # plan | interactive | auto | custom
 max_iterations = 12          # max model<->tool iterations per turn before stopping
 
+# Web search provider for the `web_search` tool.
+#   duckduckgo (keyless default) | tavily | brave | fastcrw
+# The keyed providers read their key from the SecretStore or a <PROVIDER>_API_KEY
+# env var — e.g. FASTCRW_API_KEY (https://docs.fastcrw.com). Note that a keyed
+# provider sends your query to that service.
+web_search_provider = "duckduckgo"
+
 # Commands auto-allowed without an approval prompt (prefix match).
 allowed_commands = [
   "ls", "cat", "pwd", "grep", "find",

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -1,7 +1,7 @@
 """Tests for web search — provider abstraction, the tool, and config resolution.
 
 No network: a FakeProvider is injected; third-party key handling and the REST config path
-are exercised without hitting DuckDuckGo/Tavily/Brave.
+are exercised without hitting DuckDuckGo/Tavily/Brave/fastCRW.
 """
 
 from __future__ import annotations
@@ -18,6 +18,7 @@ from coworker.web import (
 from coworker.web.providers import (
     BraveProvider,
     DuckDuckGoProvider,
+    FastCRWProvider,
     TavilyProvider,
     WebSearchProvider,
 )
@@ -81,6 +82,173 @@ def test_build_provider_third_party_requires_key():
     assert isinstance(build_provider("brave", "brv-x"), BraveProvider)
 
 
+def test_build_provider_fastcrw_requires_key():
+    with pytest.raises(ValueError):
+        build_provider("fastcrw")  # no key
+    assert isinstance(build_provider("fastcrw", "crw_live_x"), FastCRWProvider)
+    # Membership, not equality: provider_names() is list(_PROVIDERS), so asserting the
+    # whole list would break the moment anyone adds or reorders a provider.
+    assert "fastcrw" in provider_names()
+
+
+def test_provider_names_match_their_class_names():
+    from coworker.web.providers import _PROVIDERS
+
+    # resolve_provider derives the env var from the configured name while the tool
+    # reports cls.name; if the two ever diverge the key resolves but the report lies.
+    assert all(key == cls.name for key, cls in _PROVIDERS.items())
+
+
+class _Resp:
+    """Minimal httpx.Response stand-in: `json()` plus the `status_code` we fall back on."""
+
+    def __init__(self, payload, status=200):
+        self._payload, self.status_code = payload, status
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("Expecting value")  # non-JSON body
+        return self._payload
+
+
+def _patch_post(monkeypatch, resp, captured=None):
+    import httpx
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        if captured is not None:
+            captured.update(url=url, headers=headers, json=json, timeout=timeout)
+        return resp
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+
+def test_fastcrw_maps_flat_data_array(monkeypatch):
+    captured = {}
+    _patch_post(
+        monkeypatch,
+        _Resp(
+            {
+                "success": True,
+                # /v1/search returns `data` as a flat array of results.
+                "data": [
+                    {"title": "t0", "url": "https://x/0", "snippet": "s0"},
+                    {"title": "t1", "url": "https://x/1", "description": "d1"},
+                    {"title": "t2", "url": "https://x/2"},  # no snippet at all
+                ],
+            }
+        ),
+        captured,
+    )
+    results = FastCRWProvider("crw_live_x").search("openworker docs", max_results=3)
+
+    assert captured["url"] == "https://api.fastcrw.com/v1/search"
+    assert captured["headers"]["Authorization"] == "Bearer crw_live_x"
+    # Exact equality: an accidental `scrapeOptions` would scrape every hit.
+    assert captured["json"] == {"query": "openworker docs", "limit": 3}
+    assert [(r.title, r.url, r.snippet) for r in results] == [
+        ("t0", "https://x/0", "s0"),
+        ("t1", "https://x/1", "d1"),
+        ("t2", "https://x/2", ""),
+    ]
+
+
+def test_fastcrw_limit_stays_within_the_api_maximum(monkeypatch):
+    captured = {}
+    _patch_post(monkeypatch, _Resp({"success": True, "data": []}), captured)
+    make_web_search_tool(provider=FastCRWProvider("crw_live_x"))(
+        query="q", max_results=99
+    )
+    assert captured["json"]["limit"] == 10  # tool clamp, well under fastCRW's max of 20
+
+
+def test_fastcrw_bad_key_surfaces_through_the_tool(monkeypatch):
+    _patch_post(
+        monkeypatch,
+        _Resp({"success": False, "error": "Invalid or missing API key"}, status=401),
+    )
+    out = make_web_search_tool(provider=FastCRWProvider("bad"))(query="q")
+    assert out["provider"] == "fastcrw"
+    assert "Invalid or missing API key" in out["error"]
+
+
+def test_fastcrw_reports_failure_sent_with_a_200(monkeypatch):
+    # fastCRW can answer 200 with success:false, so status alone is not the signal.
+    _patch_post(monkeypatch, _Resp({"success": False, "error": "search_disabled"}))
+    out = make_web_search_tool(provider=FastCRWProvider("k"))(query="q")
+    assert "search_disabled" in out["error"]
+
+
+def test_fastcrw_non_json_body_reports_the_status(monkeypatch):
+    _patch_post(monkeypatch, _Resp(None, status=502))  # HTML from a gateway
+    out = make_web_search_tool(provider=FastCRWProvider("k"))(query="q")
+    assert "502" in out["error"]
+
+
+def test_fastcrw_rejects_a_response_shape_it_does_not_understand(monkeypatch):
+    # `data` is a required array. Returning [] for these would be the same silent
+    # "no results for that query" lie that checking `success` exists to prevent.
+    for body in ({"success": True}, {"success": True, "data": {}}, {"success": "yes"}):
+        _patch_post(monkeypatch, _Resp(body))
+        out = make_web_search_tool(provider=FastCRWProvider("k"))(query="q")
+        assert "error" in out and "results" not in out, out
+
+
+def test_fastcrw_empty_result_set_is_not_an_error(monkeypatch):
+    _patch_post(monkeypatch, _Resp({"success": True, "data": []}))
+    out = make_web_search_tool(provider=FastCRWProvider("k"))(query="q")
+    assert out == {"provider": "fastcrw", "results": []}
+
+
+def test_fastcrw_skips_unusable_rows_but_keeps_the_good_ones(monkeypatch):
+    # JSON null is a present key, so a .get() default would let None through.
+    _patch_post(
+        monkeypatch,
+        _Resp(
+            {
+                "success": True,
+                "data": [
+                    None,
+                    "junk",
+                    {},  # no url
+                    {"title": None, "url": "https://x/1", "description": None},
+                ],
+            }
+        ),
+    )
+    assert [(r.title, r.url, r.snippet) for r in FastCRWProvider("k").search("q")] == [
+        ("", "https://x/1", "")
+    ]
+
+
+def test_fastcrw_rejects_rows_it_cannot_use_at_all(monkeypatch):
+    # A non-empty array that yields nothing usable is a shape change, not "no hits" —
+    # reporting it as zero results would be the same silent lie as a swallowed 401.
+    _patch_post(monkeypatch, _Resp({"success": True, "data": [None, "junk", {}]}))
+    out = make_web_search_tool(provider=FastCRWProvider("k"))(query="q")
+    assert "error" in out and "results" not in out, out
+
+
+def test_fastcrw_non_dict_error_body_still_reports_the_status(monkeypatch):
+    # A CDN in front of the API can answer with a bare JSON list or string.
+    for body in (["Service Unavailable"], "maintenance", 0):
+        _patch_post(monkeypatch, _Resp(body, status=503))
+        out = make_web_search_tool(provider=FastCRWProvider("k"))(query="q")
+        assert "503" in out["error"], out
+        assert "has no attribute" not in out["error"], out
+
+
+def test_fastcrw_key_from_env(tmp_path, monkeypatch):
+    from coworker.web import resolve_provider
+
+    # The env var name is derived from the provider name, so this is what pins
+    # `fastcrw` (lowercase, no dash) as the only spelling that works.
+    monkeypatch.setenv("FASTCRW_API_KEY", "crw_live_env")
+    secrets = SecretStore(tmp_path / "secrets.json")
+    secrets.put("web_search:default", {"provider": "fastcrw"})
+    p = resolve_provider(secrets)
+    assert p.name == "fastcrw" and p.api_key == "crw_live_env"
+
+
 def test_tool_surfaces_missing_key_error(tmp_path):
     secrets = SecretStore(tmp_path / "secrets.json")
     secrets.put("web_search:default", {"provider": "tavily"})  # no api_key
@@ -123,6 +291,15 @@ def test_web_search_rest(tmp_path, monkeypatch):
     assert (
         client.post("/v1/web-search", json={"provider": "nope"}).json()["ok"] is False
     )
+    # Registering the provider is all it takes for the REST surface to accept it.
+    assert "fastcrw" in client.get("/v1/web-search").json()["providers"]
+    assert (
+        client.post(
+            "/v1/web-search", json={"provider": "fastcrw", "api_key": "crw_live_xyz"}
+        ).json()["ok"]
+        is True
+    )
+    assert "crw_live_xyz" not in client.get("/v1/web-search").text
 
 
 def test_engine_registers_web_search(tmp_path):


### PR DESCRIPTION
## Summary

Disclosure up front: I work on fastCRW, so treat this as a vendor PR and weigh it accordingly.

Adds `fastcrw` as a keyed `web_search` provider next to `tavily` and `brave`, following the
same shape as the existing keyed providers: one class, one `_PROVIDERS` entry, lazy `httpx`,
no new dependency.

While writing it I hit a bug that is worth more than the provider itself: **a wrong API key
currently returns `{"results": []}`, which is indistinguishable from "the web has no answer
for that query."** Tavily and Brave both do this, because they read the response with a
`.get()` chain that quietly yields nothing when the body is an error envelope:

```
>>> make_web_search_tool(provider=TavilyProvider("tvly-bogus"))(query="anything")
{'provider': 'tavily', 'results': []}
```

fastCRW returns a uniform `{"success": bool, "error": str}` envelope, so this provider checks
it and raises. `make_web_search_tool` already turns that into a real message:

```
>>> make_web_search_tool(secrets)(query="anything")   # with a bad fastCRW key
{'error': 'web search failed: Invalid or missing API key', 'provider': 'fastcrw'}
```

Happy to send the same one-line fix for Tavily and Brave as a separate PR if you want it — I
left them alone here because changing their behaviour is a change for existing users and
doesn't belong in an additive PR.

## Notes for review

- **`data` is a flat array.** `POST /v1/search` returns `{"success": true, "data": [ ... ]}`,
  not a nested object. Worth a second look if you are reading this next to #86, which maps a
  differently-shaped response.
- **No `scrapeOptions` in the request.** fastCRW can return page content inline, but
  `SearchResult` is `(title, url, snippet)`, so asking for it would be slower and billed for
  something this tool discards.
- **`success` is checked, not the status code.** The API can answer `success: false` with a
  200, so `raise_for_status()` alone would miss it — and it would also throw away the
  `error` string, which is the only part a user can act on.
- **Key resolution is the existing convention**, nothing new: the SecretStore profile
  `web_search:default`, or `FASTCRW_API_KEY` derived from the provider name.
- `docs/config.example.toml` gains a `web_search_provider` block. The file never documented
  that setting or the `<PROVIDER>_API_KEY` fallback, so this is the first place a user could
  learn either. **This touches the same lines as #86** — happy to rebase behind it, or to fold
  both providers into one comment line, whichever you prefer.
- `pyproject.toml` is untouched. `httpx` is already a core dependency.

## Why this one

fastCRW is the open-source engine's hosted API, and the same key also does page scraping and
crawling. I am not proposing any of that here — this PR is only the search provider — but it
means the fetch side could later go through the same account rather than a second vendor, and
the engine itself is self-hostable, which fits how this project treats local-first.

If the web-search provider surface is being designed internally right now, say so and I will
close this — no hard feelings, and I would rather not add noise to a queue you are already
working through.

## Test plan

`pytest tests -q` → **899 passed, 1 skipped** (up from 889; 10 new tests, no existing test
touched).

New tests cover the flat-array mapping, the exact request body, the `limit` clamp staying
under the API maximum, a 401 surfacing through the tool, `success: false` sent with a 200, a
non-JSON gateway body, `null` fields, malformed rows, a non-dict error body, and the
`FASTCRW_API_KEY` fallback. All offline — `httpx.post` is monkeypatched in the style the file
already uses.

Also exercised against the real API with a real key, not just mocks:

```
$ python -m pytest tests -q
899 passed, 1 skipped, 1 warning in 34.04s

# real key, real network, through resolve_provider
resolved provider: fastcrw
provider: fastcrw | results: 3
  - GitHub - andrewyng/openworker
    https://github.com/andrewyng/openworker
  - Andrew Ng Just Released OpenWorker: An Open-Source, Local-First ...
    https://www.marktechpost.com/2026/07/23/andrew-ng-just-released-openworker-...
  - Andrew Ng's OpenWorker: Open-Source Desktop AI That Returns Fini...
    https://radar.aitoolnet.com/guide/andrew-ngs-openworker-open-source-desktop-ai...

# bad key -> a message, not an empty list
{'error': 'web search failed: Invalid or missing API key', 'provider': 'fastcrw'}
```

## Screenshots

There is no web-search UI on `main` (that arrives with #58), so there is no screen to capture
— the equivalent is the REST surface, which picks the provider up from `provider_names()`
with no extra wiring:

```
$ curl -s -H "x-openworker-token: $TOKEN" localhost:8765/v1/web-search
{"provider":"duckduckgo","has_key":false,
 "providers":["duckduckgo","tavily","brave","fastcrw"]}

$ curl -s -X POST -H "x-openworker-token: $TOKEN" localhost:8765/v1/web-search \
    -d '{"provider":"fastcrw","api_key":"crw_live_..."}'
{"ok":true,"provider":"fastcrw"}

$ curl -s -H "x-openworker-token: $TOKEN" localhost:8765/v1/web-search
{"provider":"fastcrw","has_key":true,
 "providers":["duckduckgo","tavily","brave","fastcrw"]}
```

The key is stored and never echoed back, same as the other providers.

One thing for whoever lands #58: its `SEARCH_LABELS` / `SEARCH_HELP` / `SEARCH_LOGOS` maps are
hardcoded, so a provider added after it renders as a bare lowercase string with no logo. Not a
problem today, just needs an entry whenever that lands.
