### PR TITLE
fix: preserve exception chain in RelayHub.wait_dispatched

### DIFF
--- a/coworker/connectors/relay_client.py
+++ b/coworker/connectors/relay_client.py
@@ -204,10 +204,10 @@ class RelayHub:
                 )
             try:
                 await asyncio.wait_for(self._progress.wait(), timeout=remaining)
-            except asyncio.TimeoutError:
+            except asyncio.TimeoutError as exc:
                 raise TimeoutError(
                     f"only {self._dispatched} frames dispatched (< {at_least})"
-                )
+                ) from exc
 
     # -- default transport ---------------------------------------------------
     def _default_transport_factory(self) -> RelayTransport:

--- a/tests/test_slack_relay.py
+++ b/tests/test_slack_relay.py
@@ -223,6 +223,18 @@ async def test_relay_ignores_own_bot_echo():
     assert events == []
 
 
+async def test_wait_dispatched_timeout_preserves_exception_chain():
+    """A timed-out wait must chain the original asyncio.TimeoutError, not swallow it."""
+    adapter = _adapter([], close_after=False)  # no frames ever arrive
+    await adapter.connect()
+    try:
+        with pytest.raises(TimeoutError) as excinfo:
+            await adapter.wait_dispatched(1, timeout=0.05)
+        assert isinstance(excinfo.value.__cause__, asyncio.TimeoutError)
+    finally:
+        await adapter.disconnect()
+
+
 # --- reconnect --------------------------------------------------------------
 
 


### PR DESCRIPTION
Fixes #<167>

`RelayHub.wait_dispatched` re-raised `TimeoutError` inside an
`except asyncio.TimeoutError:` block without chaining, so the
original exception and traceback were discarded (`__cause__` was
`None`).

Fix: capture the caught exception and chain it with `from exc`.
Added a regression test (`test_wait_dispatched_timeout_preserves_exception_chain`)
that fails without the fix and passes with it.

Note: ran the full local suite on Windows and saw some unrelated
pre-existing failures (symlink permissions, missing optional
`slack_bolt`/`messaging` extras, Windows file-locking) — these
reproduce on `main` without this change and aren't related to this fix.