### PR TITLE
docs: fix grammar — 'signing-in', 'API-keys', 'the App' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A curated model list marks what we've verified for tool-calling work. Adding any
 
 ## Privacy
 
-OpenWorker is local-first. Everything lives on your machine: the agent loop, your conversations, connector tokens, and model keys - all in the app's local secret store. The only cloud piece is a small service that brokers OAuth handshakes for connectors. You can always use the App without signing-in - use the connectors via manually-created credentials/API-keys.
+OpenWorker is local-first. Everything lives on your machine: the agent loop, your conversations, connector tokens, and model keys - all in the app's local secret store. The only cloud piece is a small service that brokers OAuth handshakes for connectors. You can always use the app without signing in — use the connectors via manually-created credentials / API keys.
 
 ## Run from source
 


### PR DESCRIPTION
## Documentation Fix

**File:** `README.md`
**Line:** 61
**Category:** grammar
**Severity:** minor

### Problem
Three grammar issues on one line:
- `'signing-in'` should be `'signing in'` (verb form is two words, not hyphenated)
- `'API-keys'` should be `'API keys'` (missing space)
- `'the App'` is capitalized inconsistently — everywhere else uses `'the app'` (lowercase)

### Fix
Changed to: `'use the app without signing in — use the connectors via manually-created credentials / API keys'`

### Verification
- [x] Fix applied to line 61
- [x] No other occurrences of these patterns in the file
- [x] No functional code changes — documentation only