### PR TITLE
fix: add httpx2 dev dependency to silence Starlette TestClient deprec…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "pytest-asyncio", "httpx"]
+dev = ["pytest>=8", "pytest-asyncio", "httpx", "httpx2" ]
 # Inbound messaging listeners (outbound send_message needs only httpx, already a core dep).
 # aiohttp is slack-bolt's Socket Mode transport at runtime (and the FakeSlack test harness
 # drives the real handler) — declare it so CI installs it, not just transitively.


### PR DESCRIPTION
## What was broken
Running the test suite (`pytest`) emits a `StarletteDeprecationWarning`:

> Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.

This comes from Starlette's `TestClient`, which has moved to `httpx2` (Pydantic's
maintained fork of `httpx`, since the original became unmaintained).

## Fix
Added `httpx2` to the `dev` optional-dependencies group in `pyproject.toml`,
alongside the existing `httpx` (which remains a core runtime dependency used
elsewhere in the app, e.g. outbound messaging senders — untouched).

## Before / after

**Before:**
<img width="1911" height="287" alt="image" src="https://github.com/user-attachments/assets/7c126eaf-5344-4e20-a2e7-e1ad6743e3de" />
**After:**
<img width="1900" height="122" alt="image" src="https://github.com/user-attachments/assets/a6a36d77-c997-464c-96a1-03c9ebc687f8" />
Warning is gone, all tests still pass, no other behavior changed.