### PR TITLE
docs: fix grammar — 'a internal' → 'an internal' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ OpenWorker was originally developed inside the aisuite repository before moving 
 
 Contributions and bug reports are welcome - open an [issue](https://github.com/andrewyng/openworker/issues) or a pull request. The app updates itself, so fixes reach installs quickly.
 For any PR, please attach screenshots of what was broken and how it is fixed now. We will shortly add features that you can contribute to.
-Please note that we are actively developing based off a internal list and goal, so we may not approve PRs that add features that are already under-development or deviates from our vision.
+Please note that we are actively developing based off an internal list and goal, so we may not approve PRs that add features that are already under-development or deviates from our vision.
 
 ## License
 


### PR DESCRIPTION
## Documentation Fix

**File:** `README.md`
**Line:** 115
**Category:** grammar
**Severity:** minor

### Problem
Missing article: `'based off a internal list'` should be `'based off an internal list'` (vowel sound requires 'an').

### Fix
Changed `'a internal'` → `'an internal'`.

### Verification
- [x] Fix applied to the exact line (115)
- [x] No other occurrences in the file
- [x] No functional code changes — documentation only