### PR TITLE
fix(web): cap web_fetch downloads at a byte budget instead of buffering entire bodies

### DIFF
--- a/coworker/web/fetch.py
+++ b/coworker/web/fetch.py
@@ -15,6 +15,9 @@ import aisuite as ai
 
 _MAX = 20000  # default chars returned
 
+# Transfer cap — `max_chars` trims what is returned, not what is downloaded.
+_MAX_DOWNLOAD_BYTES = 5 * 1024 * 1024
+
 _SCHEMA = {
     "type": "function",
     "function": {
@@ -89,18 +92,26 @@ def make_web_fetch_tool() -> Callable[..., Any]:
                 timeout=20.0,
                 headers={"User-Agent": "coworker/0.1 (+desktop)"},
             ) as client:
-                resp = client.get(url)
-                resp.raise_for_status()
-                ctype = resp.headers.get("content-type", "")
-                body = resp.text
-                final_url = str(resp.url)
+                with client.stream("GET", url) as resp:
+                    resp.raise_for_status()
+                    ctype = resp.headers.get("content-type", "")
+                    raw = bytearray()
+                    body_truncated = False
+                    for chunk in resp.iter_bytes():
+                        raw.extend(chunk)
+                        if len(raw) >= _MAX_DOWNLOAD_BYTES:
+                            body_truncated = True
+                            break
+                    encoding = resp.encoding or "utf-8"
+                    final_url = str(resp.url)
+            body = bytes(raw).decode(encoding, errors="replace")
         except Exception as exc:  # network / HTTP / TLS
             return {"error": f"fetch failed: {exc}"}
         text = _html_to_text(body) if "html" in ctype.lower() else body
         return {
             "url": final_url,
             "content_type": ctype,
-            "truncated": len(text) > cap,
+            "truncated": body_truncated or len(text) > cap,
             "text": text[:cap],
         }
 

--- a/tests/test_web_fetch.py
+++ b/tests/test_web_fetch.py
@@ -1,0 +1,85 @@
+"""Tests for `web_fetch` — text extraction and the transfer-level download cap."""
+
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from coworker.web.fetch import _MAX_DOWNLOAD_BYTES, make_web_fetch_tool
+
+_CHUNK = b"x" * 65536
+_HUGE_CHUNKS = 400  # ~25 MB
+
+
+class _Handler(BaseHTTPRequestHandler):
+    bytes_sent = 0
+
+    def do_GET(self):  # noqa: N802
+        if self.path == "/huge":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            try:
+                for _ in range(_HUGE_CHUNKS):
+                    self.wfile.write(_CHUNK)
+                    type(self).bytes_sent += len(_CHUNK)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            return
+        if self.path == "/page":
+            body = (
+                b"<html><head><style>p { color: red }</style></head>"
+                b"<body><p>hello world</p></body></html>"
+            )
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture()
+def server_url():
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_rejects_non_http_urls():
+    web_fetch = make_web_fetch_tool()
+    assert "error" in web_fetch("ftp://example.com/file")
+    assert "error" in web_fetch("file:///etc/hosts")
+
+
+def test_html_stripped_to_text(server_url):
+    web_fetch = make_web_fetch_tool()
+    result = web_fetch(server_url + "/page")
+    assert "error" not in result
+    assert "hello world" in result["text"]
+    assert "color: red" not in result["text"]
+    assert result["truncated"] is False
+
+
+def test_huge_body_download_is_capped(server_url):
+    """The client must hang up near the byte budget, not buffer the whole body."""
+    _Handler.bytes_sent = 0
+    web_fetch = make_web_fetch_tool()
+    result = web_fetch(server_url + "/huge")
+    assert "error" not in result
+    assert result["truncated"] is True
+    assert len(result["text"]) <= 20000
+    # 3x budget allows for OS socket buffering on loopback; the server offered ~25 MB.
+    assert _Handler.bytes_sent < 3 * _MAX_DOWNLOAD_BYTES


### PR DESCRIPTION
Fixes #156

### Problem

`web_fetch` fetched with `client.get(url)` + `resp.text`, buffering the entire response body into memory before `max_chars` trimmed what is returned. `max_chars` bounds the *output*, not the *download* — so a large file or an endless streaming endpoint could grow the local agent server's memory without bound. Since the tool runs without approval, a single bad link in a page the agent is researching is enough to trigger it.

### Fix

- Stream the response (`client.stream`) and stop reading once a **5 MiB transfer budget** is reached — generous headroom for the largest allowed `max_chars=100000`, since HTML strips down heavily.
- Decode whatever arrived using the response's declared encoding (fallback UTF-8, `errors="replace"`), preserving the previous decoding behavior for normal pages.
- `truncated` now also reflects a capped transfer, not just output trimming.

Behavior for normal pages is unchanged: same headers, redirects, timeout, HTML-to-text extraction, and result shape.

### Tests

`web_fetch` had no test coverage; this adds `tests/test_web_fetch.py`:

- rejects non-`http(s)` URLs,
- strips HTML to visible text (script/style skipped),
- **regression test**: a local server offers ~25 MB; asserts the result is truncated and the server's byte counter shows the client hung up near the budget (would fail with the old buffer-everything behavior).

Full suite: 883 passed; the only failures (`test_fake_slack`, `test_ui_refresh_e2e`) fail identically on unmodified `main` in my environment, so they are pre-existing.
