### PR TITLE
Add read-only git_blame and git_show tools

### DIFF
--- a/coworker/catalog.py
+++ b/coworker/catalog.py
@@ -83,7 +83,8 @@ def _files(context: AgentContext) -> list:
 
 def _git(context: AgentContext) -> list:
     ws = str(context.workspace)
-    return [*ai.toolkits.git(root=ws), *git_tools(ws)]  # git_status, git_diff, git_log
+    # git_status, git_diff + git_log/git_blame/git_show
+    return [*ai.toolkits.git(root=ws), *git_tools(ws)]
 
 
 def _search(context: AgentContext) -> list:
@@ -118,7 +119,7 @@ _CAPS: list[Capability] = [
     Capability(
         id="git",
         name="Git",
-        description="Inspect git state and history (status, diff, log).",
+        description="Inspect git state and history (status, diff, log, blame, show).",
         build=_git,
         requires=("workspace",),
         risk=(RiskClass.READ,),

--- a/coworker/tools/git.py
+++ b/coworker/tools/git.py
@@ -1,13 +1,16 @@
-"""`git_log` — recent commit history for context (read-only).
+"""Read-only git context tools: `git_log`, `git_blame`, `git_show`.
 
-aisuite's git toolkit gives `git_status`/`git_diff`; this adds history so the agent can see how
-a file came to be the way it is before changing it. Read-only; no commit/push here (the prompt
-forbids those without explicit ask, and they'd go through run_shell anyway).
+aisuite's git toolkit gives `git_status`/`git_diff`; these add history — log (how a file
+came to be), blame (who last touched each line), show (what a commit changed) — so the
+agent can understand how code evolved before changing it. Read-only; no commit/push here
+(the prompt forbids those without explicit ask, and they'd go through run_shell anyway).
 """
 
 from __future__ import annotations
 
+import re
 import subprocess
+from datetime import date
 from pathlib import Path
 from typing import Any, Optional
 
@@ -15,7 +18,21 @@ import aisuite as ai
 
 _SEP = "\x1f"
 
-_SCHEMA = {
+# Blame/show output is bounded so a huge file or mega-commit can't flood the context.
+_BLAME_MAX_LINES = 300
+_SHOW_MAX_CHARS = 8000
+
+# Refs are user/model input on a subprocess argv: a leading "-" would be parsed as an
+# option (`git show --output=…` writes files), so refs must look like refs. Paths are
+# always passed after `--` and need no such guard.
+_REF_RE = re.compile(r"^[\w.@{}^~/-]+$")
+
+
+def _bad_ref(ref: str) -> bool:
+    return not ref or ref.startswith("-") or not _REF_RE.match(ref)
+
+
+_LOG_SCHEMA = {
     "type": "function",
     "function": {
         "name": "git_log",
@@ -39,6 +56,74 @@ _SCHEMA = {
     },
 }
 
+_BLAME_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "git_blame",
+        "description": (
+            "Who last touched each line of a file (hash, author, date, content per line). "
+            "Optionally scope to a line range. Use it to find the commit and author behind "
+            "a specific line before changing it. Read-only."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "File to blame (required).",
+                },
+                "start_line": {
+                    "type": "integer",
+                    "description": "First line of the range (1-based).",
+                },
+                "end_line": {
+                    "type": "integer",
+                    "description": "Last line of the range (inclusive).",
+                },
+            },
+            "required": ["path"],
+        },
+    },
+}
+
+_SHOW_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "git_show",
+        "description": (
+            "A commit's message, diffstat, and patch (default HEAD). Optionally limit the "
+            "patch to one path. Use it to see exactly what a commit from git_log/git_blame "
+            "changed. Read-only."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "ref": {
+                    "type": "string",
+                    "description": "Commit ref (hash, branch, HEAD~2, …). Default HEAD.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Optional file/dir to limit the patch to.",
+                },
+            },
+        },
+    },
+}
+
+
+def _run_git(root: str, args: list[str]) -> tuple[Optional[str], Optional[str]]:
+    """Run a git subcommand; returns (stdout, None) or (None, error-string)."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", root, *args], capture_output=True, text=True, timeout=15
+        )
+    except Exception as exc:
+        return None, f"git {args[0]} failed: {exc}"
+    if out.returncode != 0:
+        return None, (out.stderr or f"git {args[0]} failed").strip()[:300]
+    return out.stdout, None
+
 
 def git_tools(workspace: str) -> list:
     root = str(Path(workspace).resolve())
@@ -46,25 +131,19 @@ def git_tools(workspace: str) -> list:
     def git_log(path: Optional[str] = None, max_count: int = 20) -> dict[str, Any]:
         n = max_count if isinstance(max_count, int) and max_count > 0 else 20
         n = min(n, 200)
-        cmd = [
-            "git",
-            "-C",
-            root,
+        args = [
             "log",
             f"-n{n}",
             f"--pretty=format:%h{_SEP}%an{_SEP}%ad{_SEP}%s",
             "--date=short",
         ]
         if path:
-            cmd += ["--", path]
-        try:
-            out = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
-        except Exception as exc:
-            return {"error": f"git log failed: {exc}"}
-        if out.returncode != 0:
-            return {"error": (out.stderr or "git log failed").strip()[:300]}
+            args += ["--", path]
+        out, err = _run_git(root, args)
+        if err:
+            return {"error": err}
         commits = []
-        for line in out.stdout.splitlines():
+        for line in out.splitlines():
             parts = line.split(_SEP)
             if len(parts) == 4:
                 commits.append(
@@ -77,14 +156,80 @@ def git_tools(workspace: str) -> list:
                 )
         return {"count": len(commits), "commits": commits}
 
-    git_log.__name__ = "git_log"
-    git_log.__doc__ = _SCHEMA["function"]["description"]
-    git_log.__aisuite_tool_metadata__ = ai.ToolMetadata(
-        name="git_log",
-        category="git",
-        risk_level="low",
-        capabilities=["git"],
-        requires_approval=False,
-    )
-    git_log.__coworker_schema__ = _SCHEMA
-    return [git_log]
+    def git_blame(
+        path: str,
+        start_line: Optional[int] = None,
+        end_line: Optional[int] = None,
+    ) -> dict[str, Any]:
+        if not path or not isinstance(path, str):
+            return {"error": "path is required"}
+        args = ["blame", "--line-porcelain"]
+        if start_line is not None or end_line is not None:
+            s = start_line if isinstance(start_line, int) and start_line > 0 else 1
+            e = end_line if isinstance(end_line, int) and end_line >= s else s
+            args += ["-L", f"{s},{e}"]
+        args += ["--", path]
+        out, err = _run_git(root, args)
+        if err:
+            return {"error": err}
+        lines: list[dict[str, Any]] = []
+        cur: dict[str, Any] = {}
+        for raw in out.splitlines():
+            if raw.startswith("\t"):
+                cur["content"] = raw[1:][:300]
+                lines.append(cur)
+                cur = {}
+            elif "hash" not in cur and re.match(r"^[0-9a-f]{7,40} \d+ \d+", raw):
+                head = raw.split()
+                cur = {"line": int(head[2]), "hash": head[0][:8]}
+            elif raw.startswith("author "):
+                cur["author"] = raw[len("author ") :]
+            elif raw.startswith("author-time "):
+                cur["date"] = date.fromtimestamp(int(raw.split()[1])).isoformat()
+        result: dict[str, Any] = {"path": path, "count": len(lines)}
+        if len(lines) > _BLAME_MAX_LINES:
+            lines = lines[:_BLAME_MAX_LINES]
+            result["note"] = (
+                f"showing first {_BLAME_MAX_LINES} lines; "
+                "pass start_line/end_line to scope the rest"
+            )
+        result["lines"] = lines
+        return result
+
+    def git_show(ref: str = "HEAD", path: Optional[str] = None) -> dict[str, Any]:
+        ref = str(ref or "HEAD").strip()
+        if _bad_ref(ref):
+            return {"error": f"invalid ref: {ref!r}"}
+        args = ["show", ref, "--date=short", "--stat", "--patch"]
+        if path:
+            args += ["--", path]
+        out, err = _run_git(root, args)
+        if err:
+            return {"error": err}
+        result: dict[str, Any] = {"ref": ref}
+        if len(out) > _SHOW_MAX_CHARS:
+            out = out[:_SHOW_MAX_CHARS]
+            result["note"] = (
+                f"output truncated to {_SHOW_MAX_CHARS} chars; "
+                "pass `path` to limit the patch to one file"
+            )
+        result["output"] = out
+        return result
+
+    for fn, schema in (
+        (git_log, _LOG_SCHEMA),
+        (git_blame, _BLAME_SCHEMA),
+        (git_show, _SHOW_SCHEMA),
+    ):
+        name = schema["function"]["name"]
+        fn.__name__ = name
+        fn.__doc__ = schema["function"]["description"]
+        fn.__aisuite_tool_metadata__ = ai.ToolMetadata(
+            name=name,
+            category="git",
+            risk_level="low",
+            capabilities=["git"],
+            requires_approval=False,
+        )
+        fn.__coworker_schema__ = schema
+    return [git_log, git_blame, git_show]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -27,6 +27,8 @@ CODE_TOOLS = {
     "git_status",
     "git_diff",
     "git_log",
+    "git_blame",
+    "git_show",
     "grep",
     "run_shell",
     "shell_task_output",

--- a/tests/test_code_tools.py
+++ b/tests/test_code_tools.py
@@ -102,6 +102,79 @@ def test_git_log_errors_outside_repo(tmp_path):
     assert "error" in git_log()
 
 
+# -- git_blame / git_show --------------------------------------------------------
+def _two_author_repo(tmp_path):
+    """A repo where line 1 was written by T and line 2 rewritten by U."""
+    ws = tmp_path / "repo"
+    ws.mkdir()
+    run = lambda *a: subprocess.run(
+        ["git", "-C", str(ws), *a], capture_output=True, check=True
+    )
+    run("init", "-q")
+    run("config", "user.email", "t@t.io")
+    run("config", "user.name", "T")
+    (ws / "f.txt").write_text("one\ntwo\n", encoding="utf-8")
+    run("add", "-A")
+    run("commit", "-qm", "first")
+    run("config", "user.email", "u@u.io")
+    run("config", "user.name", "U")
+    (ws / "f.txt").write_text("one\nTWO\n", encoding="utf-8")
+    run("add", "-A")
+    run("commit", "-qm", "second")
+    return ws
+
+
+def _by_name(ws):
+    return {t.__name__: t for t in git_tools(str(ws))}
+
+
+def test_git_blame_attributes_lines(tmp_path):
+    ws = _two_author_repo(tmp_path)
+    out = _by_name(ws)["git_blame"](path="f.txt")
+    assert out["count"] == 2
+    assert [ln["line"] for ln in out["lines"]] == [1, 2]
+    assert out["lines"][0]["author"] == "T" and out["lines"][0]["content"] == "one"
+    assert out["lines"][1]["author"] == "U" and out["lines"][1]["content"] == "TWO"
+    assert set(out["lines"][0]) == {"line", "hash", "author", "date", "content"}
+
+
+def test_git_blame_scopes_to_range(tmp_path):
+    ws = _two_author_repo(tmp_path)
+    out = _by_name(ws)["git_blame"](path="f.txt", start_line=2, end_line=2)
+    assert out["count"] == 1 and out["lines"][0]["line"] == 2
+
+
+def test_git_blame_errors(tmp_path):
+    assert "error" in _by_name(tmp_path)["git_blame"](path="f.txt")  # not a repo
+    ws = _two_author_repo(tmp_path)
+    assert "error" in _by_name(ws)["git_blame"](path="missing.txt")
+    assert "error" in _by_name(ws)["git_blame"](path="")
+
+
+def test_git_show_head_has_message_and_patch(tmp_path):
+    ws = _two_author_repo(tmp_path)
+    out = _by_name(ws)["git_show"]()
+    assert out["ref"] == "HEAD"
+    assert "second" in out["output"]  # commit subject
+    assert "+TWO" in out["output"]  # the patch itself
+    assert "f.txt" in out["output"]  # the diffstat
+
+
+def test_git_show_accepts_relative_refs_and_paths(tmp_path):
+    ws = _two_author_repo(tmp_path)
+    out = _by_name(ws)["git_show"](ref="HEAD~1", path="f.txt")
+    assert "first" in out["output"] and "+two" in out["output"]
+
+
+def test_git_show_rejects_option_injection(tmp_path):
+    ws = _two_author_repo(tmp_path)
+    git_show = _by_name(ws)["git_show"]
+    # A leading "-" would be parsed as a git option (e.g. --output writes files).
+    assert "error" in git_show(ref="--output=/tmp/pwn")
+    assert "error" in git_show(ref="HEAD; rm -rf /")  # whitespace/metachars
+    assert "error" in git_show(ref="bogus-ref-does-not-exist")
+
+
 # -- read_file -----------------------------------------------------------------
 def test_read_file_numbers_lines(tmp_path):
     (tmp_path / "a.py").write_text("one\ntwo\nthree\n", encoding="utf-8")


### PR DESCRIPTION
## What

Adds **`git_blame`** and **`git_show`** to the read-only git toolkit in `coworker/tools/git.py`, whose module docstring already frames the purpose ("see how a file came to be the way it is before changing it") — blame and show complete the natural loop: `git_log` (which commits) → `git_blame` (who last touched this line, in which commit) → `git_show` (what that commit actually changed).

- **`git_blame(path, start_line?, end_line?)`** → per-line `{line, hash, author, date, content}`, parsed from `--line-porcelain`. Whole-file blame is capped at 300 lines with a note pointing at the range parameters.
- **`git_show(ref=HEAD, path?)`** → the commit's message, diffstat, and patch, capped at 8000 chars with a note pointing at `path` scoping.

Both follow the `git_log` template exactly: schema dict, `ToolMetadata(category="git", risk_level="low", requires_approval=False)`, `__coworker_schema__`. The subprocess runner is factored out and shared; `git_log`'s behavior and error strings are unchanged. Commit/push stay excluded per the module's existing contract — they route through `run_shell` and its approval gate.

**Security note:** a ref is model input landing on a subprocess argv. `git_show` rejects anything that doesn't look like a ref — a leading `-` would be parsed as a git option (`--output` writes arbitrary files), and whitespace/metachars are refused. Paths are always passed after `--`, as `git_log` already does. There's a test asserting the injection refusal.

## Wiring (no new surface)

The `git` capability builder already returns everything from `git_tools()`, so the new tools reach exactly the personas/agents that had git before (Code, and the read-only Explore subagent) — no catalog, persona, or permission changes beyond:
- `tests/test_catalog.py`: the Phase-0 exact-toolset equivalence set extended with the two names.
- The `git` capability description now says "(status, diff, log, blame, show)".

## Tests

Six new tests in `tests/test_code_tools.py` following the existing `git_log` fixtures: two-author repo → blame attributes each line to the right author/commit; range scoping; error paths (no repo, missing file, empty path); show returns subject + patch + diffstat; relative refs (`HEAD~1`) with path scoping; and option-injection refusal.

## Verification

```
$ .venv/bin/python -m pytest tests/test_code_tools.py -q
20 passed

$ .venv/bin/python -m pytest tests -q
895 passed, 1 skipped
```

No UI change (tools surface through the existing tool-approval cards), so no screenshots.
