### PR TITLE
Let users cancel ask_user questions

### DIFF
--- a/coworker/interactions.py
+++ b/coworker/interactions.py
@@ -3,7 +3,8 @@
 When an Inbox item is mirrored to a channel, discrete choices (approve/deny, an ask_user option)
 render as **buttons**. The item id rides in each button's value, so a click resolves the exact
 item — no `[ow:id]`-in-reply fragility, no thread tracking. Free-text answers aren't offered over
-messaging (the user opens the app for those).
+messaging (the user opens the app for those) — but every question still gets a Cancel button so
+the user can decline without opening the app.
 
 Provider-agnostic: a `Button` is `(label, value)`; each adapter renders it natively (Slack Block
 Kit, Telegram inline keyboard, …). The value is opaque to the adapter — `encode`/`decode` here own
@@ -14,9 +15,16 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from .inbox import KIND_APPROVAL, KIND_QUESTION
+
+# Reserved Inbox resolution for declining an ask_user prompt. Not a user-visible option label —
+# the UI/Slack button says "Cancel", and question_answer() maps this to an empty answer + error
+# so the agent doesn't treat the word "cancelled" as a real reply (and so it can't collide with
+# an option the model offered).
+QUESTION_CANCELLED = "__cancelled__"
+QUESTION_INTERRUPTED = "__interrupted__"
 
 
 @dataclass
@@ -40,15 +48,29 @@ def decode(value: str) -> Optional[tuple[str, str]]:
     return None
 
 
+def question_answer(resolution: str) -> dict[str, Any]:
+    """Map an Inbox question resolution to the ask_user tool result the engine expects."""
+    if resolution == QUESTION_CANCELLED:
+        return {"answer": "", "error": "cancelled by user"}
+    if resolution == QUESTION_INTERRUPTED:
+        return {"answer": "", "error": "interrupted by user"}
+    return {"answer": resolution or ""}
+
+
 def buttons_for(item) -> list[Button]:
-    """The discrete-choice buttons for an Inbox item, or [] if it has none (free-text question,
-    notification, …) — the caller then sends plain text with an "open the app" hint."""
+    """The discrete-choice buttons for an Inbox item, or [] if it has none (notification, …) —
+    the caller then sends plain text with an "open the app" hint. Questions always include
+    Cancel so the user can decline without typing an answer."""
     if item.kind == KIND_APPROVAL:
         return [
             Button("Approve", encode(item.id, "allow")),
             Button("Deny", encode(item.id, "deny")),
         ]
-    if item.kind == KIND_QUESTION and getattr(item, "options", None):
-        # One button per option; the resolution IS the chosen option text (what the agent gets).
-        return [Button(opt, encode(item.id, opt)) for opt in item.options]
+    if item.kind == KIND_QUESTION:
+        opts = list(getattr(item, "options", None) or [])
+        # Option buttons first; resolution IS the chosen option text (what the agent gets).
+        # Cancel last — HIG secondary action, reserved sentinel so it never looks like an answer.
+        return [Button(opt, encode(item.id, opt)) for opt in opts] + [
+            Button("Cancel", encode(item.id, QUESTION_CANCELLED))
+        ]
     return []

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -157,6 +157,7 @@ from ..attachments import (
 )
 from ..engine import ApprovalOutcome
 from ..inbox import VIS_INBOX, VIS_INLINE, args_preview
+from ..interactions import QUESTION_INTERRUPTED, question_answer
 from ..permissions import Mode
 from ..providers import AssistantTurn
 from .manager import SessionManager
@@ -1552,7 +1553,15 @@ def create_app(manager: SessionManager) -> FastAPI:
                             },
                         }
                     )
-            return {"answer": await manager.inbox.wait(item.id)}
+                try:
+                    return question_answer(await manager.inbox.wait(item.id))
+                except asyncio.CancelledError:
+                    # Stop cancels the engine's wait. Close the authoritative Inbox
+                    # item too, or it remains clickable even though no turn is listening.
+                    manager.inbox.resolve(item.id, QUESTION_INTERRUPTED)
+                    raise
+            # Durable resume re-raised an already-answered prompt.
+            return question_answer(item.resolution or "")
 
         async def directory_requester(args: dict, tool_call_id=None) -> dict:
             # The engine has already emitted DIRECTORY_REQUESTED. Park, await, then apply the grant.

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -27,6 +27,7 @@ from ..connections import (
 )
 from ..inbox import InboxStore, args_preview
 from ..inbox_routing import InboxRouting
+from ..interactions import QUESTION_INTERRUPTED, question_answer
 from ..personas import PersonaRegistry
 from ..personas.registry import set_registry as set_persona_registry
 from ..selfwake import WakeStore
@@ -738,11 +739,16 @@ class SessionManager:
             if (
                 item.state != "pending"
             ):  # durable resume re-raised an already-answered prompt
-                return {"answer": item.resolution or ""}
+                return question_answer(item.resolution or "")
             self.persist_session(session_id)  # the pending tool call is now on disk
             await self.mirror_inbox_item(item)
-            answer = await self.inbox.wait(item.id)
-            return {"answer": answer}
+            try:
+                return question_answer(await self.inbox.wait(item.id))
+            except asyncio.CancelledError:
+                # The turn was stopped while parked. Resolve the stored prompt so
+                # it cannot outlive the tool call and accept a meaningless answer.
+                self.inbox.resolve(item.id, QUESTION_INTERRUPTED)
+                raise
 
         return ask
 
@@ -2611,6 +2617,8 @@ class SessionManager:
         target = f"{binding.channel}:{binding.target}"
         body = "\n".join(p for p in (item.title, item.body) if p).strip()
         buttons = buttons_for(item)
+        if item.kind == "question" and not getattr(item, "options", None):
+            body = f"{body}\n(Open the app to answer, or cancel here.)"
         try:
             if buttons:
                 await self.gateway.deliver_interactive(target, body, buttons)

--- a/coworker/tools/ask.py
+++ b/coworker/tools/ask.py
@@ -34,8 +34,11 @@ def ask_user_tool() -> object:
         - `multi`: allow the user to pick more than one option.
         - `header`: a short (≤ ~12 char) label for the Inbox card chip, e.g. "Region".
 
-        Returns `{"answer": "..."}` — the chosen option(s) or the typed text. Don't ask what you can
-        reasonably decide yourself; reserve this for choices that are actually the user's to make.
+        Returns `{"answer": "..."}` — the chosen option(s) or the typed text. If the user cancels
+        the question (Cancel / Esc), returns `{"answer": "", "error": "cancelled by user"}` — treat
+        that as a declined prompt and continue without re-asking the same thing in a loop. Don't
+        ask what you can reasonably decide yourself; reserve this for choices that are actually
+        the user's to make.
         """
         # Real handling lives in the engine (it needs the out-of-band Inbox round-trip). This body
         # only runs if no question_asker is wired (e.g. a headless surface).

--- a/surfaces/gui/src/App.question.test.ts
+++ b/surfaces/gui/src/App.question.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { resolveLastQuestion } from "./App";
+import type { Item } from "./types";
+
+describe("question lifecycle", () => {
+  it("closes the latest unresolved question when its tool call finishes", () => {
+    const items: Item[] = [
+      { kind: "question", question: "First?", resolved: "yes" },
+      { kind: "assistant", text: "Continuing" },
+      { kind: "question", question: "Second?" },
+    ];
+
+    const resolved = resolveLastQuestion(items, "interrupted by user");
+
+    expect(resolved[0]).toEqual(items[0]);
+    expect(resolved[2]).toEqual({
+      kind: "question",
+      question: "Second?",
+      resolved: "interrupted by user",
+    });
+    expect(items[2]).toEqual({ kind: "question", question: "Second?" });
+  });
+});

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -663,16 +663,21 @@ export function App() {
           ]);
           break;
         case "tool_finished":
-          setItems((p) =>
-            updateLastTool(
+          setItems((p) => {
+            const updated = updateLastTool(
               p,
               d.name,
               d.status,
               d.result_preview || d.reason,
               d.display?.hidden_by_filters,
               d.standing_rule,
-            ),
-          );
+            );
+            // ask_user can finish because it was answered, cancelled, or interrupted.
+            // In every case its live card is no longer actionable.
+            return d.name === "ask_user"
+              ? resolveLastQuestion(updated, d.result_preview || "closed")
+              : updated;
+          });
           // Refresh the right rail when something it shows may have changed: browser state, or a
           // file write that should appear under Artifacts immediately (not only after the turn).
           if (String(d.name || "").startsWith("browser_") || FILE_WRITE_TOOLS.has(d.name)) {
@@ -708,6 +713,10 @@ export function App() {
           break;
         case "turn_done":
           setRunning(false);
+          // Catch abnormal paths that ended without a tool_finished frame. No
+          // question remains actionable after the turn itself is done.
+          setItems((p) => resolveLastQuestion(p, "closed"));
+          setSessionInbox((p) => p.filter((item) => item.kind !== "question"));
           refreshSessions();
           // Catch-all artifact refresh: files created via shell or on a brand-new session (whose
           // record only exists after the first save) appear once the turn completes.
@@ -1719,7 +1728,7 @@ function resolveLastPlan(items: Item[], resolved: "approved" | "rejected"): Item
   return copy;
 }
 
-function resolveLastQuestion(items: Item[], answer: string): Item[] {
+export function resolveLastQuestion(items: Item[], answer: string): Item[] {
   const copy = [...items];
   for (let i = copy.length - 1; i >= 0; i--) {
     const it = copy[i];

--- a/surfaces/gui/src/components/ApprovalCard.test.tsx
+++ b/surfaces/gui/src/components/ApprovalCard.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { ApprovalCard } from "./ApprovalCard";
-import { InboxItemCard } from "./InboxItemCard";
+import { InboxItemCard, QUESTION_CANCELLED } from "./InboxItemCard";
 import type { Item } from "../types";
 import type { InboxItem } from "../api";
 
@@ -218,5 +218,60 @@ describe("InboxItemCard — Allow every time on parked run approvals", () => {
     fireEvent.click(screen.getByText("Allow once"));
     expect(onResolve).toHaveBeenCalledWith("i1", "allow");
     // Old rows without tool data keep the legacy treatment (covered above).
+  });
+});
+
+describe("InboxItemCard — question Cancel", () => {
+  const questionItem = (extra: Partial<InboxItem> = {}): InboxItem => ({
+    id: "q1",
+    session_id: "s1",
+    kind: "question",
+    title: "Which region?",
+    body: "",
+    state: "pending",
+    resolution: null,
+    inbox: "default",
+    created_at: "",
+    resolved_at: null,
+    options: ["us-east-1", "us-west-2"],
+    allow_text: true,
+    ...extra,
+  });
+
+  it("offers Cancel and resolves with the reserved sentinel", () => {
+    const onResolve = vi.fn();
+    render(<InboxItemCard item={questionItem()} onResolve={onResolve} compact />);
+    fireEvent.click(screen.getByTitle("Cancel (Esc)"));
+    expect(onResolve).toHaveBeenCalledWith("q1", QUESTION_CANCELLED);
+  });
+
+  it("Esc cancels when the draft is empty; clears a typed draft first", () => {
+    const onResolve = vi.fn();
+    render(<InboxItemCard item={questionItem()} onResolve={onResolve} compact />);
+    const input = screen.getByPlaceholderText("Or type your own answer…") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "maybe later" } });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onResolve).not.toHaveBeenCalled();
+    expect(input.value).toBe("");
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onResolve).toHaveBeenCalledWith("q1", QUESTION_CANCELLED);
+  });
+
+  it("still shows Cancel when allow_text is false (only escape hatch besides options)", () => {
+    render(
+      <InboxItemCard
+        item={questionItem({ allow_text: false })}
+        onResolve={vi.fn()}
+      />,
+    );
+    expect(screen.getByTitle("Cancel (Esc)")).toBeTruthy();
+    expect(screen.queryByPlaceholderText(/answer/i)).toBeNull();
+  });
+
+  it("does not let an Inbox-list card claim the global Esc shortcut", () => {
+    const onResolve = vi.fn();
+    render(<InboxItemCard item={questionItem()} onResolve={onResolve} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onResolve).not.toHaveBeenCalled();
   });
 });

--- a/surfaces/gui/src/components/ApprovalCard.test.tsx
+++ b/surfaces/gui/src/components/ApprovalCard.test.tsx
@@ -245,7 +245,7 @@ describe("InboxItemCard — question Cancel", () => {
     expect(onResolve).toHaveBeenCalledWith("q1", QUESTION_CANCELLED);
   });
 
-  it("Esc cancels when the draft is empty; clears a typed draft first", () => {
+  it("one Esc cancels even with a typed draft; repeated keydown is ignored", () => {
     const onResolve = vi.fn();
     render(<InboxItemCard item={questionItem()} onResolve={onResolve} compact />);
     const input = screen.getByPlaceholderText("Or type your own answer…") as HTMLInputElement;
@@ -254,12 +254,15 @@ describe("InboxItemCard — question Cancel", () => {
     expect(onResolve).not.toHaveBeenCalled();
     expect(input.value).toBe("maybe later");
     fireEvent.keyDown(window, { key: "Escape" });
-    expect(onResolve).not.toHaveBeenCalled();
-    expect(input.value).toBe("");
-    fireEvent.keyDown(window, { key: "Escape", repeat: true });
-    expect(onResolve).not.toHaveBeenCalled();
-    fireEvent.keyDown(window, { key: "Escape" });
     expect(onResolve).toHaveBeenCalledWith("q1", QUESTION_CANCELLED);
+  });
+
+  it("places Cancel immediately before the primary Send action", () => {
+    render(<InboxItemCard item={questionItem()} onResolve={vi.fn()} compact />);
+    const actions = screen
+      .getAllByRole("button")
+      .map((button) => button.textContent?.trim());
+    expect(actions.slice(-2)).toEqual(["Cancel", "Send"]);
   });
 
   it("still shows Cancel when allow_text is false (only escape hatch besides options)", () => {

--- a/surfaces/gui/src/components/ApprovalCard.test.tsx
+++ b/surfaces/gui/src/components/ApprovalCard.test.tsx
@@ -250,9 +250,14 @@ describe("InboxItemCard — question Cancel", () => {
     render(<InboxItemCard item={questionItem()} onResolve={onResolve} compact />);
     const input = screen.getByPlaceholderText("Or type your own answer…") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "maybe later" } });
+    fireEvent.keyDown(window, { key: "Escape", repeat: true });
+    expect(onResolve).not.toHaveBeenCalled();
+    expect(input.value).toBe("maybe later");
     fireEvent.keyDown(window, { key: "Escape" });
     expect(onResolve).not.toHaveBeenCalled();
     expect(input.value).toBe("");
+    fireEvent.keyDown(window, { key: "Escape", repeat: true });
+    expect(onResolve).not.toHaveBeenCalled();
     fireEvent.keyDown(window, { key: "Escape" });
     expect(onResolve).toHaveBeenCalledWith("q1", QUESTION_CANCELLED);
   });

--- a/surfaces/gui/src/components/InboxItemCard.tsx
+++ b/surfaces/gui/src/components/InboxItemCard.tsx
@@ -50,8 +50,8 @@ export function InboxItemCard({
 
   // HIG: Escape is Cancel's key equivalent for the active inline prompt. Inbox-list cards do
   // not claim a global shortcut: several can be mounted at once, and one Esc must never cancel
-  // multiple questions. Softened vs Claude Code — Esc with a draft clears first; empty draft
-  // cancels. Distinct from Stop (whole-turn interrupt): this resolves only the ask_user item.
+  // multiple questions. Distinct from Stop (whole-turn interrupt): this resolves only the
+  // ask_user item.
   useEffect(() => {
     if (item.kind !== "question" || !compact) return;
     const onKey = (e: KeyboardEvent) => {
@@ -60,16 +60,22 @@ export function InboxItemCard({
       if (e.repeat) return;
       e.preventDefault();
       e.stopImmediatePropagation();
-      if (answer.trim() || selected.length) {
-        setAnswer("");
-        setSelected([]);
-        return;
-      }
       onResolve(item.id, QUESTION_CANCELLED);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [item.kind, item.id, answer, selected, onResolve, compact]);
+  }, [item.kind, item.id, onResolve, compact]);
+
+  const cancelButton = () => (
+    <button
+      type="button"
+      className={BTN_BORDERED}
+      title="Cancel (Esc)"
+      onClick={cancelQuestion}
+    >
+      Cancel
+    </button>
+  );
 
   const textRow = (placeholder: string) => (
     <div className="flex items-center gap-2 mt-2.5">
@@ -82,6 +88,7 @@ export function InboxItemCard({
           if (e.key === "Enter" && answer.trim()) onResolve(item.id, answer);
         }}
       />
+      {cancelButton()}
       <button className={BTN_PRIMARY} disabled={!answer.trim()} onClick={() => onResolve(item.id, answer)}>
         Send
       </button>
@@ -176,7 +183,8 @@ export function InboxItemCard({
             </div>
           )}
           {multi && options.length > 0 && (
-            <div className="mt-2.5">
+            <div className="flex items-center justify-end gap-2 mt-2.5">
+              {!allowText && cancelButton()}
               <button
                 className={BTN_PRIMARY}
                 disabled={!selected.length}
@@ -188,18 +196,9 @@ export function InboxItemCard({
           )}
           {(allowText || options.length === 0) &&
             textRow(options.length ? "Or type your own answer…" : "Your answer…")}
-          {/* HIG Cancel — quiet secondary, same dialect as Deny. Always shown (including
-              allow_text=false) so Esc isn't the only escape hatch. */}
-          <div className="mt-2 flex justify-end">
-            <button
-              type="button"
-              className={BTN_QUIET}
-              title="Cancel (Esc)"
-              onClick={cancelQuestion}
-            >
-              Cancel
-            </button>
-          </div>
+          {!allowText && !multi && (
+            <div className="flex justify-end mt-2.5">{cancelButton()}</div>
+          )}
         </>
       ) : item.kind === "directory" ? (
         <div className="flex items-center gap-2 mt-2.5">

--- a/surfaces/gui/src/components/InboxItemCard.tsx
+++ b/surfaces/gui/src/components/InboxItemCard.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import type { InboxItem } from "../api";
 import { humanizeApprovalTitle } from "../humanize";
 import { PreviewBlock, scopeNote, TitleText } from "./ApprovalCard";
@@ -6,7 +6,11 @@ import { PreviewBlock, scopeNote, TitleText } from "./ApprovalCard";
 // One Inbox item, rendered identically in the Inbox list and inline in its own session view
 // (answer-in-context). Resolving either place hits the same item id — first responder wins.
 // Questions (ask_user) mirror Claude Code's AskUserQuestion: optional quick-reply options + an
-// always-available free-text escape, with optional multi-select.
+// always-available free-text escape, with optional multi-select — plus Cancel (Esc) to decline.
+
+// Reserved Inbox resolution for declining a question. Wire value only — the button label is
+// "Cancel". Must match coworker/interactions.py QUESTION_CANCELLED.
+export const QUESTION_CANCELLED = "__cancelled__";
 
 // Shared styles (mock parity — same language as SourcesDrawer/PersonaView).
 const SEC = "text-[11px] uppercase tracking-[0.05em] text-faint font-semibold";
@@ -41,6 +45,30 @@ export function InboxItemCard({
   const options = item.options || [];
   const multi = !!item.multi;
   const allowText = item.allow_text !== false;
+
+  const cancelQuestion = () => onResolve(item.id, QUESTION_CANCELLED);
+
+  // HIG: Escape is Cancel's key equivalent for the active inline prompt. Inbox-list cards do
+  // not claim a global shortcut: several can be mounted at once, and one Esc must never cancel
+  // multiple questions. Softened vs Claude Code — Esc with a draft clears first; empty draft
+  // cancels. Distinct from Stop (whole-turn interrupt): this resolves only the ask_user item.
+  useEffect(() => {
+    if (item.kind !== "question" || !compact) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (e.defaultPrevented) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      if (answer.trim() || selected.length) {
+        setAnswer("");
+        setSelected([]);
+        return;
+      }
+      onResolve(item.id, QUESTION_CANCELLED);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [item.kind, item.id, answer, selected, onResolve, compact]);
 
   const textRow = (placeholder: string) => (
     <div className="flex items-center gap-2 mt-2.5">
@@ -159,6 +187,18 @@ export function InboxItemCard({
           )}
           {(allowText || options.length === 0) &&
             textRow(options.length ? "Or type your own answer…" : "Your answer…")}
+          {/* HIG Cancel — quiet secondary, same dialect as Deny. Always shown (including
+              allow_text=false) so Esc isn't the only escape hatch. */}
+          <div className="mt-2 flex justify-end">
+            <button
+              type="button"
+              className={BTN_QUIET}
+              title="Cancel (Esc)"
+              onClick={cancelQuestion}
+            >
+              Cancel
+            </button>
+          </div>
         </>
       ) : item.kind === "directory" ? (
         <div className="flex items-center gap-2 mt-2.5">

--- a/surfaces/gui/src/components/InboxItemCard.tsx
+++ b/surfaces/gui/src/components/InboxItemCard.tsx
@@ -57,6 +57,7 @@ export function InboxItemCard({
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
       if (e.defaultPrevented) return;
+      if (e.repeat) return;
       e.preventDefault();
       e.stopImmediatePropagation();
       if (answer.trim() || selected.length) {

--- a/tests/test_durable_resume.py
+++ b/tests/test_durable_resume.py
@@ -94,6 +94,42 @@ def test_durable_resume_question(tmp_path):
     assert mgr.inbox.pending(sid) == []  # nothing left pending
 
 
+def test_durable_resume_question_cancel(tmp_path):
+    """Cancel resolves the parked question; agent continues with cancelled-by-user tool result."""
+    from coworker.interactions import QUESTION_CANCELLED
+
+    mgr = SessionManager(
+        workspace=tmp_path,
+        provider=ScriptedProvider(
+            [
+                _tool(
+                    "ask_user",
+                    {"question": "Which region?", "options": ["us-east-1"]},
+                    "call_qc",
+                ),
+                _text("Understood — skipping the region pick."),
+            ]
+        ),
+    )
+    sid = "dur-qc"
+
+    async def scenario():
+        engine = mgr.get_engine(sid, agent="cowork", workspace=str(tmp_path))
+        item = await _run_until_pending(mgr, sid, engine)
+        await mgr.resolve_inbox(item.id, QUESTION_CANCELLED)
+
+    asyncio.run(scenario())
+    assert any("skipping" in (t or "").lower() for t in _final_assistant_texts(mgr, sid))
+    assert mgr.inbox.pending(sid) == []
+    # Tool result should carry the cancel error, not the sentinel as a fake answer.
+    rec = mgr.session_store.load(sid)
+    tool_msgs = [m for m in rec.messages if m.get("role") == "tool"]
+    assert tool_msgs
+    content = tool_msgs[-1].get("content") or ""
+    assert "cancelled by user" in content
+    assert QUESTION_CANCELLED not in content
+
+
 def test_durable_resume_approval_executes_tool(tmp_path):
     # The model wants a write (needs approval); on durable resume "allow" must RE-EXECUTE the tool.
     target = tmp_path / "scratch_marker.txt"

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -4,7 +4,15 @@ import asyncio
 import json
 
 from coworker.inbox import InboxStore
-from coworker.interactions import Button, buttons_for, decode, encode
+from coworker.interactions import (
+    QUESTION_CANCELLED,
+    QUESTION_INTERRUPTED,
+    Button,
+    buttons_for,
+    decode,
+    encode,
+    question_answer,
+)
 from coworker.connectors.base import InteractionEvent
 from coworker.connectors.senders import _slack_blocks
 from coworker.providers import ModelCapabilities, ProviderClient
@@ -39,12 +47,70 @@ def test_buttons_for_kinds(tmp_path):
 
     q = st.add_question("s1", "Which region?", options=["us-east-1", "us-west-2"])
     qb = buttons_for(q)
-    assert [b.label for b in qb] == ["us-east-1", "us-west-2"]
+    assert [b.label for b in qb] == ["us-east-1", "us-west-2", "Cancel"]
     assert decode(qb[0].value) == (q.id, "us-east-1")  # resolution IS the option text
+    assert decode(qb[-1].value) == (q.id, QUESTION_CANCELLED)
 
-    # free-text question (no options) and notifications get no buttons → "open the app"
-    assert buttons_for(st.add_question("s1", "Say something")) == []
+    # free-text question (no options) still gets Cancel — notifications get none
+    free = buttons_for(st.add_question("s1", "Say something"))
+    assert [b.label for b in free] == ["Cancel"]
     assert buttons_for(st.add_notification("s1", "FYI")) == []
+
+
+def test_question_answer_cancel_maps_to_error():
+    assert question_answer("us-west-2") == {"answer": "us-west-2"}
+    assert question_answer("") == {"answer": ""}
+    assert question_answer(QUESTION_CANCELLED) == {
+        "answer": "",
+        "error": "cancelled by user",
+    }
+    assert question_answer(QUESTION_INTERRUPTED) == {
+        "answer": "",
+        "error": "interrupted by user",
+    }
+
+
+async def test_interrupt_closes_parked_question(tmp_path):
+    mgr = SessionManager(workspace=tmp_path, provider=ScriptedProvider([]))
+    ask = mgr.inbox_question_asker("s1", "cowork")
+    waiter = asyncio.create_task(
+        ask({"question": "Which region?", "options": ["us-east-1"]}, "call_q")
+    )
+    await asyncio.sleep(0)
+    item = mgr.inbox.pending("s1")[0]
+
+    waiter.cancel()
+    try:
+        await waiter
+    except asyncio.CancelledError:
+        pass
+    else:
+        raise AssertionError("the parked question waiter should be cancelled")
+
+    assert mgr.inbox.pending("s1") == []
+    assert mgr.inbox.get(item.id).resolution == QUESTION_INTERRUPTED
+
+
+async def test_free_text_question_mirror_keeps_open_app_hint(tmp_path):
+    from coworker.server.manager import SessionManager
+
+    mgr = SessionManager(workspace=tmp_path)
+    delivered = {}
+
+    class Gateway:
+        async def deliver_interactive(self, target, text, buttons):
+            delivered.update(target=target, text=text, buttons=buttons)
+
+    mgr.gateway = Gateway()
+    mgr.inbox_routing.set_binding(
+        "default", channel="fake", target="questions"
+    )
+    item = mgr.inbox.add_question("s1", "What should I call it?")
+
+    await mgr.mirror_inbox_item(item)
+
+    assert "Open the app to answer, or cancel here." in delivered["text"]
+    assert [button.label for button in delivered["buttons"]] == ["Cancel"]
 
 
 def test_slack_blocks_shape():


### PR DESCRIPTION
# Let users cancel `ask_user` questions

An `ask_user` prompt currently has to be answered even when the user wants to decline the question. The only broader escape is stopping the whole turn. This adds a question-level Cancel action so the agent can receive a clear cancellation result and continue without treating “cancelled” as an ordinary answer.

## Changes

- Add Cancel to question cards, including questions with fixed options or no free-text field.
- Let one Esc cancel the active inline question, including when the user has a draft or selected options.
- Ignore repeated Esc keydown events so holding the key cannot clear a draft and immediately cancel the question.
- Keep Inbox-list cards from claiming a global Esc shortcut, so one keypress cannot cancel multiple pending questions.
- Add Cancel to questions mirrored to messaging channels while preserving the “open the app to answer” hint for free-text questions.
- Map cancellation to `{"answer": "", "error": "cancelled by user"}` consistently for attended sessions, unattended sessions, and durable resume.
- Resolve the authoritative Inbox item when a turn is stopped while waiting, and close the live card when `ask_user` or the turn finishes, so an orphaned question cannot accept a meaningless late answer.
- Tell the agent not to re-ask the same declined question in a loop.

## Validation

- Full backend suite: 893 passed, 1 skipped.
- Full GUI unit suite: 73 passed.
- Production GUI build passed.
- Focused durable-resume, interaction, gateway, Slack ownership, and question-card tests passed.

## Screenshot

Before
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/20cebecb-1574-4df0-a177-842977608a6b" />

After
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/edd8ae96-ca0c-42f1-b5ee-447a178f43f8" />
