### PR TITLE
Add recurring Google Calendar and Outlook events

### DIFF
--- a/coworker/connectors/calendar_recurrence.py
+++ b/coworker/connectors/calendar_recurrence.py
@@ -1,0 +1,305 @@
+"""Shared calendar recurrence helpers for Google Calendar + Outlook create tools.
+
+Agent-facing surface is flat (freq/interval/by_day/until/count). Forever =
+freq set with neither until nor count — matches GCal (omit UNTIL/COUNT) and
+Graph (range.type=noEnd).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from typing import Any, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+_FREQS = frozenset({"daily", "weekly", "monthly", "yearly"})
+
+# Accept Graph names, RFC BYDAY tokens, and common abbreviations.
+_DAY_ALIASES: dict[str, str] = {
+    "su": "SU",
+    "sun": "SU",
+    "sunday": "SU",
+    "mo": "MO",
+    "mon": "MO",
+    "monday": "MO",
+    "tu": "TU",
+    "tue": "TU",
+    "tues": "TU",
+    "tuesday": "TU",
+    "we": "WE",
+    "wed": "WE",
+    "wednesday": "WE",
+    "th": "TH",
+    "thu": "TH",
+    "thur": "TH",
+    "thurs": "TH",
+    "thursday": "TH",
+    "fr": "FR",
+    "fri": "FR",
+    "friday": "FR",
+    "sa": "SA",
+    "sat": "SA",
+    "saturday": "SA",
+}
+
+_GCAL_TO_GRAPH = {
+    "SU": "sunday",
+    "MO": "monday",
+    "TU": "tuesday",
+    "WE": "wednesday",
+    "TH": "thursday",
+    "FR": "friday",
+    "SA": "saturday",
+}
+
+_WEEKDAY_TO_GCAL = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"]  # datetime.weekday()
+
+RECURRENCE_PROPS: dict[str, Any] = {
+    "freq": {
+        "type": "string",
+        "description": (
+            "Recurrence frequency: daily, weekly, monthly, or yearly. "
+            "Omit for a one-off event. With neither until nor count, repeats "
+            "indefinitely."
+        ),
+    },
+    "interval": {
+        "type": "integer",
+        "description": "Repeat every N periods (default 1). E.g. 2 + weekly = biweekly.",
+    },
+    "by_day": {
+        "type": "string",
+        "description": (
+            "Weekdays for weekly recurrence, comma-separated "
+            "(MO,WE or monday,wednesday). Defaults to the weekday of start."
+        ),
+    },
+    "until": {
+        "type": "string",
+        "description": (
+            "Optional inclusive end date (YYYY-MM-DD). Do not combine with count."
+        ),
+    },
+    "count": {
+        "type": "integer",
+        "description": "Optional number of occurrences. Do not combine with until.",
+    },
+}
+
+
+def parse_recurrence(
+    *,
+    freq: str = "",
+    interval: int = 1,
+    by_day: str = "",
+    until: str = "",
+    count: int = 0,
+    start: str = "",
+) -> tuple[Optional[dict[str, Any]], Optional[dict[str, str]]]:
+    """Normalize recurrence args.
+
+    Returns (spec, None) when recurring, (None, None) when one-off,
+    (None, {"error": ...}) on invalid input.
+    """
+    raw = (freq or "").strip().lower()
+    if not raw:
+        return None, None
+    if raw not in _FREQS:
+        return None, {
+            "error": "freq must be one of: daily, weekly, monthly, yearly"
+        }
+
+    try:
+        iv = int(interval) if interval not in (None, "") else 1
+    except (TypeError, ValueError):
+        return None, {"error": "interval must be a positive integer"}
+    if iv < 1:
+        return None, {"error": "interval must be a positive integer"}
+
+    until_s = (until or "").strip()
+    try:
+        count_n = int(count) if count not in (None, "") else 0
+    except (TypeError, ValueError):
+        return None, {"error": "count must be a positive integer"}
+    if count_n < 0:
+        return None, {"error": "count must be a positive integer"}
+    if until_s and count_n:
+        return None, {"error": "pass until or count, not both"}
+
+    stamp = _parse_start(start)
+    if stamp is None:
+        return None, {"error": "recurrence needs a parseable ISO start datetime"}
+
+    until_date = ""
+    if until_s:
+        until_date, err = _normalize_until(until_s)
+        if err:
+            return None, err
+        if _dt.date.fromisoformat(until_date) < stamp.date():
+            return None, {"error": "until must be on or after the event start date"}
+
+    days = _parse_by_day(by_day)
+    if days is None:
+        return None, {
+            "error": "by_day must be comma-separated weekdays "
+            "(e.g. MO,WE or monday,wednesday)"
+        }
+    if raw == "weekly" and not days:
+        days = [_WEEKDAY_TO_GCAL[stamp.weekday()]]
+    elif raw != "weekly" and days:
+        return None, {"error": "by_day is only supported for weekly recurrence"}
+
+    day_of_month = 0
+    month = 0
+    if raw in ("monthly", "yearly"):
+        day_of_month = stamp.day
+        month = stamp.month
+
+    return (
+        {
+            "freq": raw,
+            "interval": iv,
+            "by_days": days,
+            "until_date": until_date,
+            "count": count_n,
+            "day_of_month": day_of_month,
+            "month": month,
+        },
+        None,
+    )
+
+
+def gcal_recurrence(spec: dict[str, Any], timezone: str = "UTC") -> list[str]:
+    """Build Google Calendar recurrence[] (RFC5545 RRULE line)."""
+    try:
+        event_zone = ZoneInfo(timezone)
+    except (TypeError, ZoneInfoNotFoundError) as exc:
+        raise ValueError(
+            "timezone must be a valid IANA name for recurring Google events"
+        ) from exc
+
+    parts = [f"FREQ={spec['freq'].upper()}"]
+    if spec["interval"] != 1:
+        parts.append(f"INTERVAL={spec['interval']}")
+    if spec["freq"] == "weekly" and spec["by_days"]:
+        parts.append("BYDAY=" + ",".join(spec["by_days"]))
+    if spec["freq"] == "monthly" and spec["day_of_month"]:
+        parts.append(f"BYMONTHDAY={spec['day_of_month']}")
+    if spec["freq"] == "yearly":
+        if spec["month"]:
+            parts.append(f"BYMONTH={spec['month']}")
+        if spec["day_of_month"]:
+            parts.append(f"BYMONTHDAY={spec['day_of_month']}")
+    if spec["until_date"]:
+        end_date = _dt.date.fromisoformat(spec["until_date"])
+        local_cutoff = _dt.datetime.combine(
+            end_date, _dt.time(23, 59, 59), tzinfo=event_zone
+        )
+        until_utc = local_cutoff.astimezone(_dt.timezone.utc)
+        parts.append(f"UNTIL={until_utc.strftime('%Y%m%dT%H%M%SZ')}")
+    elif spec["count"]:
+        parts.append(f"COUNT={spec['count']}")
+    return ["RRULE:" + ";".join(parts)]
+
+
+def outlook_recurrence(
+    spec: dict[str, Any], start: str, timezone: str = "UTC"
+) -> dict[str, Any]:
+    """Build Microsoft Graph patternedRecurrence (noEnd when unbounded)."""
+    start_date = _date_from_start(start)
+    if not start_date:
+        # parse_recurrence already requires parseable start for weekly/monthly/yearly;
+        # daily with empty start still needs a range.startDate for Graph.
+        raise ValueError("start date required for Outlook recurrence")
+
+    pattern: dict[str, Any] = {
+        "interval": spec["interval"],
+    }
+    freq = spec["freq"]
+    if freq == "daily":
+        pattern["type"] = "daily"
+    elif freq == "weekly":
+        pattern["type"] = "weekly"
+        pattern["daysOfWeek"] = [_GCAL_TO_GRAPH[d] for d in spec["by_days"]]
+        pattern["firstDayOfWeek"] = "sunday"
+    elif freq == "monthly":
+        pattern["type"] = "absoluteMonthly"
+        pattern["dayOfMonth"] = spec["day_of_month"]
+    else:  # yearly
+        pattern["type"] = "absoluteYearly"
+        pattern["dayOfMonth"] = spec["day_of_month"]
+        pattern["month"] = spec["month"]
+
+    if spec["until_date"]:
+        range_obj: dict[str, Any] = {
+            "type": "endDate",
+            "startDate": start_date,
+            "endDate": spec["until_date"],
+            "recurrenceTimeZone": timezone,
+        }
+    elif spec["count"]:
+        range_obj = {
+            "type": "numbered",
+            "startDate": start_date,
+            "numberOfOccurrences": spec["count"],
+            "recurrenceTimeZone": timezone,
+        }
+    else:
+        range_obj = {
+            "type": "noEnd",
+            "startDate": start_date,
+            "recurrenceTimeZone": timezone,
+        }
+
+    return {"pattern": pattern, "range": range_obj}
+
+
+def _parse_by_day(raw: str) -> Optional[list[str]]:
+    text = (raw or "").strip()
+    if not text:
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for token in re.split(r"[,;\s]+", text):
+        if not token:
+            continue
+        key = token.strip().lower()
+        gcal = _DAY_ALIASES.get(key)
+        if not gcal:
+            return None
+        if gcal not in seen:
+            seen.add(gcal)
+            out.append(gcal)
+    return out
+
+
+def _parse_start(start: str) -> Optional[_dt.datetime]:
+    text = (start or "").strip()
+    if not text:
+        return None
+    # Accept trailing Z by normalizing to fromisoformat-friendly offset form.
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return _dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _date_from_start(start: str) -> str:
+    stamp = _parse_start(start)
+    if stamp is None:
+        return ""
+    return stamp.date().isoformat()
+
+
+def _normalize_until(until: str) -> tuple[str, Optional[dict[str, str]]]:
+    """Validate and return an inclusive YYYY-MM-DD recurrence end date."""
+    text = until.strip()
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", text):
+        return "", {"error": "until must be an inclusive date in YYYY-MM-DD format"}
+    try:
+        _dt.date.fromisoformat(text)
+    except ValueError:
+        return "", {"error": "until must be a valid date in YYYY-MM-DD format"}
+    return text, None

--- a/coworker/connectors/calendar_recurrence.py
+++ b/coworker/connectors/calendar_recurrence.py
@@ -65,6 +65,7 @@ RECURRENCE_PROPS: dict[str, Any] = {
     },
     "interval": {
         "type": "integer",
+        "minimum": 1,
         "description": "Repeat every N periods (default 1). E.g. 2 + weekly = biweekly.",
     },
     "by_day": {
@@ -82,6 +83,7 @@ RECURRENCE_PROPS: dict[str, Any] = {
     },
     "count": {
         "type": "integer",
+        "minimum": 1,
         "description": "Optional number of occurrences. Do not combine with until.",
     },
 }
@@ -93,7 +95,7 @@ def parse_recurrence(
     interval: int = 1,
     by_day: str = "",
     until: str = "",
-    count: int = 0,
+    count: Optional[int] = None,
     start: str = "",
 ) -> tuple[Optional[dict[str, Any]], Optional[dict[str, str]]]:
     """Normalize recurrence args.
@@ -109,19 +111,23 @@ def parse_recurrence(
             "error": "freq must be one of: daily, weekly, monthly, yearly"
         }
 
-    try:
-        iv = int(interval) if interval not in (None, "") else 1
-    except (TypeError, ValueError):
+    if interval in (None, ""):
+        iv = 1
+    elif isinstance(interval, bool) or not isinstance(interval, int):
         return None, {"error": "interval must be a positive integer"}
+    else:
+        iv = interval
     if iv < 1:
         return None, {"error": "interval must be a positive integer"}
 
     until_s = (until or "").strip()
-    try:
-        count_n = int(count) if count not in (None, "") else 0
-    except (TypeError, ValueError):
+    if count in (None, ""):
+        count_n = 0
+    elif isinstance(count, bool) or not isinstance(count, int):
         return None, {"error": "count must be a positive integer"}
-    if count_n < 0:
+    else:
+        count_n = count
+    if count not in (None, "") and count_n < 1:
         return None, {"error": "count must be a positive integer"}
     if until_s and count_n:
         return None, {"error": "pass until or count, not both"}

--- a/coworker/connectors/integration_tools.py
+++ b/coworker/connectors/integration_tools.py
@@ -20,6 +20,12 @@ import aisuite as ai
 
 from ..secrets import SecretStore
 from .browser_automation import make_browser_automation_tools
+from .calendar_recurrence import (
+    RECURRENCE_PROPS,
+    gcal_recurrence,
+    outlook_recurrence,
+    parse_recurrence,
+)
 from .email_tools import make_email_tools
 from .tool_defs import approval_for_tool, connector_for_tool
 
@@ -1167,17 +1173,42 @@ def make_integration_tools(
         calendar_id: str = "primary",
         timezone: str = "UTC",
         description: str = "",
+        freq: str = "",
+        interval: int = 1,
+        by_day: str = "",
+        until: str = "",
+        count: int = 0,
         account: str = "",
     ) -> dict[str, Any]:
         email, profile, err = _gcal_profile(secrets, account)
         if err:
             return err
+        spec, rec_err = parse_recurrence(
+            freq=freq,
+            interval=interval,
+            by_day=by_day,
+            until=until,
+            count=count,
+            start=start,
+        )
+        if rec_err:
+            return rec_err
         payload = {
             "summary": summary,
             "description": description,
             "start": {"dateTime": start, "timeZone": timezone},
             "end": {"dateTime": end, "timeZone": timezone},
         }
+        if spec:
+            # IANA timeZone is required for recurrence expansion / DST.
+            if not (timezone or "").strip():
+                return {
+                    "error": "timezone (IANA name) is required for recurring events"
+                }
+            try:
+                payload["recurrence"] = gcal_recurrence(spec, timezone)
+            except ValueError as exc:
+                return {"error": str(exc)}
         return _gcal_result(
             email,
             _request(
@@ -1194,14 +1225,25 @@ def make_integration_tools(
             gcal_create_event,
             _schema(
                 "gcal_create_event",
-                "Create a Google Calendar event. Requires user approval.",
+                "Create a Google Calendar event. Optional freq (daily/weekly/"
+                "monthly/yearly) makes a series; omit until and count for "
+                "indefinite recurrence. Use an IANA timezone for series. "
+                "Returns the series master id when recurring. Requires user "
+                "approval.",
                 {
                     "summary": {"type": "string"},
                     "start": {"type": "string"},
                     "end": {"type": "string"},
                     "calendar_id": {"type": "string"},
-                    "timezone": {"type": "string"},
+                    "timezone": {
+                        "type": "string",
+                        "description": (
+                            "IANA time zone (e.g. America/Los_Angeles). "
+                            "Required for correct recurring expansion."
+                        ),
+                    },
                     "description": {"type": "string"},
+                    **RECURRENCE_PROPS,
                     "account": _CAL_ACCOUNT_PROP,
                 },
                 ["summary", "start", "end"],
@@ -1448,6 +1490,11 @@ def make_integration_tools(
         attendees: str = "",
         location: str = "",
         teams_meeting: bool = False,
+        freq: str = "",
+        interval: int = 1,
+        by_day: str = "",
+        until: str = "",
+        count: int = 0,
         account: str = "",
     ) -> dict[str, Any]:
         aid, profile, err = _account_profile(
@@ -1455,12 +1502,32 @@ def make_integration_tools(
         )
         if err:
             return err
+        spec, rec_err = parse_recurrence(
+            freq=freq,
+            interval=interval,
+            by_day=by_day,
+            until=until,
+            count=count,
+            start=start,
+        )
+        if rec_err:
+            return rec_err
         payload: dict[str, Any] = {
             "subject": subject,
             "body": {"contentType": "Text", "content": body},
             "start": {"dateTime": start, "timeZone": timezone},
             "end": {"dateTime": end, "timeZone": timezone},
         }
+        if spec:
+            if not (timezone or "").strip():
+                return {
+                    "error": "timezone (IANA or Windows name) is required "
+                    "for recurring events"
+                }
+            try:
+                payload["recurrence"] = outlook_recurrence(spec, start, timezone)
+            except ValueError as exc:
+                return {"error": str(exc)}
         if attendees:
             payload["attendees"] = [
                 {"emailAddress": {"address": a.strip()}, "type": "required"}
@@ -1490,16 +1557,26 @@ def make_integration_tools(
                 "outlook_create_event",
                 "Create an Outlook calendar event; invites go to attendees "
                 "(comma-separated emails). teams_meeting adds a Teams link. "
-                "Requires user approval.",
+                "Optional freq (daily/weekly/monthly/yearly) makes a series; "
+                "omit until and count for indefinite recurrence. Returns the "
+                "series master id when recurring. Requires user approval.",
                 {
                     "subject": {"type": "string"},
                     "start": {"type": "string"},
                     "end": {"type": "string"},
-                    "timezone": {"type": "string"},
+                    "timezone": {
+                        "type": "string",
+                        "description": (
+                            "Time zone for the event (e.g. Pacific Standard "
+                            "Time or America/Los_Angeles). Required for "
+                            "correct recurring expansion."
+                        ),
+                    },
                     "body": {"type": "string"},
                     "attendees": {"type": "string"},
                     "location": {"type": "string"},
                     "teams_meeting": {"type": "boolean"},
+                    **RECURRENCE_PROPS,
                     "account": _GEN_ACCOUNT_PROP,
                 },
                 ["subject", "start", "end"],

--- a/coworker/connectors/integration_tools.py
+++ b/coworker/connectors/integration_tools.py
@@ -1177,7 +1177,7 @@ def make_integration_tools(
         interval: int = 1,
         by_day: str = "",
         until: str = "",
-        count: int = 0,
+        count: Optional[int] = None,
         account: str = "",
     ) -> dict[str, Any]:
         email, profile, err = _gcal_profile(secrets, account)
@@ -1494,7 +1494,7 @@ def make_integration_tools(
         interval: int = 1,
         by_day: str = "",
         until: str = "",
-        count: int = 0,
+        count: Optional[int] = None,
         account: str = "",
     ) -> dict[str, Any]:
         aid, profile, err = _account_profile(

--- a/coworker/connectors/tool_defs.py
+++ b/coworker/connectors/tool_defs.py
@@ -227,7 +227,7 @@ TOOL_DEFS: tuple[ConnectorToolDef, ...] = (
         "gcal_create_event",
         "Create event",
         "write",
-        "Create a Google Calendar event.",
+        "Create a Google Calendar event (optional indefinite or bounded recurrence).",
     ),
     ConnectorToolDef(
         "google_calendar",
@@ -270,7 +270,7 @@ TOOL_DEFS: tuple[ConnectorToolDef, ...] = (
         "outlook_create_event",
         "Create event",
         "write",
-        "Create an Outlook calendar event.",
+        "Create an Outlook calendar event (optional indefinite or bounded recurrence).",
     ),
     ConnectorToolDef(
         "outlook",

--- a/tests/test_calendar_recurrence.py
+++ b/tests/test_calendar_recurrence.py
@@ -26,6 +26,25 @@ def test_parse_rejects_until_and_count():
     assert "until or count" in err["error"]
 
 
+def test_parse_rejects_non_positive_or_non_integer_bounds():
+    for kwargs, field in (
+        ({"count": 0}, "count"),
+        ({"count": -1}, "count"),
+        ({"count": 2.5}, "count"),
+        ({"count": True}, "count"),
+        ({"interval": 0}, "interval"),
+        ({"interval": 1.5}, "interval"),
+        ({"interval": True}, "interval"),
+    ):
+        spec, err = parse_recurrence(
+            freq="daily",
+            start="2026-07-27T10:00:00",
+            **kwargs,
+        )
+        assert spec is None
+        assert f"{field} must be a positive integer" == err["error"]
+
+
 def test_parse_rejects_bad_freq():
     spec, err = parse_recurrence(freq="hourly", start="2026-07-27T10:00:00")
     assert spec is None

--- a/tests/test_calendar_recurrence.py
+++ b/tests/test_calendar_recurrence.py
@@ -1,0 +1,268 @@
+"""Unit tests for calendar recurrence helpers + create-tool payloads."""
+
+from __future__ import annotations
+
+from coworker.connectors.calendar_recurrence import (
+    gcal_recurrence,
+    outlook_recurrence,
+    parse_recurrence,
+)
+from coworker.secrets import SecretStore
+
+
+def test_parse_one_off_when_freq_empty():
+    spec, err = parse_recurrence(freq="", start="2026-07-27T10:00:00")
+    assert spec is None and err is None
+
+
+def test_parse_rejects_until_and_count():
+    spec, err = parse_recurrence(
+        freq="daily",
+        until="2026-12-31",
+        count=5,
+        start="2026-07-27T10:00:00",
+    )
+    assert spec is None
+    assert "until or count" in err["error"]
+
+
+def test_parse_rejects_bad_freq():
+    spec, err = parse_recurrence(freq="hourly", start="2026-07-27T10:00:00")
+    assert spec is None
+    assert "daily" in err["error"]
+
+
+def test_indefinite_weekly_infers_weekday_from_start():
+    # 2026-07-27 is a Monday
+    spec, err = parse_recurrence(
+        freq="weekly", start="2026-07-27T10:00:00", interval=1
+    )
+    assert err is None
+    assert spec["freq"] == "weekly"
+    assert spec["by_days"] == ["MO"]
+    assert spec["count"] == 0
+    assert spec["until_date"] == ""
+
+
+def test_gcal_rrule_forever_weekly():
+    spec, _ = parse_recurrence(
+        freq="weekly", by_day="MO,WE", start="2026-07-27T10:00:00"
+    )
+    assert gcal_recurrence(spec) == ["RRULE:FREQ=WEEKLY;BYDAY=MO,WE"]
+
+
+def test_gcal_rrule_until_and_count():
+    until_spec, _ = parse_recurrence(
+        freq="daily", until="2026-12-31", start="2026-07-27T10:00:00"
+    )
+    assert gcal_recurrence(until_spec, "America/Los_Angeles") == [
+        "RRULE:FREQ=DAILY;UNTIL=20270101T075959Z"
+    ]
+
+    count_spec, _ = parse_recurrence(
+        freq="weekly", by_day="friday", count=8, start="2026-07-31T10:00:00"
+    )
+    assert gcal_recurrence(count_spec) == [
+        "RRULE:FREQ=WEEKLY;BYDAY=FR;COUNT=8"
+    ]
+
+
+def test_gcal_rrule_biweekly_interval():
+    spec, _ = parse_recurrence(
+        freq="weekly", interval=2, by_day="TU", start="2026-07-28T09:00:00"
+    )
+    assert gcal_recurrence(spec) == ["RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=TU"]
+
+
+def test_outlook_no_end_weekly():
+    spec, _ = parse_recurrence(
+        freq="weekly", by_day="monday", start="2026-07-27T10:00:00"
+    )
+    body = outlook_recurrence(spec, "2026-07-27T10:00:00")
+    assert body == {
+        "pattern": {
+            "type": "weekly",
+            "interval": 1,
+            "daysOfWeek": ["monday"],
+            "firstDayOfWeek": "sunday",
+        },
+        "range": {
+            "type": "noEnd",
+            "startDate": "2026-07-27",
+            "recurrenceTimeZone": "UTC",
+        },
+    }
+
+
+def test_outlook_end_date_and_numbered():
+    until_spec, _ = parse_recurrence(
+        freq="daily", until="2026-08-15", start="2026-07-27T10:00:00"
+    )
+    assert outlook_recurrence(until_spec, "2026-07-27T10:00:00")["range"] == {
+        "type": "endDate",
+        "startDate": "2026-07-27",
+        "endDate": "2026-08-15",
+        "recurrenceTimeZone": "UTC",
+    }
+
+    count_spec, _ = parse_recurrence(
+        freq="monthly", count=6, start="2026-07-15T10:00:00"
+    )
+    out = outlook_recurrence(count_spec, "2026-07-15T10:00:00")
+    assert out["pattern"] == {
+        "type": "absoluteMonthly",
+        "interval": 1,
+        "dayOfMonth": 15,
+    }
+    assert out["range"] == {
+        "type": "numbered",
+        "startDate": "2026-07-15",
+        "numberOfOccurrences": 6,
+        "recurrenceTimeZone": "UTC",
+    }
+
+
+def test_outlook_yearly_absolute():
+    spec, _ = parse_recurrence(freq="yearly", start="2026-03-15T09:00:00")
+    out = outlook_recurrence(spec, "2026-03-15T09:00:00")
+    assert out["pattern"]["type"] == "absoluteYearly"
+    assert out["pattern"]["month"] == 3
+    assert out["pattern"]["dayOfMonth"] == 15
+    assert out["range"]["type"] == "noEnd"
+
+
+def test_parse_rejects_invalid_or_pre_start_until():
+    for until in ("2026-02-30", "2026-07-26", "2026-07-27T23:59:59Z"):
+        spec, err = parse_recurrence(
+            freq="daily", until=until, start="2026-07-27T10:00:00"
+        )
+        assert spec is None
+        assert "until" in err["error"]
+
+
+def test_parse_rejects_nonweekly_by_day_and_invalid_start():
+    spec, err = parse_recurrence(
+        freq="monthly", by_day="MO", start="2026-07-27T10:00:00"
+    )
+    assert spec is None
+    assert "only supported for weekly" in err["error"]
+
+    spec, err = parse_recurrence(freq="daily", start="not-a-date")
+    assert spec is None
+    assert "ISO start datetime" in err["error"]
+
+
+def test_gcal_rejects_non_iana_timezone_for_bounded_recurrence():
+    spec, _ = parse_recurrence(
+        freq="daily", until="2026-08-01", start="2026-07-27T10:00:00"
+    )
+    try:
+        gcal_recurrence(spec, "Pacific Standard Time")
+    except ValueError as exc:
+        assert "valid IANA name" in str(exc)
+    else:
+        raise AssertionError("expected invalid IANA timezone to be rejected")
+
+
+def _connect_gcal(secrets: SecretStore) -> None:
+    from coworker.connectors import gcal_accounts
+
+    gcal_accounts.managed_connect_account(
+        secrets,
+        {
+            "type": "oauth",
+            "enabled": True,
+            "managed": True,
+            "access_token": "tok",
+            "account": "me@example.com",
+        },
+    )
+
+
+def test_gcal_create_event_indefinite_payload(tmp_path, monkeypatch):
+    import coworker.connectors.integration_tools as it
+
+    secrets = SecretStore(tmp_path / "secrets.json")
+    _connect_gcal(secrets)
+    calls = []
+
+    def fake_request(method, url, *, headers=None, params=None, json=None, auth=None):
+        calls.append({"method": method, "url": url, "json": json})
+        return {"ok": True, "data": {"id": "series1"}}
+
+    monkeypatch.setattr(it, "_request", fake_request)
+    tools = {t.__name__: t for t in it.make_integration_tools(secrets)}
+
+    tools["gcal_create_event"](
+        "Standup",
+        "2026-07-27T10:00:00",
+        "2026-07-27T10:15:00",
+        timezone="America/Los_Angeles",
+        freq="weekly",
+        by_day="MO,WE,FR",
+    )
+    payload = calls[-1]["json"]
+    assert payload["recurrence"] == ["RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"]
+    assert payload["start"]["timeZone"] == "America/Los_Angeles"
+
+
+def test_gcal_create_event_rejects_until_and_count(tmp_path, monkeypatch):
+    import coworker.connectors.integration_tools as it
+
+    secrets = SecretStore(tmp_path / "secrets.json")
+    _connect_gcal(secrets)
+    monkeypatch.setattr(
+        it,
+        "_request",
+        lambda *a, **k: {"ok": True, "data": {}},
+    )
+    tools = {t.__name__: t for t in it.make_integration_tools(secrets)}
+    out = tools["gcal_create_event"](
+        "X",
+        "2026-07-27T10:00:00",
+        "2026-07-27T11:00:00",
+        freq="daily",
+        until="2026-12-31",
+        count=3,
+    )
+    assert "error" in out
+
+
+def test_outlook_create_event_indefinite_payload(tmp_path, monkeypatch):
+    import coworker.connectors.integration_tools as it
+    from coworker.cloud import managed_profile_from_callback
+    from coworker.connectors.setup import managed_connect_connector
+
+    secrets = SecretStore(tmp_path / "secrets.json")
+    managed_connect_connector(
+        secrets,
+        "outlook",
+        managed_profile_from_callback(
+            {
+                "access_token": "tok",
+                "account": "rohit@openworker.com",
+                "provider": "microsoft",
+            }
+        ),
+    )
+    calls = []
+
+    def fake_request(method, url, *, headers=None, params=None, json=None, auth=None):
+        calls.append({"json": json})
+        return {"ok": True, "data": {"id": "series1"}}
+
+    monkeypatch.setattr(it, "_request", fake_request)
+    tools = {t.__name__: t for t in it.make_integration_tools(secrets)}
+
+    tools["outlook_create_event"](
+        "Sync",
+        "2026-07-27T10:00:00",
+        "2026-07-27T10:30:00",
+        timezone="Pacific Standard Time",
+        freq="weekly",
+    )
+    rec = calls[-1]["json"]["recurrence"]
+    assert rec["range"]["type"] == "noEnd"
+    assert rec["range"]["startDate"] == "2026-07-27"
+    assert rec["range"]["recurrenceTimeZone"] == "Pacific Standard Time"
+    assert rec["pattern"]["daysOfWeek"] == ["monday"]


### PR DESCRIPTION
# Add recurring Google Calendar and Outlook events

OpenWorker's calendar tools can currently create only one-off events. This adds recurring event creation so the coworker can schedule a daily, weekly, monthly, or yearly series without sending the user back to the calendar UI. A series repeats indefinitely when no end date or occurrence count is supplied.

## Changes

- Add optional `freq`, `interval`, `by_day`, `until`, and `count` arguments to the Google Calendar and Outlook create-event tools.
- Normalize and validate recurrence once, then map it to an RFC 5545 `RRULE` for Google Calendar and a Graph `patternedRecurrence` for Outlook.
- Infer the weekday or calendar date from the event start where appropriate.
- Validate inclusive end dates and generate Google's UTC `UNTIL` cutoff in the event's IANA timezone so the final local day is not truncated.
- Document recurrence in the agent-facing schemas and connector tool catalog.

## Sources

- Google Calendar recurring events: https://developers.google.com/workspace/calendar/api/guides/recurringevents
- Microsoft Graph recurrence patterns: https://learn.microsoft.com/en-us/graph/api/resources/recurrencepattern
- Microsoft Graph recurrence ranges: https://learn.microsoft.com/en-us/graph/api/resources/recurrencerange

## Validation

- Full backend suite: 906 passed, 1 skipped.
- Focused recurrence and connector suite: 73 passed.
- Python compilation and `git diff --check` passed.

There is no visual UI change.
