### PR TITLE
Let the composer's model picker accept a typed model id

### DIFF
--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -809,6 +809,12 @@ export async function mockApi(page: import("@playwright/test").Page) {
     }
 
     if (p.endsWith("/v1/health")) return json(HEALTH);
+    if (p.endsWith("/v1/settings/models/add") && m === "POST") {
+      // A model typed into the composer picker is persisted into the curated shortlist.
+      const added = String(req.postDataJSON()?.model || "");
+      if (added && !SETTINGS.models.includes(added)) SETTINGS.models.push(added);
+      return json({ ok: true, models: SETTINGS.models, model_labels: SETTINGS.model_labels });
+    }
     if (p.endsWith("/v1/settings")) return json(SETTINGS);
     if (p.endsWith("/v1/settings/pdf") && m === "POST") {
       Object.assign(SETTINGS, req.postDataJSON());

--- a/surfaces/gui/e2e/model-switch.spec.ts
+++ b/surfaces/gui/e2e/model-switch.spec.ts
@@ -31,3 +31,47 @@ test("mid-session model switch shows the marker and later turns use the new mode
     page.getByText("Echo: after the switch [model=gpt-5.5]", { exact: false }).first(),
   ).toBeVisible();
 });
+
+test("the picker accepts a model id typed by hand and remembers it", async ({ page }) => {
+  // #120: the curated list is a shortlist, not an allow-list — the server takes any model
+  // string. Before this, a freshly pulled Ollama tag was unreachable from the composer.
+  await page.goto("/");
+  await page.getByText("Draft the launch note").first().click();
+  const box = page.getByPlaceholder(/Ask the coworker/);
+  await box.fill("hello there");
+  await box.press("Enter");
+  await expect(page.getByText("Echo: hello there", { exact: false }).first()).toBeVisible();
+
+  const picker = page.locator(".dd").filter({ hasText: "Claude Opus 4.8" });
+  await picker.locator(".pill").click();
+  await page.getByTestId("dd-filter").fill("ollama:qwen3-coder:30b");
+  await page.getByTestId("dd-use-custom").click();
+
+  // The switch took effect…
+  await expect(page.getByText(/Model switched to ollama:qwen3-coder:30b/).first()).toBeVisible();
+  await box.fill("after the switch");
+  await box.press("Enter");
+  await expect(
+    page.getByText("Echo: after the switch [model=ollama:qwen3-coder:30b]", { exact: false }).first(),
+  ).toBeVisible();
+
+  // …and the typed id joined the shortlist, so it's one click away next time.
+  await page.locator(".dd").first().locator(".pill").click();
+  await expect(
+    page.locator(".dd-item").filter({ hasText: "qwen3-coder:30b" }).first(),
+  ).toBeVisible();
+});
+
+test("typing filters the list and Escape closes without switching", async ({ page }) => {
+  await page.goto("/");
+  await page.getByText("Draft the launch note").first().click();
+
+  const picker = page.locator(".dd").filter({ hasText: "Claude Opus 4.8" });
+  await picker.locator(".pill").click();
+  await page.getByTestId("dd-filter").fill("gpt");
+  await expect(page.locator(".dd-item").filter({ hasText: "Claude Opus 4.8" })).toHaveCount(0);
+
+  await page.getByTestId("dd-filter").press("Escape");
+  await expect(page.getByTestId("dd-filter")).toHaveCount(0);
+  await expect(picker).toBeVisible(); // still on the original model
+});

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type PointerEvent } from "react";
 import {
+  addModel,
   announceInboxUnlock,
   finalizeAutomationRun,
   getArtifacts,
@@ -872,6 +873,19 @@ export function App() {
     if (running) return; // the server refuses mid-turn rebinds — don't let the header lie
     setModel(m);
     sessionRef.current?.setModel(m);
+    // A model typed into the picker isn't in the curated list yet. Persist it so it survives
+    // a reload and shows up in Settings → Models (where it can be removed); the switch itself
+    // already happened above, so a failure here costs nothing but the shortlist entry.
+    if (m && !models.includes(m)) {
+      void addModel(m)
+        .then((s) => {
+          if (s?.ok) {
+            setModels(s.models || []);
+            setModelLabels(s.model_labels || {});
+          }
+        })
+        .catch(() => {});
+    }
   };
 
   const startNewSession = (forAgent?: string) => {

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -476,7 +476,17 @@ export function Composer(props: Props) {
               <span className="model-warn-ico" aria-hidden>⚠</span>
             </button>
           ) : modelsLoaded ? (
-            <Dropdown value={props.model} options={modelOptions} onChange={props.onModelChange} align="right" />
+            <Dropdown
+              value={props.model}
+              options={modelOptions}
+              onChange={props.onModelChange}
+              align="right"
+              // The curated list is a shortlist, not an allow-list — the server accepts any
+              // model string, so let people type one (a freshly pulled Ollama tag, a preview
+              // id) without a round trip through Settings.
+              editable
+              editablePlaceholder="Filter or type a model id…"
+            />
           ) : (
             <button
               className="pill chip text-faint cursor-default"

--- a/surfaces/gui/src/components/Dropdown.test.tsx
+++ b/surfaces/gui/src/components/Dropdown.test.tsx
@@ -1,0 +1,116 @@
+// The composer's model chip must let you type a model id the curated list doesn't have —
+// the backend already accepts any string ("Adding any model string works at your own risk"),
+// but a select-only picker gave no way in. `editable` turns the menu into a combobox while
+// leaving every existing (non-editable) Dropdown untouched.
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Dropdown, type Option } from "./Dropdown";
+
+afterEach(cleanup);
+
+const OPTIONS: Option[] = [
+  { value: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
+  { value: "anthropic:claude-fable-5", label: "Claude Fable 5" },
+];
+
+const open = () => fireEvent.click(screen.getByRole("button", { name: /GPT-5.6 Sol/ }));
+
+describe("Dropdown (select mode, unchanged)", () => {
+  it("picks an option and closes", () => {
+    const onChange = vi.fn();
+    render(<Dropdown value="gpt-5.6-sol" options={OPTIONS} onChange={onChange} />);
+    open();
+    fireEvent.click(screen.getByText("Claude Fable 5"));
+    expect(onChange).toHaveBeenCalledWith("anthropic:claude-fable-5");
+  });
+
+  it("shows no filter box unless editable", () => {
+    render(<Dropdown value="gpt-5.6-sol" options={OPTIONS} onChange={() => {}} />);
+    open();
+    expect(screen.queryByRole("combobox")).toBeNull();
+  });
+});
+
+describe("Dropdown (editable combobox)", () => {
+  const renderEditable = (onChange = vi.fn()) => {
+    render(<Dropdown value="gpt-5.6-sol" options={OPTIONS} onChange={onChange} editable />);
+    open();
+    return onChange;
+  };
+
+  it("commits a typed model id that is not in the list", () => {
+    const onChange = renderEditable();
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "ollama:qwen3-coder:30b" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith("ollama:qwen3-coder:30b");
+  });
+
+  it("trims whitespace and ignores an empty commit", () => {
+    const onChange = renderEditable();
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "  spaced:model  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith("spaced:model");
+
+    onChange.mockClear();
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("filters the curated options as you type", () => {
+    renderEditable();
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "claude" } });
+    // Scope to the menu — the trigger pill still shows the current model's label.
+    const shown = screen.getAllByRole("option").map((o) => o.textContent);
+    expect(shown.some((t) => t?.includes("Claude Fable 5"))).toBe(true);
+    expect(shown.some((t) => t?.includes("GPT-5.6 Sol"))).toBe(false);
+  });
+
+  it("still lets you click a curated option", () => {
+    const onChange = renderEditable();
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "claude" } });
+    fireEvent.click(screen.getByText("Claude Fable 5"));
+    expect(onChange).toHaveBeenCalledWith("anthropic:claude-fable-5");
+  });
+
+  it("selects the highlighted option with the arrow keys", () => {
+    const onChange = renderEditable();
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith("anthropic:claude-fable-5");
+  });
+
+  it("closes on Escape without committing, and keeps Escape from reaching the composer", () => {
+    // Composer binds Escape to Stop — an open picker must claim it first, so we assert the
+    // event never reaches an ancestor handler.
+    const onChange = vi.fn();
+    const onAncestorKeyDown = vi.fn();
+    render(
+      <div onKeyDown={onAncestorKeyDown}>
+        <Dropdown value="gpt-5.6-sol" options={OPTIONS} onChange={onChange} editable />
+      </div>,
+    );
+    open();
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "draft:model" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(onAncestorKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("exposes combobox/listbox semantics", () => {
+    renderEditable();
+    const input = screen.getByRole("combobox");
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+    expect(input.getAttribute("aria-autocomplete")).toBe("list");
+    expect(screen.getByRole("listbox")).toBeTruthy();
+    expect(screen.getAllByRole("option").length).toBe(2);
+  });
+});

--- a/surfaces/gui/src/components/Dropdown.tsx
+++ b/surfaces/gui/src/components/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Icon } from "./Icon";
 
 export interface Option {
@@ -15,42 +15,161 @@ interface Props {
   align?: "left" | "right";
   // Extra classes appended to the trigger pill (e.g. "chip" for a bordered composer-head chip).
   className?: string;
+  // Opt-in combobox: the menu grows a filter box and any typed value can be committed, for
+  // lists the server treats as suggestions rather than an allow-list (the model picker —
+  // Settings already says "adding any model string works at your own risk"). Off by default,
+  // so every other Dropdown keeps its select-only behavior.
+  editable?: boolean;
+  // Placeholder for that filter box (e.g. "Filter or type a model id…").
+  editablePlaceholder?: string;
 }
 
-export function Dropdown({ prefix, value, options, onChange, align = "left", className }: Props) {
+export function Dropdown({
+  prefix,
+  value,
+  options,
+  onChange,
+  align = "left",
+  className,
+  editable = false,
+  editablePlaceholder = "Filter or type a value…",
+}: Props) {
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  // -1 = "commit exactly what's typed"; >=0 indexes the filtered list.
+  const [active, setActive] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
   const current = options.find((o) => o.value === value);
   const label = (prefix ? `${prefix}: ` : "") + (current?.label || value);
+
+  const typed = query.trim();
+  const shown =
+    editable && typed
+      ? options.filter(
+          (o) =>
+            o.label.toLowerCase().includes(typed.toLowerCase()) ||
+            o.value.toLowerCase().includes(typed.toLowerCase()),
+        )
+      : options;
+  // Offer the raw text only when it isn't already one of the suggestions.
+  const custom = editable && typed && !options.some((o) => o.value === typed) ? typed : "";
+
+  useEffect(() => {
+    if (open && editable) inputRef.current?.focus();
+  }, [open, editable]);
+
+  const close = () => {
+    setOpen(false);
+    setQuery("");
+    setActive(-1);
+  };
+
+  const commit = (v: string) => {
+    const next = v.trim();
+    if (!next) return; // an empty box commits nothing
+    onChange(next);
+    close();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!shown.length) return;
+      const step = e.key === "ArrowDown" ? 1 : -1;
+      // -1 (the typed text) participates in the cycle only when there is typed text.
+      const min = custom ? -1 : 0;
+      const span = shown.length - min;
+      setActive((i) => min + ((i - min + step + span) % span));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      commit(active >= 0 && shown[active] ? shown[active].value : query);
+    } else if (e.key === "Escape") {
+      // The composer binds Escape to Stop — an open picker must claim it first.
+      e.preventDefault();
+      e.stopPropagation();
+      close();
+    } else if (e.key === "Tab") {
+      close();
+    }
+  };
+
   return (
     <div className="dd">
       <button
         className={"pill" + (className ? " " + className : "")}
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => (open ? close() : setOpen(true))}
         title={label}
+        aria-haspopup={editable ? "listbox" : undefined}
+        aria-expanded={editable ? open : undefined}
       >
         <span className="pill-label">{label}</span>
         <Icon name="chevronDown" size={13} className="caret" />
       </button>
       {open && (
         <>
-          <div className="dd-backdrop" onClick={() => setOpen(false)} />
+          <div className="dd-backdrop" onClick={close} />
           <div className={"dd-menu " + align}>
-            {options.map((o) => (
-              <div
-                key={o.value}
-                className={"dd-item" + (o.value === value ? " sel" : "")}
-                onClick={() => {
-                  onChange(o.value);
-                  setOpen(false);
+            {editable && (
+              <input
+                ref={inputRef}
+                className="dd-filter"
+                role="combobox"
+                aria-expanded="true"
+                aria-autocomplete="list"
+                aria-controls="dd-listbox"
+                placeholder={editablePlaceholder}
+                value={query}
+                spellCheck={false}
+                autoComplete="off"
+                data-testid="dd-filter"
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setActive(-1);
                 }}
-              >
-                <div className="dd-label">
-                  {o.label}
-                  {o.value === value && <span className="chk">✓</span>}
+                onKeyDown={onKeyDown}
+              />
+            )}
+            <div id="dd-listbox" role={editable ? "listbox" : undefined}>
+              {shown.map((o, i) => (
+                <div
+                  key={o.value}
+                  className={
+                    "dd-item" + (o.value === value ? " sel" : "") + (i === active ? " active" : "")
+                  }
+                  role={editable ? "option" : undefined}
+                  aria-selected={editable ? o.value === value : undefined}
+                  onMouseEnter={() => editable && setActive(i)}
+                  onClick={() => {
+                    onChange(o.value);
+                    close();
+                  }}
+                >
+                  <div className="dd-label">
+                    {o.label}
+                    {o.value === value && <span className="chk">✓</span>}
+                  </div>
+                  {o.description && <div className="dd-desc">{o.description}</div>}
                 </div>
-                {o.description && <div className="dd-desc">{o.description}</div>}
+              ))}
+            </div>
+            {custom && (
+              <div
+                className={"dd-item dd-custom" + (active === -1 ? " active" : "")}
+                role="option"
+                aria-selected={false}
+                onMouseEnter={() => setActive(-1)}
+                onClick={() => commit(custom)}
+                data-testid="dd-use-custom"
+              >
+                <div className="dd-label">Use “{custom}”</div>
+                <div className="dd-desc">Not in the curated list — it must exist on the provider.</div>
               </div>
-            ))}
+            )}
+            {editable && !shown.length && !custom && (
+              <div className="dd-desc" style={{ padding: "6px 10px" }}>
+                No matches.
+              </div>
+            )}
           </div>
         </>
       )}

--- a/surfaces/gui/src/styles.css
+++ b/surfaces/gui/src/styles.css
@@ -504,6 +504,16 @@ button.btn.danger { color: var(--accent); }
 .dd-label { font-size: 13.5px; color: var(--ink); display: flex; justify-content: space-between; align-items: center; }
 .dd-item .chk { color: var(--accent); }
 .dd-desc { font-size: 12px; color: var(--faint); margin-top: 1px; }
+/* Editable dropdown (the composer's model picker): a filter box above the list, plus a
+   keyboard-active row that reads the same as :hover. */
+.dd-filter {
+  width: 100%; box-sizing: border-box; margin-bottom: 4px; padding: 7px 10px;
+  font: inherit; font-size: 13.5px; color: var(--ink);
+  background: var(--paper); border: 1px solid var(--line); border-radius: 8px; outline: none;
+}
+.dd-filter:focus { border-color: var(--accent); }
+.dd-item.active { background: var(--paper); }
+.dd-custom { border-top: 1px solid var(--line); border-radius: 0 0 8px 8px; margin-top: 4px; padding-top: 8px; }
 .send { width: 34px; height: 34px; border-radius: 50%; border: none; background: var(--accent); color: #fff; cursor: pointer; font-size: 16px; }
 .send:disabled { opacity: 0.4; cursor: default; }
 .statusline { max-width: 760px; margin: 6px auto 0; font-size: 12px; color: var(--faint); display: flex; gap: 12px; }


### PR DESCRIPTION
## Summary

Fixes #120.

The curated model list is a shortlist, not an allow-list — the server accepts any model string,
and Settings → Models already says so ("adding any model string works at your own risk"). But the
composer's picker was select-only, so a model that isn't curated (a freshly pulled Ollama tag, a
preview id, a self-hosted name) had no way in.

This makes the picker an **editable combobox**: type to filter the curated options, or commit
anything you type.

## What changed

`Dropdown` gains an opt-in **`editable`** prop. Only the composer's model chip passes it — every
other Dropdown renders exactly as before, and the existing DOM (`.dd` / `.pill` / `.dd-item`) is
preserved, so current selectors and styling keep working.

When editable:

- the menu grows a filter box; typing narrows the curated options by label *or* raw id
- text that isn't already an option surfaces a **Use "<id>"** row with a short caveat
- **keyboard**: Up/Down move an active row (the typed text participates as its own entry), Enter
  commits, Tab closes, Escape closes without switching
- **a11y**: the box is a real `combobox` (`aria-expanded`, `aria-autocomplete="list"`,
  `aria-controls`) over a `listbox` of `option`s with `aria-selected`

Two details worth calling out for review:

- **Escape stops propagation.** The composer binds Escape to Stop; an open picker has to claim it
  first, otherwise dismissing the menu would also abort the turn. There's a test for exactly this.
- **A typed model is persisted** through the existing `/v1/settings/models/add`, so it survives a
  reload and can be removed later from Settings → Models. The switch is applied *first*, so a
  failed persist costs only the shortlist entry, never the switch.

## Test plan

New `src/components/Dropdown.test.tsx` — 9 cases, including two that pin the **unchanged**
select-only behavior:

- select mode still picks an option, and shows no filter box
- commits a typed id not in the list; trims whitespace; ignores an empty commit
- filters curated options as you type; a filtered option is still clickable
- arrow keys highlight and Enter selects
- Escape closes without committing **and never reaches an ancestor keydown handler**
- combobox/listbox/option roles and ARIA attributes are wired

```
$ npx vitest run src/components/Dropdown.test.tsx
9 passed

$ npx tsc --noEmit          # exit 0

$ npx playwright test e2e/model-switch.spec.ts e2e/error-retry.spec.ts e2e/provider-keys.spec.ts
8 passed
```

Two new e2e flows in `model-switch.spec.ts`: a hand-typed id switches the session, the next turn
carries it, and it joins the shortlist (one click next time); plus filter-then-Escape leaves the
original model selected. The pre-existing mid-session switch test is unmodified and still passes,
which is the point of keeping the `.dd-item` DOM.

Unrelated pre-existing failures, verified to reproduce identically on a clean `main` checkout:
`src/components/Sidebar.test.tsx` (7 vitest cases) and `e2e/nav-collapse.spec.ts:23` (presses ⌘B
during the boot splash; fails 3/3 on `main` here).

No new dependencies.
