### PR TITLE
Add LM Studio as a keyless local model provider.

### DIFF
--- a/coworker/providers/capabilities.py
+++ b/coworker/providers/capabilities.py
@@ -24,7 +24,7 @@ def capabilities_for(model: str) -> ModelCapabilities:
 
     # Ollama (local) models vary widely and many fake/mishandle parallel tool calls — assume
     # tools work (we only point at tool-capable models) but stay conservative otherwise.
-    if provider == "ollama":
+    if provider in ("ollama", "lm_studio"):
         return ModelCapabilities(
             tools=True, vision=False, parallel_tool_calls=False, streaming=True
         )

--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -8,8 +8,8 @@ model string and builds (and caches) its client from the matching SecretStore pr
 
 Today: `openai` (the default, with an optional custom endpoint that covers Azure OpenAI's
 `/openai/v1` and any OpenAI-compliant gateway), `anthropic` (native Messages API via
-`AnthropicProvider`), `gemini` (native Google GenAI API via `GeminiProvider`), and `ollama`
-(local, OpenAI-compatible `/v1`). Bedrock/Vertex auth for Claude is future work.
+`AnthropicProvider`), `gemini` (native Google GenAI API via `GeminiProvider`), `ollama` and
+`lm_studio` (local, OpenAI-compatible `/v1`). Bedrock/Vertex auth for Claude is future work.
 """
 
 from __future__ import annotations
@@ -24,6 +24,9 @@ from .gemini_provider import GeminiProvider
 from .openai_provider import OpenAIProvider
 
 DEFAULT_OLLAMA_URL = "http://localhost:11434"
+DEFAULT_LM_STUDIO_URL = "http://localhost:1234"
+
+_KEYLESS_LOCAL = frozenset({"ollama", "lm_studio"})
 
 
 @dataclass(frozen=True)
@@ -81,18 +84,24 @@ class ProviderDescriptor:
         }
 
 
+def _normalize_local_v1_url(url: Optional[str], default: str) -> str:
+    """Accept `http://host:port` or `.../v1` and return an OpenAI-compatible base URL."""
+    base = (url or default).strip().rstrip("/") or default
+    return base if base.endswith("/v1") else base + "/v1"
+
+
 def _normalize_ollama_url(url: Optional[str]) -> str:
     """Accept `http://host:11434` or `.../v1` and return an OpenAI-compatible base URL.
 
     Ollama serves its OpenAI-compatible API under `/v1`; the native API lives at the root, so we
     always target `<root>/v1`.
     """
-    base = (url or DEFAULT_OLLAMA_URL).strip().rstrip("/")
-    if not base:
-        base = DEFAULT_OLLAMA_URL
-    if not base.endswith("/v1"):
-        base = base + "/v1"
-    return base
+    return _normalize_local_v1_url(url, DEFAULT_OLLAMA_URL)
+
+
+def _normalize_lm_studio_url(url: Optional[str]) -> str:
+    """LM Studio's local server speaks OpenAI-compatible `/v1`; normalize like Ollama."""
+    return _normalize_local_v1_url(url, DEFAULT_LM_STUDIO_URL)
 
 
 def _build_openai(profile: dict[str, Any], secrets: Any) -> ProviderClient:
@@ -131,6 +140,12 @@ def _build_ollama(profile: dict[str, Any], secrets: Any) -> ProviderClient:
     # string, so we pass a placeholder. `base_url` comes from the stored profile (or the default).
     base_url = _normalize_ollama_url((profile or {}).get("base_url"))
     return OpenAIProvider(api_key="ollama", base_url=base_url)
+
+
+def _build_lm_studio(profile: dict[str, Any], secrets: Any) -> ProviderClient:
+    # LM Studio's local OpenAI-compatible server is keyless; the SDK still wants a string.
+    base_url = _normalize_lm_studio_url((profile or {}).get("base_url"))
+    return OpenAIProvider(api_key="lm-studio", base_url=base_url)
 
 
 def _openai_compat(vendor: str, default_base_url: str, env_key: Optional[str] = None):
@@ -352,6 +367,22 @@ DESCRIPTORS: list[ProviderDescriptor] = [
         # `ollama pull qwen3-coder:30b`.
         recommended_model="qwen3-coder:30b",
     ),
+    ProviderDescriptor(
+        name="lm_studio",
+        title="LM Studio (local models)",
+        needs_key=False,
+        fields=[
+            ProviderField(
+                "base_url",
+                "LM Studio server URL",
+                secret=False,
+                required=False,
+                placeholder=DEFAULT_LM_STUDIO_URL,
+                help="Where LM Studio's local API is listening. The /v1 path is added automatically.",
+            ),
+        ],
+        build=_build_lm_studio,
+    ),
 ]
 
 _BY_NAME = {d.name: d for d in DESCRIPTORS}
@@ -424,6 +455,9 @@ def verify_provider_key(
         elif name == "ollama":
             base = _normalize_ollama_url(base_url)
             resp = httpx.get(base.rstrip("/") + "/models", timeout=timeout)
+        elif name == "lm_studio":
+            base = _normalize_lm_studio_url(base_url)
+            resp = httpx.get(base.rstrip("/") + "/models", timeout=timeout)
         else:  # openai + any OpenAI-compatible endpoint (Azure, OpenRouter, vendors, vLLM…)
             default_base = next(
                 (f.default for f in d.fields if f.key == "base_url" and f.default), ""
@@ -447,10 +481,10 @@ def verify_provider_key(
     if resp.status_code < 300:
         return {"ok": True}
     if resp.status_code in (401, 403):
-        if name == "ollama":
+        if name in _KEYLESS_LOCAL:
             return {"ok": False, "error": "Server rejected the request."}
         return {"ok": False, "error": "Invalid API key."}
-    if resp.status_code == 404 and name == "ollama":
+    if resp.status_code == 404 and name in _KEYLESS_LOCAL:
         return {
             "ok": False,
             "error": "Reached the server, but no OpenAI-compatible /v1 API there.",

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1497,6 +1497,8 @@ class SessionManager:
         topped up with the compat-vendor extras the matrix doesn't vouch for."""
         if name == "ollama":
             return [m.split(":", 1)[-1] for m in self._ollama_models()]
+        if name == "lm_studio":
+            return [m.split(":", 1)[-1] for m in self._lm_studio_models()]
         from ..providers.matrix import models_for_provider
 
         return list(
@@ -1678,6 +1680,49 @@ class SessionManager:
         except Exception:
             return []
 
+    def _lm_studio_alive(self) -> bool:
+        """Best-effort LM Studio liveness, cached 30s. `lm_studio:*` picker entries show only
+        while the local server answers — keyless must not mean always-present."""
+        now = time.monotonic()
+        cached = getattr(self, "_lm_studio_alive_cache", None)
+        if cached and now - cached[0] < 30:
+            return cached[1]
+        from ..providers.registry import _normalize_lm_studio_url
+
+        profile = self.secrets.get("provider:lm_studio") or {}
+        base = _normalize_lm_studio_url(profile.get("base_url"))
+        try:
+            import httpx
+
+            alive = (
+                httpx.get(base.rstrip("/") + "/models", timeout=0.8).status_code == 200
+            )
+        except Exception:
+            alive = False
+        self._lm_studio_alive_cache = (now, alive)
+        return alive
+
+    def _lm_studio_models(self) -> list[str]:
+        """Live list of models loaded in LM Studio (via OpenAI `/v1/models`), as
+        `lm_studio:<id>` so they're directly selectable. Empty if unreachable."""
+        profile = self.secrets.get("provider:lm_studio")
+        if not profile:
+            return []
+        from ..providers.registry import _normalize_lm_studio_url
+
+        base = _normalize_lm_studio_url(profile.get("base_url"))
+        try:
+            import httpx
+
+            data = httpx.get(base.rstrip("/") + "/models", timeout=2.0).json()
+            return [
+                f"lm_studio:{m['id']}"
+                for m in data.get("data", [])
+                if m.get("id")
+            ]
+        except Exception:
+            return []
+
     def _curated_models(self) -> list[str]:
         """The models offered in the composer's selector: every curated-matrix model
         (`get_settings` culls the ones whose provider has no key) plus custom ids the user
@@ -1746,6 +1791,8 @@ class SessionManager:
             provider = self._model_provider(m)
             if provider == "ollama":
                 return self._ollama_alive()
+            if provider == "lm_studio":
+                return self._lm_studio_alive()
             return self._provider_configured(provider)
 
         selectable = [m for m in self._curated_models() if _selectable(m)]

--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -334,6 +334,7 @@ const PROVIDERS = [
   // ollama: keyless local provider — "configured" without proving anything runs; the
   // onboarding gallery shows "No key needed" and its form is endpoint + Detect (§39).
   { name: "ollama", title: "Ollama (local models)", needs_key: false, fields: [{ key: "base_url", label: "Endpoint", secret: false, required: false, help: "", placeholder: "http://127.0.0.1:11434", default: "http://127.0.0.1:11434" }], configured: true, values: {}, suggested_models: ["qwen3-coder:30b"], key_set_at: null, last_used_at: null },
+  { name: "lm_studio", title: "LM Studio (local models)", needs_key: false, fields: [{ key: "base_url", label: "Endpoint", secret: false, required: false, help: "", placeholder: "http://127.0.0.1:1234", default: "http://127.0.0.1:1234" }], configured: true, values: {}, suggested_models: [], key_set_at: null, last_used_at: null },
 ];
 
 /** Install the API + WebSocket mocks on a page. Returns handles for assertions/seed data. */

--- a/surfaces/gui/src/providers/ProviderSetup.tsx
+++ b/surfaces/gui/src/providers/ProviderSetup.tsx
@@ -31,6 +31,20 @@ export const KEY_HELP: Record<string, { url: string; label: string }> = {
   xai: { url: "https://console.x.ai", label: "console.x.ai" },
 };
 
+// Keyless local providers — install link + one-line hint (no API key field).
+const KEYLESS_HELP: Record<string, { text: string; url: string; label: string }> = {
+  ollama: {
+    text: "No API key needed — Ollama runs models on this Mac.",
+    url: "https://ollama.com/download",
+    label: "Install Ollama",
+  },
+  lm_studio: {
+    text: "No API key needed — LM Studio runs models on this computer.",
+    url: "https://lmstudio.ai/download",
+    label: "Install LM Studio",
+  },
+};
+
 export type Verify = { state: "idle" | "testing" | "ok" | "error"; msg?: string };
 
 /** Brand chip: always a light plate so multicolor marks read on any theme. */
@@ -406,14 +420,14 @@ export function ProviderForm({
           — takes about a minute.
         </p>
       )}
-      {info && !info.needs_key && (
+      {info && !info.needs_key && KEYLESS_HELP[sel] && (
         <p className="text-[11.5px] text-faint mt-2">
-          No API key needed — Ollama runs models on this Mac.{" "}
+          {KEYLESS_HELP[sel].text}{" "}
           <button
             className="text-muted underline decoration-line underline-offset-2 hover:text-ink"
-            onClick={() => openExternal("https://ollama.com/download")}
+            onClick={() => openExternal(KEYLESS_HELP[sel].url)}
           >
-            Install Ollama ↗
+            {KEYLESS_HELP[sel].label} ↗
           </button>
         </p>
       )}

--- a/surfaces/gui/src/providers/logos.ts
+++ b/surfaces/gui/src/providers/logos.ts
@@ -43,6 +43,7 @@ export const PROVIDER_ORDER = [
   "gemini",
   "meta",
   "ollama",
+  "lm_studio",
   "fireworks",
   "together",
   "zai",

--- a/tests/test_provider_router.py
+++ b/tests/test_provider_router.py
@@ -14,7 +14,11 @@ from coworker.providers import (
     StreamChunk,
     capabilities_for,
 )
-from coworker.providers.registry import _normalize_ollama_url, build_provider_client
+from coworker.providers.registry import (
+    _normalize_lm_studio_url,
+    _normalize_ollama_url,
+    build_provider_client,
+)
 from coworker.providers.openai_provider import _salvage_tool_calls_from_text
 
 
@@ -55,6 +59,15 @@ def test_normalize_ollama_url():
     assert _normalize_ollama_url("  ") == "http://localhost:11434/v1"
 
 
+def test_normalize_lm_studio_url():
+    assert _normalize_lm_studio_url(None) == "http://localhost:1234/v1"
+    assert (
+        _normalize_lm_studio_url("http://localhost:1234") == "http://localhost:1234/v1"
+    )
+    assert _normalize_lm_studio_url("http://h:1/v1/") == "http://h:1/v1"
+    assert _normalize_lm_studio_url("  ") == "http://localhost:1234/v1"
+
+
 def test_build_ollama_client_uses_base_url(monkeypatch):
     captured: dict = {}
 
@@ -69,6 +82,22 @@ def test_build_ollama_client_uses_base_url(monkeypatch):
     client._ensure_client()  # type: ignore[attr-defined]
     assert captured["base_url"] == "http://box:11434/v1"
     assert captured["api_key"] == "ollama"  # placeholder, Ollama ignores it
+
+
+def test_build_lm_studio_client_uses_base_url(monkeypatch):
+    captured: dict = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", FakeOpenAI)
+    client = build_provider_client(
+        "lm_studio", {"base_url": "http://box:1234"}, secrets=None
+    )
+    client._ensure_client()  # type: ignore[attr-defined]
+    assert captured["base_url"] == "http://box:1234/v1"
+    assert captured["api_key"] == "lm-studio"
 
 
 # -- router routing -------------------------------------------------------------
@@ -151,6 +180,13 @@ def test_router_capabilities_prefix_aware():
 # -- capabilities ---------------------------------------------------------------
 def test_capabilities_ollama():
     caps = capabilities_for("ollama:qwen2.5-coder")
+    assert caps.tools is True
+    assert caps.parallel_tool_calls is False
+    assert caps.vision is False
+
+
+def test_capabilities_lm_studio():
+    caps = capabilities_for("lm_studio:llama-3.2-3b")
     assert caps.tools is True
     assert caps.parallel_tool_calls is False
     assert caps.vision is False

--- a/tests/test_provider_verify.py
+++ b/tests/test_provider_verify.py
@@ -90,6 +90,14 @@ def test_verify_ollama_uses_v1_models_no_key(monkeypatch):
     assert "headers" not in cap  # keyless
 
 
+def test_verify_lm_studio_uses_v1_models_no_key(monkeypatch):
+    cap: dict = {}
+    _patch_get(monkeypatch, status=200, capture=cap)
+    verify_provider_key("lm_studio", base_url="http://localhost:1234")
+    assert cap["url"] == "http://localhost:1234/v1/models"
+    assert "headers" not in cap  # keyless
+
+
 def test_verify_network_error_is_clean(monkeypatch):
     _patch_get(monkeypatch, raise_exc=ConnectionError("boom"))
     res = verify_provider_key("openai", api_key="sk-x")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1050,3 +1050,11 @@ def test_set_provider_persists_extra_fields(tmp_path):
     manager.set_provider("ollama", {"base_url": ""})
     providers = {p["name"]: p for p in manager.get_providers()}
     assert "base_url" not in providers["ollama"]["values"]
+
+    assert manager.set_provider("lm_studio", {"base_url": "http://127.0.0.1:8888"})["ok"]
+    providers = {p["name"]: p for p in manager.get_providers()}
+    assert providers["lm_studio"]["values"]["base_url"] == "http://127.0.0.1:8888"
+
+    manager.set_provider("lm_studio", {"base_url": ""})
+    providers = {p["name"]: p for p in manager.get_providers()}
+    assert "base_url" not in providers["lm_studio"]["values"]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -174,3 +174,19 @@ def test_ollama_models_gated_on_liveness(tmp_path, monkeypatch):
 
     monkeypatch.setattr(SessionManager, "_ollama_alive", lambda self: True)
     assert "ollama:llama3.3" in manager.get_settings()["models"]
+
+
+def test_lm_studio_models_gated_on_liveness(tmp_path, monkeypatch):
+    """`lm_studio:*` entries show only while LM Studio's local server answers."""
+    from coworker.server.manager import SessionManager
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    manager = SessionManager(data_dir=tmp_path / "data")
+    manager.add_model("lm_studio:llama-3.2-3b")
+
+    monkeypatch.setattr(SessionManager, "_lm_studio_alive", lambda self: False)
+    assert "lm_studio:llama-3.2-3b" not in manager.get_settings()["models"]
+
+    monkeypatch.setattr(SessionManager, "_lm_studio_alive", lambda self: True)
+    assert "lm_studio:llama-3.2-3b" in manager.get_settings()["models"]


### PR DESCRIPTION
Fixes #122

## Summary

Adds LM Studio as a first-class keyless local model provider, following the same pattern as Ollama.

- Register `lm_studio` in the provider registry with default endpoint `http://localhost:1234/v1`
- Wrap `OpenAIProvider` with placeholder key `lm-studio` and configurable `base_url`
- Keyless verification via `GET /v1/models` (no auth header)
- Live model discovery and liveness gating for `lm_studio:*` entries in the model picker
- Conservative capability defaults for local models (same as Ollama)
- Provider-specific Settings help text and gallery ordering

LM Studio models are not added to `matrix.py` — users load arbitrary GGUF models locally. Models can be discovered after Detect (when the local server is running) or added manually via the existing "Add another model…" field.

## Test plan
- [x] `pytest tests/test_provider_router.py tests/test_provider_verify.py tests/test_settings.py tests/test_server.py`
- [x] Start LM Studio, load a model, enable local server
- [x] Settings → LM Studio → Detect → card shows "✓ Running"
- [x] Configure Models → suggested loaded models appear → tick one → use in composer as `lm_studio:<model>`
- [x] Send a chat message and confirm completion works