### PR TITLE
Let Esc stop a running turn

### DIFF
--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -1523,6 +1523,9 @@ export function App() {
               modelLabels={modelLabels}
               running={running}
               connected={connected}
+              questionPending={
+                !!pendingQuestion || sessionInbox[0]?.kind === "question"
+              }
               modelReady={modelReady}
               onConnectModel={openModelSetup}
               onConfigureVoiceInput={() => openSettings("voice")}

--- a/surfaces/gui/src/components/Composer.esc.test.tsx
+++ b/surfaces/gui/src/components/Composer.esc.test.tsx
@@ -1,0 +1,131 @@
+// Esc → Stop: HIG key equivalent while a turn is running. Composition matches
+// feat/cancel-question (honor defaultPrevented) and keeps dictation Esc ahead of interrupt.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Composer } from "./Composer";
+
+const READY = {
+  recording: false,
+  model_installed: true,
+  model_verified: true,
+  test_passed: true,
+  download_in_progress: false,
+  model_name: "Whisper Base English (local)",
+  model_bytes: 147964211,
+  supported: true,
+  device_summary: "macOS 15 · Apple Silicon",
+  compatibility_reason: null,
+};
+const RECORDING = { ...READY, recording: true };
+
+let invoke: ReturnType<typeof vi.fn>;
+
+const props = (extra: Partial<Parameters<typeof Composer>[0]> = {}) => ({
+  mode: "interactive",
+  model: "gpt-5.6-sol",
+  running: false,
+  connected: true,
+  onSend: vi.fn(),
+  onInterrupt: vi.fn(),
+  onModeChange: vi.fn(),
+  onModelChange: vi.fn(),
+  ...extra,
+});
+
+beforeEach(() => {
+  invoke = vi.fn(async (cmd: string) => {
+    if (cmd === "get_dictation_status") return READY;
+    if (cmd === "start_dictation") return RECORDING;
+    if (cmd === "cancel_dictation") return null;
+    if (cmd === "stop_dictation") return "hello from the mic";
+    return null;
+  });
+  (globalThis as any).__TAURI__ = { core: { invoke }, event: { listen: async () => () => {} } };
+});
+
+afterEach(() => {
+  cleanup();
+  delete (globalThis as any).__TAURI__;
+});
+
+describe("Composer — Esc Stop", () => {
+  it("Esc interrupts when a turn is running", () => {
+    const onInterrupt = vi.fn();
+    render(<Composer {...props({ running: true, onInterrupt })} />);
+    expect(screen.getByTitle("Stop (Esc)")).toBeTruthy();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onInterrupt).toHaveBeenCalledTimes(1);
+  });
+
+  it("Esc is a no-op when idle (does not interrupt)", () => {
+    const onInterrupt = vi.fn();
+    render(<Composer {...props({ running: false, onInterrupt })} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onInterrupt).not.toHaveBeenCalled();
+  });
+
+  it("leaves Esc to a visible question instead of stopping the turn", () => {
+    const onInterrupt = vi.fn();
+    render(
+      <Composer
+        {...props({ running: true, questionPending: true, onInterrupt })}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onInterrupt).not.toHaveBeenCalled();
+  });
+
+  it("honors defaultPrevented so an earlier Esc handler wins", () => {
+    const onInterrupt = vi.fn();
+    // Capture-phase claim mimics a modal / question Cancel that already handled Esc.
+    const claim = (e: KeyboardEvent) => {
+      if (e.key === "Escape") e.preventDefault();
+    };
+    window.addEventListener("keydown", claim, true);
+    try {
+      render(<Composer {...props({ running: true, onInterrupt })} />);
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(onInterrupt).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("keydown", claim, true);
+    }
+  });
+
+  it("does not stop the turn while a dialog or menu owns Escape", () => {
+    const onInterrupt = vi.fn();
+    const { rerender } = render(
+      <>
+        <div role="dialog">Settings</div>
+        <Composer {...props({ running: true, onInterrupt })} />
+      </>,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onInterrupt).not.toHaveBeenCalled();
+
+    rerender(
+      <>
+        <div role="menu">Session actions</div>
+        <Composer {...props({ running: true, onInterrupt })} />
+      </>,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onInterrupt).not.toHaveBeenCalled();
+  });
+
+  it("ignores repeated keydown events", () => {
+    const onInterrupt = vi.fn();
+    render(<Composer {...props({ running: true, onInterrupt })} />);
+    fireEvent.keyDown(window, { key: "Escape", repeat: true });
+    expect(onInterrupt).not.toHaveBeenCalled();
+  });
+
+  it("Esc while dictating cancels the mic, not the turn", async () => {
+    const onInterrupt = vi.fn();
+    render(<Composer {...props({ running: true, onInterrupt })} />);
+    fireEvent.click(await screen.findByLabelText("Start dictation"));
+    await screen.findByLabelText("Stop dictation");
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith("cancel_dictation", undefined));
+    expect(onInterrupt).not.toHaveBeenCalled();
+  });
+});

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -53,6 +53,9 @@ interface Props {
   // interactive-then-disabled control.
   running: boolean;
   connected: boolean;
+  // A visible ask_user prompt owns Escape. The composer must not depend on
+  // window-listener registration order to decide whether to stop the turn.
+  questionPending?: boolean;
   // False when the default model's provider has no key — the composer shows a "connect a model"
   // banner and routes sends to setup (preserving the draft) instead of dropping them.
   modelReady?: boolean;
@@ -178,20 +181,42 @@ export function Composer(props: Props) {
     return () => window.clearInterval(timer);
   }, [dictation?.recording]);
 
+  // HIG: Escape is Stop's key equivalent while a turn is running (mirrors the TUI). Honor
+  // `defaultPrevented` and visible higher-priority surfaces so closing a dialog/menu never also
+  // stops the turn. Dictation outranks Stop — Esc while recording cancels the mic only.
   useEffect(() => {
-    if (!dictation?.recording) return;
-    const cancelOnEscape = (event: KeyboardEvent) => {
+    const onEscape = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
+      if (event.defaultPrevented) return;
+      if (
+        document.querySelector(
+          '[role="dialog"], [role="menu"], [role="listbox"]',
+        )
+      )
+        return;
+      if (dictation?.recording) {
+        event.preventDefault();
+        void cancelDictation()
+          .catch(() => undefined)
+          .finally(() => {
+            void getDictationStatus().then((status) => status && setDictation(status));
+          });
+        return;
+      }
+      if (props.questionPending) return;
+      if (!props.running) return;
+      if (event.repeat) return;
       event.preventDefault();
-      void cancelDictation()
-        .catch(() => undefined)
-        .finally(() => {
-          void getDictationStatus().then((status) => status && setDictation(status));
-        });
+      props.onInterrupt();
     };
-    window.addEventListener("keydown", cancelOnEscape);
-    return () => window.removeEventListener("keydown", cancelOnEscape);
-  }, [dictation?.recording]);
+    window.addEventListener("keydown", onEscape);
+    return () => window.removeEventListener("keydown", onEscape);
+  }, [
+    dictation?.recording,
+    props.running,
+    props.onInterrupt,
+    props.questionPending,
+  ]);
 
   const voiceReady = !!dictation?.supported && !!dictation?.model_verified && !!dictation?.test_passed;
   const recordingTime = `${Math.floor(recordingSeconds / 60)}:${String(recordingSeconds % 60).padStart(2, "0")}`;
@@ -516,7 +541,7 @@ export function Composer(props: Props) {
 
           {/* send / stop */}
           {props.running ? (
-            <button className="btn danger" onClick={props.onInterrupt}>
+            <button className="btn danger" onClick={props.onInterrupt} title="Stop (Esc)">
               ⏹ Stop
             </button>
           ) : (

--- a/surfaces/gui/src/components/GalleryModal.tsx
+++ b/surfaces/gui/src/components/GalleryModal.tsx
@@ -367,7 +367,13 @@ export function GalleryModal({
   );
 
   return (
-    <div className="fixed inset-0 z-50" data-testid="gallery-modal">
+    <div
+      className="fixed inset-0 z-50"
+      data-testid="gallery-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Persona Gallery"
+    >
       <div className="absolute inset-0 bg-black/30 backdrop-blur-[1px]" onClick={onClose} />
       <div className="absolute left-1/2 top-[6vh] -translate-x-1/2 w-[720px] max-w-[94vw] max-h-[88vh] rounded-xl2 border border-line bg-panel shadow-2xl overflow-hidden flex flex-col">
         <div className="px-5 pt-4 pb-3 border-b border-line flex items-center gap-3 shrink-0">


### PR DESCRIPTION
# Let Esc stop a running turn

The composer already exposes a Stop button while the agent is working. This gives it the expected Esc key equivalent, making an in-progress turn faster to stop without changing the existing interrupt path.

## Changes

- Make Esc invoke the composer's existing interrupt action while a turn is running.
- Keep Esc inert while idle and ignore repeated keydown events.
- Give dictation, questions, dialogs, menus, and listboxes priority so Esc handles the most local action instead of also stopping the turn.
- Pass pending-question state to the composer explicitly, avoiding shortcut behavior that depends on window-listener registration order.
- Advertise the shortcut in the Stop button tooltip.
- Mark the Persona Gallery as an accessible modal dialog so it participates in the same shortcut precedence.

## Validation

- Full GUI unit suite: 75 passed.
- Production GUI build passed.
- Focused Composer shortcut and dictation tests: 11 passed.
- `git diff --check` passed.

There is no material visual layout change.
