### PR TITLE
Enable Tauri CSP and isolate HTML artifact iframes

### DIFF
--- a/surfaces/gui/src-tauri/tauri.conf.json
+++ b/surfaces/gui/src-tauri/tauri.conf.json
@@ -13,7 +13,30 @@
     "withGlobalTauri": true,
     "windows": [],
     "security": {
-      "csp": null
+      "csp": {
+        "default-src": "'self'",
+        "script-src": "'self'",
+        "style-src": "'self' 'unsafe-inline'",
+        "img-src": "'self' data: blob:",
+        "font-src": "'self' data:",
+        "connect-src": "'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:*",
+        "worker-src": "'self' blob:",
+        "object-src": "'none'",
+        "base-uri": "'self'",
+        "form-action": "'self'"
+      },
+      "devCsp": {
+        "default-src": "'self'",
+        "script-src": "'self' 'unsafe-eval'",
+        "style-src": "'self' 'unsafe-inline'",
+        "img-src": "'self' data: blob:",
+        "font-src": "'self' data:",
+        "connect-src": "'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:* http://localhost:1420 ws://localhost:1420 http://127.0.0.1:1420 ws://127.0.0.1:1420",
+        "worker-src": "'self' blob:",
+        "object-src": "'none'",
+        "base-uri": "'self'",
+        "form-action": "'self'"
+      }
     }
   },
   "bundle": {

--- a/surfaces/gui/src/components/RightRail.tsx
+++ b/surfaces/gui/src/components/RightRail.tsx
@@ -363,11 +363,16 @@ function ArtifactViewer({
         ) : content.error ? (
           <div className="rail-error">{content.error}</div>
         ) : content.kind === "html" ? (
+          // Scripts may run for interactive previews, but NOT with same-origin —
+          // that pairing lets agent HTML reach `window.parent.__COWORKER_API_TOKEN__`
+          // and drive the local sidecar. Unique opaque origin keeps the preview useful
+          // while blocking the XSS → tools path (#99).
           <iframe
             key={`${artifact.path}-${reloadKey}`}
-            sandbox="allow-scripts allow-same-origin"
+            sandbox="allow-scripts"
             className="artifact-frame"
             srcDoc={content.content || ""}
+            data-testid="artifact-html-frame"
           />
         ) : content.kind === "markdown" ? (
           <div className="artifact-md">

--- a/tests/test_tauri_csp.py
+++ b/tests/test_tauri_csp.py
@@ -1,0 +1,85 @@
+"""Contract tests for the Tauri webview Content Security Policy (#99).
+
+CI does not boot a Tauri webview, so these hermetic assertions pin the policy that
+ships in tauri.conf.json — and the artifact-iframe sandbox that actually closes
+the XSS → local-API path the issue describes. A missing directive or a regression
+to `csp: null` / `allow-same-origin` fails here.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TAURI_CONF = ROOT / "surfaces" / "gui" / "src-tauri" / "tauri.conf.json"
+RIGHT_RAIL = ROOT / "surfaces" / "gui" / "src" / "components" / "RightRail.tsx"
+
+
+def _security() -> dict:
+    cfg = json.loads(TAURI_CONF.read_text())
+    return cfg["app"]["security"]
+
+
+def test_production_csp_is_enabled_and_covers_the_sidecar():
+    sec = _security()
+    csp = sec.get("csp")
+    assert csp is not None and isinstance(csp, dict), "production CSP must not be null"
+
+    # Tauri IPC + the dynamically-chosen sidecar port (127.0.0.1:0 → free_port()).
+    connect = csp["connect-src"]
+    for required in ("ipc:", "http://ipc.localhost", "http://127.0.0.1:*", "ws://127.0.0.1:*"):
+        assert required in connect, f"connect-src missing {required!r}: {connect}"
+
+    # No remote connect/script: CSP's real win is blocking XSS from talking to the internet
+    # or loading remote script. The updater is a native Rust plugin — not webview connect-src.
+    assert "https://" not in connect
+    assert "unsafe-eval" not in csp.get("script-src", "")
+
+    # React inline styles + pdfjs worker + attachment data:/blob: URLs.
+    assert "unsafe-inline" in csp["style-src"]
+    assert "blob:" in csp["worker-src"]
+    assert "data:" in csp["img-src"] and "blob:" in csp["img-src"]
+    assert csp["object-src"] == "'none'"
+
+
+def test_dev_csp_is_set_and_allows_vite_hmr():
+    # Without a separate devCsp, Tauri injects the prod CSP into `tauri dev` too —
+    # and Vite HMR on localhost:1420 would be blocked.
+    sec = _security()
+    dev = sec.get("devCsp")
+    assert dev is not None and isinstance(dev, dict)
+
+    connect = dev["connect-src"]
+    for required in (
+        "ipc:",
+        "http://127.0.0.1:*",
+        "ws://127.0.0.1:*",
+        "http://localhost:1420",
+        "ws://localhost:1420",
+    ):
+        assert required in connect, f"devCsp connect-src missing {required!r}: {connect}"
+    # HMR / Fast Refresh commonly needs eval in dev; prod must stay clean (pinned above).
+    assert "unsafe-eval" in dev["script-src"]
+
+
+def test_html_artifact_iframe_is_not_same_origin():
+    """Parent CSP does not contain a srcDoc iframe. allow-same-origin + allow-scripts
+    together let agent HTML reach window.parent.__COWORKER_API_TOKEN__. Scripts-only
+    keeps interactive previews while giving the frame a unique opaque origin.
+    """
+    src = RIGHT_RAIL.read_text()
+    # The HTML artifact preview is the only iframe that feeds agent-authored markup
+    # through srcDoc — pin its sandbox specifically.
+    match = re.search(
+        r"<iframe\b[^>]*?\bsandbox=\"([^\"]+)\"[^>]*?\bsrcDoc=\{content\.content",
+        src,
+        re.DOTALL,
+    )
+    assert match, "RightRail HTML artifact iframe (sandbox + srcDoc) not found"
+    tokens = match.group(1).split()
+    assert "allow-scripts" in tokens
+    assert "allow-same-origin" not in tokens, (
+        "allow-same-origin on a scriptable artifact iframe re-opens the XSS → API path"
+    )


### PR DESCRIPTION
## Summary

Fixes #99.

The desktop shell has shipped with `app.security.csp: null` since the initial import. Any XSS
in the webview could load remote script or open arbitrary connections. The HTML artifact
preview made the practical exploit path worse: it used

```html
sandbox="allow-scripts allow-same-origin"
```

so agent-authored markup in a `srcDoc` iframe could reach `window.parent.__COWORKER_API_TOKEN__`
and drive the local sidecar. Parent CSP alone cannot contain a `srcDoc` iframe — that sandbox
is the real XSS → tools fix.

## What changed

**Production CSP** (object form in `tauri.conf.json`), shaped for this codebase:

| Directive | Why |
|---|---|
| `connect-src` … `ipc:` `http://ipc.localhost` | Tauri 2 IPC / `withGlobalTauri` |
| `http://127.0.0.1:*` `ws://127.0.0.1:*` | Sidecar port is `free_port()` → `127.0.0.1:0` at launch; a fixed port cannot work |
| `style-src 'self' 'unsafe-inline'` | Widespread React `style={{…}}` |
| `worker-src 'self' blob:` | pdfjs worker via `?url` |
| `img-src … data: blob:` | Attachment / artifact data URLs |
| **no** `unsafe-eval`, **no** remote `https:` in `connect-src` | Prod stays tight; the updater is a native Rust plugin, not webview `connect-src` |

**`devCsp`** (mandatory): without it, Tauri injects the prod CSP into `tauri dev` too, and Vite
HMR on `localhost:1420` dies. Dev allows `'unsafe-eval'` and the Vite HMR hosts; production does
not.

**Artifact iframe:** drop `allow-same-origin`. Scripts may still run for interactive previews;
the frame gets a unique opaque origin, so it cannot read the parent token / SPA.

Honest scope note: a per-launch API token already gates the sidecar (`#28` / `#40` lineage). CSP
is defense-in-depth — especially against *remote* connect/script. `127.0.0.1:*` still allows a
compromised page to talk to *any* loopback port; pinning one port would require dropping
`free_port()`, which is out of scope here.

## Test plan

Hermetic contract tests (CI does **not** boot a Tauri webview):

```
$ pytest tests/test_tauri_csp.py -q
3 passed
```

They pin:

- production `csp` is non-null and contains IPC + `127.0.0.1:*` WS/HTTP wildcards
- no `unsafe-eval` / no remote `https:` in prod `connect-src`
- `devCsp` is set and allows Vite HMR on `:1420`
- the HTML artifact iframe keeps `allow-scripts` and does **not** set `allow-same-origin`

```
$ npx tsc --noEmit   # exit 0
```

**Manual smoke** (please, before merge — CI will not catch webview CSP breakage):

1. `cd surfaces/gui && npm run tauri dev`
2. Boot → health → one WS turn → Settings
3. Open an HTML artifact preview, a PDF, and an image attachment
4. Confirm update check still works (native plugin; not webview `connect-src`)

No new dependencies. Complementary to #170 (SSRF) and #92 (CORS) — those don't touch
`tauri.conf` security CSP.
