### PR TITLE
[codex] Fix sidebar reveal button flicker

### DIFF
--- a/surfaces/gui/e2e/nav-collapse.spec.ts
+++ b/surfaces/gui/e2e/nav-collapse.spec.ts
@@ -23,10 +23,45 @@ test("collapse hides the sidebar and reclaims the width; reveal button docks it 
 test("⌘B toggles the sidebar collapse", async ({ page }) => {
   await page.goto("/");
   const app = page.locator(".app");
+  await expect(page.locator(".sidebar")).toBeVisible();
   await page.keyboard.press("Meta+b");
   await expect(app).toHaveClass(/nav-collapsed/);
   await page.keyboard.press("Meta+b");
   await expect(app).not.toHaveClass(/nav-collapsed/);
+});
+
+test("reveal button stays clickable on non-session screens", async ({ page }) => {
+  await page.goto("/");
+  const app = page.locator(".app");
+
+  // Settings uses the standalone reveal button instead of the session topbar cluster.
+  await page.getByTestId("account-row").click();
+  await page.getByTestId("account-menu").getByText("Settings", { exact: true }).click();
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+
+  const reveal = page.getByRole("button", { name: "Show sidebar" });
+  await expect(reveal).toBeVisible();
+  await reveal.hover();
+
+  // Hovering the explicit control must not replace its own click target with a transient peek.
+  await expect(reveal).toBeVisible();
+  await expect(app).not.toHaveClass(/nav-peek/);
+  await reveal.click();
+  await expect(app).not.toHaveClass(/nav-collapsed/);
+});
+
+test("left edge still previews the collapsed sidebar", async ({ page }) => {
+  await page.goto("/");
+  const app = page.locator(".app");
+  await expect(page.locator(".sidebar")).toBeVisible();
+  await page.keyboard.press("Meta+b");
+  await expect(app).toHaveClass(/nav-collapsed/);
+
+  // The zone is intentionally transparent and may sit below other fixed chrome; moving the
+  // pointer to its exposed left-edge coordinates exercises the real interaction directly.
+  await page.mouse.move(1, 100);
+  await expect(app).toHaveClass(/nav-peek/);
+  await expect(page.locator(".sidebar")).toBeVisible();
 });
 
 test("RECENT header group/filter popover: switch grouping + see coworker filters", async ({

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -1222,7 +1222,6 @@ export function App() {
         <button
           className="nav-reveal-btn"
           onClick={toggleNav}
-          onMouseEnter={() => setNavPeek(true)}
           title="Show sidebar (⌘B)"
           aria-label="Show sidebar"
         >


### PR DESCRIPTION
## What changed

- keep the standalone **Show sidebar** button mounted while it is hovered
- preserve the separate left-edge hover preview behavior
- add regression coverage for non-session screens and edge preview
- make the existing keyboard-toggle test wait for boot completion

## Root cause

The standalone reveal button set `navPeek` during `mouseenter`. That state change immediately removed the button from the DOM and replaced it with the transient sidebar peek, so a normal click raced against its own disappearing target. This was most visible on Settings and other non-session screens.

## User impact

Clicking **Show sidebar** now reliably docks the sidebar instead of briefly flashing it and collapsing again. Hovering the left edge still provides the intended temporary preview.

## Validation

- `npx playwright test e2e/nav-collapse.spec.ts` — 5 passed
- `npm test -- --run` — 68 passed
- `npm run build` — passed