### PR TITLE
docs: fix stale platform/ paths left over from monorepo extraction

### DIFF
--- a/coworker/connectors/adapters.py
+++ b/coworker/connectors/adapters.py
@@ -194,7 +194,7 @@ class SlackAdapter(BasePlatformAdapter):
         # Base-URL override so tests (and the FakeSlack harness) can redirect every Web API
         # call — auth.test/users.info/conversations.info/chat.update AND Socket Mode's
         # apps.connections.open, which the handler issues on this same client. Default is the
-        # real Slack API. See platform/docs/FAKE-SLACK-SPEC.md.
+        # real Slack API. See docs/FAKE-SLACK-SPEC.md.
         base_url = os.environ.get("SLACK_API_URL", "https://slack.com/api/")
         client = AsyncWebClient(token=self.bot_token, base_url=base_url)
         self._app = AsyncApp(client=client)

--- a/coworker/connectors/senders.py
+++ b/coworker/connectors/senders.py
@@ -23,7 +23,7 @@ _TIMEOUT = 30.0
 
 def _slack_api_base() -> str:
     """Web API base URL. `SLACK_API_URL` (trailing slash) lets tests / the FakeSlack harness
-    redirect outbound sends to a local fake. See platform/docs/FAKE-SLACK-SPEC.md."""
+    redirect outbound sends to a local fake. See docs/FAKE-SLACK-SPEC.md."""
     return os.environ.get("SLACK_API_URL", "https://slack.com/api/")
 
 

--- a/coworker/personas/__init__.py
+++ b/coworker/personas/__init__.py
@@ -3,7 +3,7 @@
 A persona is a manifest (YAML frontmatter + a markdown body that is the system prompt) that
 composes vetted catalog capabilities, a family/workspace shape, and lifecycle metadata. The
 built-in surfaces (Code, Cowork, Chat, Ops) are themselves manifests — the same format third
-parties use. See `platform/docs/PERSONAS.md`.
+parties use. See `docs/PERSONAS.md`.
 """
 
 from __future__ import annotations

--- a/coworker/testing/fake_slack/__init__.py
+++ b/coworker/testing/fake_slack/__init__.py
@@ -1,6 +1,6 @@
 """FakeSlack — a local, controllable Slack test double (Web API + Socket Mode).
 
-See :mod:`coworker.testing.fake_slack.server` and ``platform/docs/FAKE-SLACK-SPEC.md``.
+See :mod:`coworker.testing.fake_slack.server` and ``docs/FAKE-SLACK-SPEC.md``.
 """
 
 from __future__ import annotations

--- a/coworker/testing/fake_slack/server.py
+++ b/coworker/testing/fake_slack/server.py
@@ -5,7 +5,7 @@ Implements just enough of the Web API + Socket Mode envelope protocol for the re
 Slack app console**. Built on Starlette + uvicorn (both already core deps) and served on an
 ephemeral port via an in-process ``uvicorn.Server`` background task.
 
-See ``platform/docs/FAKE-SLACK-SPEC.md``. The adapter is pointed at the fake via the
+See ``docs/FAKE-SLACK-SPEC.md``. The adapter is pointed at the fake via the
 ``SLACK_API_URL`` base-URL override (env), which redirects every Web API call — including
 Socket Mode's ``apps.connections.open``, so the fake decides the WebSocket URL.
 

--- a/surfaces/gui/README.md
+++ b/surfaces/gui/README.md
@@ -5,23 +5,23 @@ Same codebase runs in a browser (dev) and as the OpenWorker desktop app.
 
 ## First time: bootstrap the Python backend
 
-A fresh checkout has no server to run — create the venv both flows below expect:
+A fresh checkout has no server to run — create the venv both flows below expect
+(run from the repo root):
 
 ```bash
-bash platform/packaging/setup_dev_env.sh   # → platform/.venv (server + this repo's aisuite)
+bash packaging/setup_dev_env.sh   # → .venv (server + this repo's aisuite)
 ```
 
 ## Run it (browser, two terminals)
 
 1. **Start the server** (needs a model key, e.g. `OPENAI_API_KEY`, in the environment —
-   or add one later in the app's Settings):
+   or add one later in the app's Settings). From the repo root:
    ```bash
-   cd platform
    ./.venv/bin/openworker-server --cwd /path/to/your/project --port 8765
    ```
 2. **Start the UI:**
    ```bash
-   cd platform/surfaces/gui
+   cd surfaces/gui
    npm install      # first time
    npm run dev      # → http://localhost:5173
    ```
@@ -35,11 +35,11 @@ Vite if the server is restarted.
 
 The Tauri shell wraps the same UI and supervises the Python server itself — no separate
 terminal. It needs the Rust toolchain (`rustup`) plus the venv from the bootstrap step;
-in dev it finds the server at `platform/.venv/bin/openworker-server` automatically (a
-packaged sidecar binary is only produced by the release scripts in `platform/packaging/`).
+in dev it finds the server at `.venv/bin/openworker-server` automatically (a
+packaged sidecar binary is only produced by the release scripts in `packaging/`).
 
 ```bash
-cd platform/surfaces/gui
+cd surfaces/gui
 npm install        # first time
 npm run tauri dev  # builds the shell, launches the window, starts the server
 ```

--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -54,7 +54,7 @@ fn launch_token() -> String {
 ///      (next to the app exe) on Windows.
 ///   3. Legacy onefile slot: `openworker-server[.exe]` next to the app binary (pre-onedir
 ///      builds used Tauri externalBin).
-///   4. Dev fallback: the repo venv, relative to this crate (`src-tauri` → `platform/.venv`;
+///   4. Dev fallback: the repo venv, relative to this crate (`src-tauri` → `.venv`;
 ///      `bin/` on POSIX, `Scripts\` on Windows).
 fn server_bin() -> PathBuf {
     if let Ok(p) = std::env::var("COWORKER_SERVER_BIN") {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 `fake_slack` boots the in-process FakeSlack harness on an ephemeral port and points the Slack
 adapter at it via `SLACK_API_URL`, so the real `SlackAdapter` / `slack_bolt` stack runs
 end-to-end with no network, tokens, or the Slack app console. See
-`coworker.testing.fake_slack` and `platform/docs/FAKE-SLACK-SPEC.md`.
+`coworker.testing.fake_slack` and `docs/FAKE-SLACK-SPEC.md`.
 """
 
 from __future__ import annotations

--- a/tests/test_fake_slack.py
+++ b/tests/test_fake_slack.py
@@ -1,5 +1,5 @@
 """FakeSlack acceptance tests — the real SlackAdapter / slack_bolt stack driven against the
-in-process fake (no network). Mirrors the acceptance list in `platform/docs/FAKE-SLACK-SPEC.md`.
+in-process fake (no network). Mirrors the acceptance list in `docs/FAKE-SLACK-SPEC.md`.
 
 These are hermetic (no real Slack) and run in CI — not marked `integration`. The `fake_slack`
 fixture (see conftest.py) starts the server and sets `SLACK_API_URL`.


### PR DESCRIPTION
## What

Fixes stale `platform/` path references left over from the monorepo extraction, across 9 files. Comment/doc changes only — no behavior change.

1. **`surfaces/gui/README.md`** — every command referenced a `platform/` directory that doesn't exist in this repo, so a fresh checkout could not follow the GUI README at all.
2. **7 Python files** — docstring/comment citations of `platform/docs/FAKE-SLACK-SPEC.md` and `platform/docs/PERSONAS.md` normalized to `docs/...` (`tests/conftest.py`, `tests/test_fake_slack.py`, `coworker/connectors/adapters.py`, `coworker/connectors/senders.py`, `coworker/personas/__init__.py`, `coworker/testing/fake_slack/server.py`, `coworker/testing/fake_slack/__init__.py`).
3. **`surfaces/gui/src-tauri/src/lib.rs:57`** — the doc comment on `server_bin()` said the dev fallback is `platform/.venv`, but the code below resolves `../../../.venv` from `src-tauri`, i.e. the repo-root `.venv`. Comment now matches the code.

## Before / after

Before (`surfaces/gui/README.md`) — none of these paths exist:

```bash
bash platform/packaging/setup_dev_env.sh   # → platform/.venv (...)
cd platform
./.venv/bin/openworker-server --cwd /path/to/your/project --port 8765
cd platform/surfaces/gui
```

After — matches the top-level README and the actual repo layout (verified: `packaging/setup_dev_env.sh:11` creates the venv at repo-root `.venv`):

```bash
bash packaging/setup_dev_env.sh   # → .venv (...)
./.venv/bin/openworker-server --cwd /path/to/your/project --port 8765   # from repo root
cd surfaces/gui
```

## Verification

- All edited Python files pass `python -m py_compile`.
- `grep -rn "platform/"` over `*.py`/`*.md` now returns zero stale path references.
- No UI or runtime code touched, so no screenshots — the before/after above is the user-visible change.

Note: `docs/FAKE-SLACK-SPEC.md` and `docs/PERSONAS.md` still don't exist in this repo even at the corrected path — the citations now at least point at the right location; restoring those docs seems worth its own issue/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
