### PR TITLE
Let web_fetch use the search provider's page scraper

### DIFF
--- a/coworker/agent.py
+++ b/coworker/agent.py
@@ -204,7 +204,7 @@ def build_engine(
         )
     # Web search + fetch: research tools for every agent (keyless DuckDuckGo default).
     registry.register(make_web_search_tool(secrets))
-    registry.register(make_web_fetch_tool())
+    registry.register(make_web_fetch_tool(secrets))
     # ask_user: the universal human-in-the-loop Q&A primitive (every agent; engine-intercepted).
     if question_asker is not None:
         registry.register(ask_user_tool())

--- a/coworker/config.py
+++ b/coworker/config.py
@@ -37,7 +37,8 @@ class Config:
     auto_allow: list[str] = field(default_factory=list)
     host: str = "127.0.0.1"
     port: int = 8765
-    # Web search provider: "duckduckgo" (keyless default) | "tavily" | "brave" (need a key).
+    # Web search provider: "duckduckgo" (keyless default) | "tavily" | "brave" |
+    # "fastcrw" (the last three need a key).
     web_search_provider: str = "duckduckgo"
     # OpenWorker Cloud (sign-in + managed connectors). Config, never constants:
     # dev/staging/BYO-VPC deployments point these at their own instances.

--- a/coworker/web/__init__.py
+++ b/coworker/web/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .providers import (
     BraveProvider,
     DuckDuckGoProvider,
+    FastCRWProvider,
     SearchResult,
     TavilyProvider,
     WebSearchProvider,
@@ -20,6 +21,7 @@ __all__ = [
     "DuckDuckGoProvider",
     "TavilyProvider",
     "BraveProvider",
+    "FastCRWProvider",
     "build_provider",
     "provider_names",
     "make_web_search_tool",

--- a/coworker/web/fetch.py
+++ b/coworker/web/fetch.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import re
 from html.parser import HTMLParser
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import aisuite as ai
+
+from ..secrets import SecretStore
 
 _MAX = 20000  # default chars returned
 
@@ -73,7 +75,22 @@ def _html_to_text(html: str) -> str:
     return re.sub(r"\n{3,}", "\n\n", "\n".join(parser.parts))
 
 
-def make_web_fetch_tool() -> Callable[..., Any]:
+def make_web_fetch_tool(
+    secrets: Optional[SecretStore] = None,
+    *,
+    provider: Optional[Any] = None,
+) -> Callable[..., Any]:
+    """Build the `web_fetch` tool. `provider` overrides resolution (used by tests)."""
+
+    def _scraper():
+        """The configured web provider's page scraper, if it has one."""
+        try:
+            from .tool import resolve_provider
+
+            return getattr(provider or resolve_provider(secrets), "scrape", None)
+        except Exception:  # unconfigured, or a keyed provider with no key
+            return None
+
     def web_fetch(url: str, max_chars: int = _MAX) -> dict[str, Any]:
         if not isinstance(url, str) or not url.lower().startswith(
             ("http://", "https://")
@@ -81,6 +98,24 @@ def make_web_fetch_tool() -> Callable[..., Any]:
             return {"error": "url must start with http:// or https://"}
         cap = max_chars if isinstance(max_chars, int) and max_chars > 0 else _MAX
         cap = min(cap, 100000)
+        scrape = _scraper()
+        if scrape is not None:
+            try:
+                page = scrape(url)
+            except Exception as exc:
+                # Deliberately NOT a fallback to the local client below: a URL the
+                # scraper refuses would otherwise be a reliable way to pick which
+                # code path runs, and the two do not have the same reach.
+                return {"error": f"fetch failed: {exc}"}
+            text = page.get("text") or ""
+            return {
+                "url": page.get("url") or url,
+                # What `text` IS. Reporting the origin's type here would be wrong:
+                # the local branch below keys its stripping off exactly this field.
+                "content_type": "text/markdown",
+                "truncated": len(text) > cap,
+                "text": text[:cap],
+            }
         try:
             import httpx
 

--- a/coworker/web/providers.py
+++ b/coworker/web/providers.py
@@ -159,6 +159,44 @@ class FastCRWProvider(WebSearchProvider):
             raise RuntimeError(f"unexpected result shape (HTTP {resp.status_code})")
         return results
 
+    def scrape(self, url: str) -> dict[str, str]:
+        """Markdown for one page. Optional capability, duck-typed by web/fetch.py."""
+        import httpx
+
+        resp = httpx.post(
+            "https://api.fastcrw.com/v1/scrape",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            # deadlineMs is the server-side budget (max 60000). Keeping it under the
+            # client timeout means a slow page comes back as a message we can report
+            # rather than as a socket we hung up on.
+            json={
+                "url": url,
+                "formats": ["markdown"],
+                "onlyMainContent": True,
+                "deadlineMs": 15000,
+            },
+            timeout=_TIMEOUT,
+        )
+        try:
+            body = resp.json()
+        except ValueError:
+            body = {}
+        if not isinstance(body, dict) or body.get("success") is not True:
+            err = body if isinstance(body, dict) else {}
+            raise RuntimeError(err.get("error") or f"HTTP {resp.status_code}")
+        data = body.get("data") or {}
+        meta = data.get("metadata") or {}
+        status = meta.get("statusCode")
+        if isinstance(status, int) and status >= 400:
+            # Follows the local path's raise_for_status(): an error page is not content,
+            # even though the scrape itself succeeded in fetching it. Weaker than the
+            # local check though — a JS-rendered page can report 200 for an origin 404.
+            raise RuntimeError(f"upstream HTTP {status}")
+        return {
+            "url": meta.get("sourceURL") or url,
+            "text": data.get("markdown") or "",
+        }
+
 
 _PROVIDERS = {
     "duckduckgo": DuckDuckGoProvider,

--- a/coworker/web/providers.py
+++ b/coworker/web/providers.py
@@ -1,8 +1,8 @@
 """Web search providers — a keyless default + pluggable third-party services.
 
-`duckduckgo` works with no API key (our "starting version of our own"). `tavily` and `brave`
-give better results but need a key (configured via the SecretStore / env). All providers
-return a uniform `list[SearchResult]`; the heavy client libs are lazy-imported.
+`duckduckgo` works with no API key (our "starting version of our own"). `tavily`, `brave`,
+and `fastcrw` give better results but need a key (configured via the SecretStore / env). All
+providers return a uniform `list[SearchResult]`; the heavy client libs are lazy-imported.
 """
 
 from __future__ import annotations
@@ -108,10 +108,63 @@ class BraveProvider(WebSearchProvider):
         ]
 
 
+class FastCRWProvider(WebSearchProvider):
+    """fastCRW web search (https://docs.fastcrw.com) via the hosted /v1 API."""
+
+    name = "fastcrw"
+    requires_key = True
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+        import httpx
+
+        resp = httpx.post(
+            "https://api.fastcrw.com/v1/search",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            # No `scrapeOptions`: it would scrape every hit for page content that
+            # SearchResult discards. `limit` maxes out at 20.
+            json={"query": query, "limit": max_results},
+            timeout=_TIMEOUT,
+        )
+        try:
+            data = resp.json()
+        except ValueError:  # a gateway's HTML error page, not a fastCRW envelope
+            data = {}
+        if not isinstance(data, dict) or data.get("success") is not True:
+            # fastCRW reports a bad key, quota and disabled search as
+            # {"success": false, "error": ...}, and can do so with a 200. Raise so the
+            # tool surfaces the message rather than the empty list a .get() chain would
+            # produce, which reads to the user as "no results for that query".
+            err = data if isinstance(data, dict) else {}
+            raise RuntimeError(err.get("error") or f"HTTP {resp.status_code}")
+        rows = data.get("data")
+        if not isinstance(rows, list):
+            # `data` is a required array. Anything else is a response we don't understand,
+            # and treating it as "no results" would be the same silent lie as above.
+            raise RuntimeError(f"unexpected response shape (HTTP {resp.status_code})")
+        results = [
+            SearchResult(
+                # `or ""` rather than a .get() default: JSON null is a present key.
+                title=r.get("title") or "",
+                url=r.get("url") or "",
+                # `snippet` is fastCRW's alias of `description`; either may be sent.
+                snippet=r.get("description") or r.get("snippet") or "",
+            )
+            for r in rows
+            if isinstance(r, dict) and r.get("url")  # a hit with no URL is not a hit
+        ]
+        if rows and not results:
+            raise RuntimeError(f"unexpected result shape (HTTP {resp.status_code})")
+        return results
+
+
 _PROVIDERS = {
     "duckduckgo": DuckDuckGoProvider,
     "tavily": TavilyProvider,
     "brave": BraveProvider,
+    "fastcrw": FastCRWProvider,
 }
 
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -8,6 +8,13 @@ model = "gpt-5.5"            # default model id (override per session in the UI/
 mode = "interactive"         # plan | interactive | auto | custom
 max_iterations = 12          # max model<->tool iterations per turn before stopping
 
+# Web search provider for the `web_search` tool.
+#   duckduckgo (keyless default) | tavily | brave | fastcrw
+# The keyed providers read their key from the SecretStore or a <PROVIDER>_API_KEY
+# env var — e.g. FASTCRW_API_KEY (https://docs.fastcrw.com). Note that a keyed
+# provider sends your query to that service.
+web_search_provider = "duckduckgo"
+
 # Commands auto-allowed without an approval prompt (prefix match).
 allowed_commands = [
   "ls", "cat", "pwd", "grep", "find",

--- a/tests/test_code_tools.py
+++ b/tests/test_code_tools.py
@@ -41,7 +41,9 @@ def test_grep_finds_matches_and_respects_glob(tmp_path):
     assert only_py["matches"][0]["line"] == 1
 
 
-def test_ripgrep_uses_the_same_ignored_dirs_as_the_python_fallback(tmp_path, monkeypatch):
+def test_ripgrep_uses_the_same_ignored_dirs_as_the_python_fallback(
+    tmp_path, monkeypatch
+):
     import coworker.tools.search as search
 
     commands = []
@@ -151,6 +153,101 @@ def test_html_to_text_strips_scripts_and_tags():
     text = _html_to_text(html)
     assert "Hi" in text and "Body text" in text
     assert "bad()" not in text and "x{}" not in text
+
+
+class _ScrapingProvider:
+    """A provider that offers the optional `scrape` capability (only fastCRW does)."""
+
+    name = "scraper"
+
+    def __init__(self, text="# Title\n\nBody", url="https://example.com/final"):
+        self._text, self._url = text, url
+
+    def scrape(self, url):
+        return {"url": self._url, "text": self._text}
+
+
+def _stub_local_client(monkeypatch, calls):
+    """Replace httpx.Client so the local path is both observable and offline."""
+    import httpx
+
+    class _Client:
+        def __init__(self, **kw):
+            calls.append("constructed")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def get(self, url):
+            return SimpleNamespace(
+                headers={"content-type": "text/html"},
+                text="<html><body><p>local path</p></body></html>",
+                url=url,
+                raise_for_status=lambda: None,
+            )
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+
+
+def test_web_fetch_uses_the_provider_scraper_when_one_exists(monkeypatch):
+    calls = []
+    _stub_local_client(monkeypatch, calls)
+    out = make_web_fetch_tool(provider=_ScrapingProvider())("https://example.com")
+    assert out["text"] == "# Title\n\nBody"
+    assert out["url"] == "https://example.com/final"
+    assert out["content_type"] == "text/markdown"
+    assert out["truncated"] is False
+    assert calls == []  # the local client was never constructed
+
+
+def test_web_fetch_uses_the_local_path_when_the_provider_cannot_scrape(monkeypatch):
+    calls = []
+    _stub_local_client(monkeypatch, calls)
+
+    class _SearchOnly:  # duckduckgo / tavily / brave — no `scrape` attribute
+        name = "search-only"
+
+    out = make_web_fetch_tool(provider=_SearchOnly())("https://example.com")
+    assert out["text"] == "local path"
+    assert out["content_type"] == "text/html"
+    assert calls == ["constructed"]
+
+
+def test_web_fetch_does_not_fall_back_to_the_local_path_on_a_scrape_error(monkeypatch):
+    # A failure-triggered fallback would let a chosen URL select which path runs.
+    calls = []
+    _stub_local_client(monkeypatch, calls)
+
+    class _Boom:
+        name = "boom"
+
+        def scrape(self, url):
+            raise RuntimeError("scrape API down")
+
+    out = make_web_fetch_tool(provider=_Boom())("https://example.com")
+    assert out["error"] == "fetch failed: scrape API down"
+    assert calls == []  # crucially, the local client never ran
+
+
+def test_web_fetch_scraped_text_respects_max_chars():
+    out = make_web_fetch_tool(provider=_ScrapingProvider(text="x" * 300))(
+        "https://example.com", max_chars=100
+    )
+    assert len(out["text"]) == 100 and out["truncated"] is True
+
+
+def test_web_fetch_scheme_guard_runs_before_any_provider(monkeypatch):
+    class _NeverCalled:
+        name = "never"
+
+        def scrape(self, url):  # pragma: no cover - must not run
+            raise AssertionError("scraper ran for a non-http scheme")
+
+    out = make_web_fetch_tool(provider=_NeverCalled())("file:///etc/passwd")
+    assert "http" in out["error"]
 
 
 # -- Code agent wiring ---------------------------------------------------------

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -1,7 +1,7 @@
 """Tests for web search — provider abstraction, the tool, and config resolution.
 
 No network: a FakeProvider is injected; third-party key handling and the REST config path
-are exercised without hitting DuckDuckGo/Tavily/Brave.
+are exercised without hitting DuckDuckGo/Tavily/Brave/fastCRW.
 """
 
 from __future__ import annotations
@@ -18,6 +18,7 @@ from coworker.web import (
 from coworker.web.providers import (
     BraveProvider,
     DuckDuckGoProvider,
+    FastCRWProvider,
     TavilyProvider,
     WebSearchProvider,
 )
@@ -81,6 +82,173 @@ def test_build_provider_third_party_requires_key():
     assert isinstance(build_provider("brave", "brv-x"), BraveProvider)
 
 
+def test_build_provider_fastcrw_requires_key():
+    with pytest.raises(ValueError):
+        build_provider("fastcrw")  # no key
+    assert isinstance(build_provider("fastcrw", "crw_live_x"), FastCRWProvider)
+    # Membership, not equality: provider_names() is list(_PROVIDERS), so asserting the
+    # whole list would break the moment anyone adds or reorders a provider.
+    assert "fastcrw" in provider_names()
+
+
+def test_provider_names_match_their_class_names():
+    from coworker.web.providers import _PROVIDERS
+
+    # resolve_provider derives the env var from the configured name while the tool
+    # reports cls.name; if the two ever diverge the key resolves but the report lies.
+    assert all(key == cls.name for key, cls in _PROVIDERS.items())
+
+
+class _Resp:
+    """Minimal httpx.Response stand-in: `json()` plus the `status_code` we fall back on."""
+
+    def __init__(self, payload, status=200):
+        self._payload, self.status_code = payload, status
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("Expecting value")  # non-JSON body
+        return self._payload
+
+
+def _patch_post(monkeypatch, resp, captured=None):
+    import httpx
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        if captured is not None:
+            captured.update(url=url, headers=headers, json=json, timeout=timeout)
+        return resp
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+
+def test_fastcrw_maps_flat_data_array(monkeypatch):
+    captured = {}
+    _patch_post(
+        monkeypatch,
+        _Resp(
+            {
+                "success": True,
+                # /v1/search returns `data` as a flat array of results.
+                "data": [
+                    {"title": "t0", "url": "https://x/0", "snippet": "s0"},
+                    {"title": "t1", "url": "https://x/1", "description": "d1"},
+                    {"title": "t2", "url": "https://x/2"},  # no snippet at all
+                ],
+            }
+        ),
+        captured,
+    )
+    results = FastCRWProvider("crw_live_x").search("openworker docs", max_results=3)
+
+    assert captured["url"] == "https://api.fastcrw.com/v1/search"
+    assert captured["headers"]["Authorization"] == "Bearer crw_live_x"
+    # Exact equality: an accidental `scrapeOptions` would scrape every hit.
+    assert captured["json"] == {"query": "openworker docs", "limit": 3}
+    assert [(r.title, r.url, r.snippet) for r in results] == [
+        ("t0", "https://x/0", "s0"),
+        ("t1", "https://x/1", "d1"),
+        ("t2", "https://x/2", ""),
+    ]
+
+
+def test_fastcrw_limit_stays_within_the_api_maximum(monkeypatch):
+    captured = {}
+    _patch_post(monkeypatch, _Resp({"success": True, "data": []}), captured)
+    make_web_search_tool(provider=FastCRWProvider("crw_live_x"))(
+        query="q", max_results=99
+    )
+    assert captured["json"]["limit"] == 10  # tool clamp, well under fastCRW's max of 20
+
+
+def test_fastcrw_bad_key_surfaces_through_the_tool(monkeypatch):
+    _patch_post(
+        monkeypatch,
+        _Resp({"success": False, "error": "Invalid or missing API key"}, status=401),
+    )
+    out = make_web_search_tool(provider=FastCRWProvider("bad"))(query="q")
+    assert out["provider"] == "fastcrw"
+    assert "Invalid or missing API key" in out["error"]
+
+
+def test_fastcrw_reports_failure_sent_with_a_200(monkeypatch):
+    # fastCRW can answer 200 with success:false, so status alone is not the signal.
+    _patch_post(monkeypatch, _Resp({"success": False, "error": "search_disabled"}))
+    out = make_web_search_tool(provider=FastCRWProvider("k"))(query="q")
+    assert "search_disabled" in out["error"]
+
+
+def test_fastcrw_non_json_body_reports_the_status(monkeypatch):
+    _patch_post(monkeypatch, _Resp(None, status=502))  # HTML from a gateway
+    out = make_web_search_tool(provider=FastCRWProvider("k"))(query="q")
+    assert "502" in out["error"]
+
+
+def test_fastcrw_rejects_a_response_shape_it_does_not_understand(monkeypatch):
+    # `data` is a required array. Returning [] for these would be the same silent
+    # "no results for that query" lie that checking `success` exists to prevent.
+    for body in ({"success": True}, {"success": True, "data": {}}, {"success": "yes"}):
+        _patch_post(monkeypatch, _Resp(body))
+        out = make_web_search_tool(provider=FastCRWProvider("k"))(query="q")
+        assert "error" in out and "results" not in out, out
+
+
+def test_fastcrw_empty_result_set_is_not_an_error(monkeypatch):
+    _patch_post(monkeypatch, _Resp({"success": True, "data": []}))
+    out = make_web_search_tool(provider=FastCRWProvider("k"))(query="q")
+    assert out == {"provider": "fastcrw", "results": []}
+
+
+def test_fastcrw_skips_unusable_rows_but_keeps_the_good_ones(monkeypatch):
+    # JSON null is a present key, so a .get() default would let None through.
+    _patch_post(
+        monkeypatch,
+        _Resp(
+            {
+                "success": True,
+                "data": [
+                    None,
+                    "junk",
+                    {},  # no url
+                    {"title": None, "url": "https://x/1", "description": None},
+                ],
+            }
+        ),
+    )
+    assert [(r.title, r.url, r.snippet) for r in FastCRWProvider("k").search("q")] == [
+        ("", "https://x/1", "")
+    ]
+
+
+def test_fastcrw_rejects_rows_it_cannot_use_at_all(monkeypatch):
+    # A non-empty array that yields nothing usable is a shape change, not "no hits" —
+    # reporting it as zero results would be the same silent lie as a swallowed 401.
+    _patch_post(monkeypatch, _Resp({"success": True, "data": [None, "junk", {}]}))
+    out = make_web_search_tool(provider=FastCRWProvider("k"))(query="q")
+    assert "error" in out and "results" not in out, out
+
+
+def test_fastcrw_non_dict_error_body_still_reports_the_status(monkeypatch):
+    # A CDN in front of the API can answer with a bare JSON list or string.
+    for body in (["Service Unavailable"], "maintenance", 0):
+        _patch_post(monkeypatch, _Resp(body, status=503))
+        out = make_web_search_tool(provider=FastCRWProvider("k"))(query="q")
+        assert "503" in out["error"], out
+        assert "has no attribute" not in out["error"], out
+
+
+def test_fastcrw_key_from_env(tmp_path, monkeypatch):
+    from coworker.web import resolve_provider
+
+    # The env var name is derived from the provider name, so this is what pins
+    # `fastcrw` (lowercase, no dash) as the only spelling that works.
+    monkeypatch.setenv("FASTCRW_API_KEY", "crw_live_env")
+    secrets = SecretStore(tmp_path / "secrets.json")
+    secrets.put("web_search:default", {"provider": "fastcrw"})
+    p = resolve_provider(secrets)
+    assert p.name == "fastcrw" and p.api_key == "crw_live_env"
+
+
 def test_tool_surfaces_missing_key_error(tmp_path):
     secrets = SecretStore(tmp_path / "secrets.json")
     secrets.put("web_search:default", {"provider": "tavily"})  # no api_key
@@ -123,6 +291,15 @@ def test_web_search_rest(tmp_path, monkeypatch):
     assert (
         client.post("/v1/web-search", json={"provider": "nope"}).json()["ok"] is False
     )
+    # Registering the provider is all it takes for the REST surface to accept it.
+    assert "fastcrw" in client.get("/v1/web-search").json()["providers"]
+    assert (
+        client.post(
+            "/v1/web-search", json={"provider": "fastcrw", "api_key": "crw_live_xyz"}
+        ).json()["ok"]
+        is True
+    )
+    assert "crw_live_xyz" not in client.get("/v1/web-search").text
 
 
 def test_engine_registers_web_search(tmp_path):


### PR DESCRIPTION
## Summary

Disclosure up front: I work on fastCRW, same as in #146.

**Stacked on #146** — it adds the provider class this builds on, so the diff below includes
that commit. The change to review here is the second one,
[`web_fetch` routing](https://github.com/andrewyng/openworker/pull/147/files). If #146 lands,
this rebases to ~+170. If it doesn't, close this one with it.

`web_fetch` today does `httpx.get` plus a hand-written `HTMLParser` strip. That works, but the
strip throws away every link target, heading and table — the model gets whitespace-joined text
with no structure. This lets a provider that can render a page return markdown instead, when
one is configured.

Concretely, the front page of this site through each path:

```
# today
Hacker News new | past | comments | ask | show | jobs | submit login 1. Stolen Buttons (
anatolyzenkov.com ) 217 points by Gecko4072 4 hours ago | hide | 59&nbsp;comments 2. Open-
weight AI is having its Kubernetes moment. Let&#x27;s not ruin it ( knaup.me ) 105 points ...

# with a scrape-capable provider configured
**[Hacker News](news)**[new](newest) | [past](front) | [comments](newcomments) | ...

1.
[Stolen Buttons](https://anatolyzenkov.com/stolen-buttons)
217 points by [Gecko4072](user?id=Gecko4072) 4 hours ago | [59 comments](item?id=48976262)
```

## What this does not change

`WebSearchProvider` is untouched — no new abstract method, no second ABC. `fetch.py` asks
`getattr(provider, "scrape", None)`, and only fastCRW defines it. For `duckduckgo`, `tavily`
and `brave` the attribute is absent, so the local path runs the identical bytes it runs today.
There is a test for exactly that.

The one behaviour change worth stating plainly: **setting `web_search_provider = "fastcrw"`
also changes what `web_fetch` returns.** One setting, two tools. I think that is right — same
account, same key, and a user who picked a provider that can render pages presumably wants
rendered pages — but if you'd rather have a separate `web_fetch_provider` field, say so and
I'll switch it.

## One honest caveat

An origin 4xx/5xx becomes an error, following the local path's `raise_for_status()` — but it
is a **weaker** check than the local one, and worth knowing before you merge. The scraper
reports the origin status in its metadata, and a JS-rendered page can come back as `200` even
when the origin returned 404. Measured, same commit:

```
news.ycombinator.com/nope-xyz-404   -> statusCode 404 -> {'error': 'fetch failed: ... 404 Not Found'}
github.com/<a 404 path>             -> statusCode 200 -> the rendered 404 page, as content
```

The local path would have raised on both. So on the provider path a "page not found" body can
reach the model as ordinary content. I would rather state that than have you find it. If that
matters more than the markdown does, the fix belongs upstream of this PR — in what the
scraper reports — and I will chase it there.

## On #100

This does **not** fix #100 and does not claim to. The local `httpx` path is unchanged and
still has no IP filtering; it is the default for everyone who has not configured a
scrape-capable provider.

Two things worth knowing while that issue is open:

- On the provider path the fetch happens off-box, so loopback, link-local and RFC1918 targets
  are out of reach for it. That is a side effect, not a fix.
- **There is deliberately no fallback from the provider path to the local one.** A
  failure-triggered fallback would let an injected URL — one crafted so the scraper refuses it
  — reliably select the unprotected path. So a scrape error returns an error. That is the one
  test I would not drop.

Also: routing through a provider means the URL is disclosed to it. That is a real trade, the
config comment says so, and it only happens if the user configures a keyed provider.

## Test plan

`pytest tests -q` → **906 passed, 1 skipped** (5 new tests on top of #146's).

New tests: the provider path is used when a scraper exists, the local path when it doesn't,
a scrape error does **not** construct the local client, `max_chars` truncation, and the scheme
guard still running first. `httpx.Client` is stubbed so the local path is both observable and
offline.

Exercised against the real API too, not just stubs:

```
url: https://news.ycombinator.com/
content_type: text/markdown | truncated: True
text: [![](y18.svg)](https://news.ycombinator.com) **[Hacker News](news)**[new](newest) | ...

# an origin 404 the scraper reports as 404 becomes an error, not content
{'error': 'fetch failed: Target returned 404 Not Found'}

# bad key
{'error': 'fetch failed: Invalid or missing API key'}
```

## Screenshots

No UI is involved — `web_fetch` has no settings surface and this adds none. The before/after
above is the terminal equivalent: same URL, same tool, structure preserved instead of stripped.
