### PR TITLE
Allow an optional API key for Ollama / local OpenAI-compatible servers

### DIFF
--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -127,10 +127,13 @@ def _build_gemini(profile: dict[str, Any], secrets: Any) -> ProviderClient:
 
 
 def _build_ollama(profile: dict[str, Any], secrets: Any) -> ProviderClient:
-    # Ollama's OpenAI-compatible endpoint ignores the key but the SDK requires a non-empty
-    # string, so we pass a placeholder. `base_url` comes from the stored profile (or the default).
+    # Stock Ollama ignores the key but the SDK requires a non-empty string, so we fall back to
+    # a placeholder. An optional stored key is passed through for local OpenAI-compatible
+    # servers that DO authenticate (oMLX, a gated proxy in front of `ollama serve`).
+    # `base_url` comes from the stored profile (or the default).
     base_url = _normalize_ollama_url((profile or {}).get("base_url"))
-    return OpenAIProvider(api_key="ollama", base_url=base_url)
+    api_key = ((profile or {}).get("api_key") or "").strip() or "ollama"
+    return OpenAIProvider(api_key=api_key, base_url=base_url)
 
 
 def _openai_compat(vendor: str, default_base_url: str, env_key: Optional[str] = None):
@@ -346,6 +349,13 @@ DESCRIPTORS: list[ProviderDescriptor] = [
                 placeholder=DEFAULT_OLLAMA_URL,
                 help="Where `ollama serve` is listening. The OpenAI-compatible /v1 path is added automatically.",
             ),
+            ProviderField(
+                "api_key",
+                "API key (optional)",
+                secret=True,
+                required=False,
+                help="Only for local OpenAI-compatible servers that require auth (e.g. oMLX or a proxy in front of Ollama). Leave blank for stock Ollama.",
+            ),
         ],
         build=_build_ollama,
         # Reliable native tool-calling + strong coding quality (verified). Pull with
@@ -423,7 +433,12 @@ def verify_provider_key(
             )
         elif name == "ollama":
             base = _normalize_ollama_url(base_url)
-            resp = httpx.get(base.rstrip("/") + "/models", timeout=timeout)
+            # Stock Ollama needs no auth; send Bearer only when the user supplied a key, so
+            # an authenticated local server can be tested the same way.
+            ollama_kwargs: dict[str, Any] = {"timeout": timeout}
+            if key:
+                ollama_kwargs["headers"] = {"Authorization": f"Bearer {key}"}
+            resp = httpx.get(base.rstrip("/") + "/models", **ollama_kwargs)
         else:  # openai + any OpenAI-compatible endpoint (Azure, OpenRouter, vendors, vLLM…)
             default_base = next(
                 (f.default for f in d.fields if f.key == "base_url" and f.default), ""

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1523,6 +1523,11 @@ class SessionManager:
                 val = val.strip()
             if val:
                 profile[f.key] = val
+            elif f.secret:
+                # The GUI masks a saved secret and submits it blank on a re-save (editing the
+                # server URL, re-running Detect). Keep the stored value instead of silently
+                # dropping it; a real rotation always arrives as a non-empty value.
+                continue
             elif not f.required:
                 profile.pop(f.key, None)
         missing = [f.label for f in d.fields if f.required and not profile.get(f.key)]

--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -333,7 +333,7 @@ const PROVIDERS = [
   { name: "zai", title: "Z AI (GLM)", needs_key: true, blurb: "Uses Z AI's OpenAI-compatible API — the endpoint is prefilled, just add your key.", fields: [{ key: "api_key", label: "Z AI API key", secret: true, required: true, help: "", placeholder: "" }, { key: "base_url", label: "Endpoint", secret: false, required: false, help: "Prefilled with Z AI's international endpoint.", placeholder: "https://api.z.ai/api/paas/v4", default: "https://api.z.ai/api/paas/v4" }], configured: false, values: {}, suggested_models: ["glm-5.2"], key_set_at: null, last_used_at: null },
   // ollama: keyless local provider — "configured" without proving anything runs; the
   // onboarding gallery shows "No key needed" and its form is endpoint + Detect (§39).
-  { name: "ollama", title: "Ollama (local models)", needs_key: false, fields: [{ key: "base_url", label: "Endpoint", secret: false, required: false, help: "", placeholder: "http://127.0.0.1:11434", default: "http://127.0.0.1:11434" }], configured: true, values: {}, suggested_models: ["qwen3-coder:30b"], key_set_at: null, last_used_at: null },
+  { name: "ollama", title: "Ollama (local models)", needs_key: false, fields: [{ key: "base_url", label: "Endpoint", secret: false, required: false, help: "", placeholder: "http://127.0.0.1:11434", default: "http://127.0.0.1:11434" }, { key: "api_key", label: "API key (optional)", secret: true, required: false, help: "Only for local OpenAI-compatible servers that require auth.", placeholder: "", default: "" }], configured: true, values: {}, suggested_models: ["qwen3-coder:30b"], key_set_at: null, last_used_at: null },
 ];
 
 /** Install the API + WebSocket mocks on a page. Returns handles for assertions/seed data. */

--- a/surfaces/gui/e2e/provider-keys.spec.ts
+++ b/surfaces/gui/e2e/provider-keys.spec.ts
@@ -71,3 +71,22 @@ test("non-secret fields blur-save on a configured provider (ollama endpoint)", a
   await page.getByTestId("set-provider-ollama").click();
   await expect(page.getByTestId("set-field-base_url")).toHaveValue("http://127.0.0.1:9999");
 });
+
+test("a keyless provider's optional key does not take over the form (ollama)", async ({
+  page,
+}) => {
+  // Ollama offers an optional key for local servers behind auth (oMLX, a gated proxy).
+  // That must not turn it into a "keyed" provider: the endpoint stays inline (not hidden
+  // behind the Custom endpoint disclosure) and keeps the Detect button, which stays
+  // enabled while the optional key is empty.
+  await openModels(page);
+  await page.getByTestId("set-provider-ollama").click();
+
+  await expect(page.getByTestId("set-field-base_url")).toBeVisible();
+  await expect(page.getByTestId("set-field-api_key")).toBeVisible();
+  await expect(page.getByTestId("set-endpoint-link")).toHaveCount(0);
+
+  const detect = page.getByTestId("set-test");
+  await expect(detect).toBeEnabled();
+  await expect(detect).toHaveText("Detect");
+});

--- a/surfaces/gui/src/providers/ProviderSetup.tsx
+++ b/surfaces/gui/src/providers/ProviderSetup.tsx
@@ -331,13 +331,19 @@ export function ProviderForm({
       {info?.blurb && <p className="text-[11.5px] text-faint mt-1">{info.blurb}</p>}
 
       {(info?.fields || []).map((f) => {
-        const keyed = (info?.fields || []).some((x) => x.secret);
+        // "Keyed" means the provider REQUIRES a key (needs_key) — not merely that it has a
+        // secret field. Keyless providers may expose an optional key (Ollama, for local
+        // servers behind auth) and must keep their endpoint-first layout and Detect button.
+        const keyed = !!info?.needs_key;
         // A keyed provider's base_url is an expert option — it renders BELOW the key-help
         // line as its own advanced section (owner nit 2026-07-19), not inside the loop.
         if (f.key === "base_url" && keyed) return null;
-        const testable =
-          (f.secret && f.key === (info?.fields || []).find((x) => x.secret)?.key) ||
-          (!keyed && f.key === (info?.fields || [])[0]?.key);
+        // Exactly one field carries Test/Detect: the key for keyed providers, the first
+        // field (the endpoint) otherwise.
+        const primaryKey = keyed
+          ? (info?.fields || []).find((x) => x.secret)?.key
+          : (info?.fields || [])[0]?.key;
+        const testable = f.key === primaryKey;
         return (
           <div key={f.key}>
             <label className={label}>{f.label}</label>
@@ -389,7 +395,11 @@ export function ProviderForm({
                 </button>
               )}
             </div>
-            {f.help && !f.secret && <p className="text-[11.5px] text-faint mt-1">{f.help}</p>}
+            {/* Keyed providers get KEY_HELP below instead; a keyless provider's optional
+                key still needs its own hint. */}
+            {f.help && (!f.secret || !info?.needs_key) && (
+              <p className="text-[11.5px] text-faint mt-1">{f.help}</p>
+            )}
           </div>
         );
       })}
@@ -408,7 +418,8 @@ export function ProviderForm({
       )}
       {info && !info.needs_key && (
         <p className="text-[11.5px] text-faint mt-2">
-          No API key needed — Ollama runs models on this Mac.{" "}
+          No API key needed — Ollama runs models on this machine. Add one only if your local
+          server requires auth.{" "}
           <button
             className="text-muted underline decoration-line underline-offset-2 hover:text-ink"
             onClick={() => openExternal("https://ollama.com/download")}
@@ -422,7 +433,7 @@ export function ProviderForm({
           with enough separation to read as its own advanced row — no explainer copy
           (owner calls 2026-07-18 + 2026-07-19). */}
       {(() => {
-        const keyed = (info?.fields || []).some((x) => x.secret);
+        const keyed = !!info?.needs_key;
         const ep = keyed ? (info?.fields || []).find((f) => f.key === "base_url") : undefined;
         if (!ep) return null;
         if (!ps.showEndpoint)

--- a/tests/test_provider_local_auth.py
+++ b/tests/test_provider_local_auth.py
@@ -1,0 +1,142 @@
+"""Optional API key for Ollama / authenticated local OpenAI-compatible servers.
+
+Some local runtimes that speak Ollama's OpenAI-compatible API (oMLX, a gated reverse proxy
+in front of `ollama serve`) sit behind a small auth layer. These tests pin the contract:
+an empty key keeps today's keyless behavior exactly, and a stored key is used for both the
+runtime client and the Test/Detect probe.
+
+Hermetic: no network — the OpenAI SDK constructor and `httpx.get` are monkeypatched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from coworker.providers.registry import (
+    build_provider_client,
+    get_descriptor,
+    verify_provider_key,
+)
+
+
+# -- descriptor ----------------------------------------------------------------
+def test_ollama_exposes_an_optional_secret_api_key_field():
+    d = get_descriptor("ollama")
+    assert d is not None
+    # Stays keyless: the gallery must keep showing Ollama as usable with no key.
+    assert d.needs_key is False
+    field = next((f for f in d.fields if f.key == "api_key"), None)
+    assert field is not None, "ollama should offer an optional api_key field"
+    assert field.secret is True
+    assert field.required is False
+
+
+# -- runtime client ------------------------------------------------------------
+def _capture_openai(monkeypatch):
+    captured: dict = {}
+
+    def fake_openai(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(**kwargs)
+
+    import coworker.providers.registry as reg
+
+    monkeypatch.setattr(reg, "OpenAIProvider", fake_openai)
+    return captured
+
+
+def test_build_ollama_uses_the_stored_key_when_present(monkeypatch):
+    captured = _capture_openai(monkeypatch)
+    build_provider_client(
+        "ollama", {"base_url": "http://box:11434", "api_key": "sk-local-123"}, secrets=None
+    )
+    assert captured["api_key"] == "sk-local-123"
+    assert captured["base_url"] == "http://box:11434/v1"
+
+
+def test_build_ollama_keeps_the_placeholder_when_no_key(monkeypatch):
+    captured = _capture_openai(monkeypatch)
+    build_provider_client("ollama", {"base_url": "http://box:11434"}, secrets=None)
+    # Ollama ignores the key but the OpenAI SDK requires a non-empty string.
+    assert captured["api_key"] == "ollama"
+
+
+def test_build_ollama_ignores_a_blank_key(monkeypatch):
+    captured = _capture_openai(monkeypatch)
+    build_provider_client("ollama", {"api_key": "   "}, secrets=None)
+    assert captured["api_key"] == "ollama"
+
+
+# -- verify (Test / Detect) ----------------------------------------------------
+def _capture_httpx(monkeypatch, status: int = 200):
+    calls: list[dict] = []
+
+    def fake_get(url, **kwargs):
+        calls.append({"url": url, **kwargs})
+        return SimpleNamespace(status_code=status)
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    return calls
+
+
+def test_verify_ollama_sends_bearer_when_a_key_is_given(monkeypatch):
+    calls = _capture_httpx(monkeypatch)
+    out = verify_provider_key(
+        "ollama", api_key="sk-local-123", base_url="http://localhost:11434"
+    )
+    assert out["ok"] is True
+    assert calls[0]["url"] == "http://localhost:11434/v1/models"
+    assert calls[0]["headers"] == {"Authorization": "Bearer sk-local-123"}
+
+
+def test_verify_ollama_stays_keyless_without_a_key(monkeypatch):
+    calls = _capture_httpx(monkeypatch)
+    verify_provider_key("ollama", base_url="http://localhost:11434")
+    # Unchanged from today: no auth header at all.
+    assert "headers" not in calls[0]
+
+
+# -- persistence ---------------------------------------------------------------
+def _manager(tmp_path):
+    from coworker.server.manager import SessionManager
+
+    return SessionManager(workspace=tmp_path)
+
+
+def test_set_provider_stores_the_optional_key(tmp_path):
+    mgr = _manager(tmp_path)
+    mgr.set_provider("ollama", {"base_url": "http://box:11434", "api_key": "sk-local-123"})
+    profile = mgr.secrets.get("provider:ollama")
+    assert profile["api_key"] == "sk-local-123"
+
+
+def test_resaving_without_the_key_does_not_wipe_it(tmp_path):
+    """The GUI masks saved secrets and submits them blank on a re-save / Detect.
+
+    An optional secret must therefore survive an empty submit, exactly like a required one —
+    otherwise editing the server URL silently drops the key.
+    """
+    mgr = _manager(tmp_path)
+    mgr.set_provider("ollama", {"base_url": "http://box:11434", "api_key": "sk-local-123"})
+    mgr.set_provider("ollama", {"base_url": "http://other:11434", "api_key": ""})
+    profile = mgr.secrets.get("provider:ollama")
+    assert profile["api_key"] == "sk-local-123"
+    assert profile["base_url"] == "http://other:11434"
+
+
+def test_non_secret_optional_fields_can_still_be_cleared(tmp_path):
+    mgr = _manager(tmp_path)
+    mgr.set_provider("ollama", {"base_url": "http://box:11434"})
+    mgr.set_provider("ollama", {"base_url": ""})
+    profile = mgr.secrets.get("provider:ollama")
+    assert "base_url" not in profile
+
+
+def test_verify_provider_falls_back_to_the_stored_key(tmp_path, monkeypatch):
+    calls = _capture_httpx(monkeypatch)
+    mgr = _manager(tmp_path)
+    mgr.set_provider("ollama", {"base_url": "http://box:11434", "api_key": "sk-local-123"})
+    mgr.verify_provider("ollama", {})
+    assert calls[-1]["headers"] == {"Authorization": "Bearer sk-local-123"}


### PR DESCRIPTION
## Summary

Fixes #97.

Local runtimes that speak Ollama's OpenAI-compatible API increasingly sit behind a small auth
layer — oMLX, or a gated reverse proxy in front of `ollama serve`. OpenWorker can't talk to them
today:

- `_build_ollama` hardcodes the placeholder `api_key="ollama"`, and
- the Test/Detect probe (`verify_provider_key`) sends no `Authorization` header,

so the server answers `401` and the provider just looks broken.

This adds an **optional** API key to the Ollama provider and threads it through both paths.
Following @Yashasm18's acceptance notes on the issue, the key is used for the runtime requests
*and* the connection test, and leaving it blank keeps current behavior exactly.

## What changed

- **Optional secret `api_key` field** on the Ollama descriptor. `needs_key` stays `false`, so
  Ollama remains "configured" out of the box and the gallery still shows *No key needed*.
- **`_build_ollama`** uses the stored key, falling back to the `"ollama"` placeholder when blank
  (the OpenAI SDK requires a non-empty string).
- **`verify_provider_key`** sends `Bearer <key>` for ollama **only** when a key is present;
  otherwise the request is byte-for-byte the unauthenticated one it is today.

Two supporting fixes this needs in order to be correct:

- **`set_provider` no longer wipes a saved secret on a blank submit.** Optional fields were kept
  only when non-empty, and the GUI masks a stored secret and re-submits it blank — so editing the
  server URL (or re-running Detect) would silently delete the key. Secrets now behave like
  required keys: an empty submit leaves the stored value alone, a rotation always arrives
  non-empty. Non-secret optional fields can still be cleared.
- **`ProviderSetup`: "keyed" now means `needs_key`**, not "has any secret field". With the old
  heuristic, adding this field would have hidden Ollama's endpoint behind the *Custom endpoint*
  disclosure and moved the Detect button onto the empty key — where it renders **disabled**.
  Exactly one field now owns Test/Detect: the key for keyed providers, the endpoint otherwise.

Complementary to #63 (which adds a *separate* self-hosted provider with a **required** key and a
verbatim URL); this keeps the path users actually reported — picking **Ollama** — working.

## Test plan

New hermetic `tests/test_provider_local_auth.py` (no network; the SDK constructor and `httpx.get`
are monkeypatched). Written test-first — 6 failed / 4 passed before the change, all 10 pass after:

- descriptor stays `needs_key=False` and exposes an optional secret `api_key`
- client build uses a stored key; falls back to the placeholder when missing **or blank**
- verify sends `Bearer` with a key, and **no** `headers` at all without one (pins today's behavior)
- `set_provider` stores the key, and a later blank submit does **not** wipe it
- a non-secret optional field can still be cleared
- `verify_provider` falls back to the stored key when the form omits it

```
$ pytest tests/test_provider_local_auth.py -q
10 passed

$ pytest tests -q
899 passed, 1 skipped

$ npx tsc --noEmit          # exit 0

$ npx playwright test e2e/provider-keys.spec.ts e2e/settings.spec.ts e2e/onboarding.spec.ts
14 passed
```

The e2e run includes a new regression test — *"a keyless provider's optional key does not take
over the form (ollama)"* — asserting the endpoint stays inline (no *Custom endpoint* disclosure)
and Detect is present and **enabled** while the optional key is empty.

Note: `src/components/Sidebar.test.tsx` has 7 failing vitest cases; they reproduce identically on
a clean `main` checkout and are unrelated to this change.

## Not in scope

`_ollama_alive` / `_ollama_models` still probe the **native** `/api/tags` endpoint without auth, so
an authenticated server may chat fine while its suggested-model list stays empty. That is a
separate fix (closer to #57) and I kept it out to keep this diff reviewable — happy to follow up.

No new dependencies.
