### PR TITLE
Add CLAUDE.md files for Claude Code guidance and add Groq/OpenRouter …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# OpenWorker Claude Code Guide
+
+## Overview
+
+OpenWorker is a desktop AI assistant application with a Python backend (coworker/) and a React/Tauri frontend (surfaces/). It uses a multi-agent system with persistent memory, tool integrations via MCP, and a skill system for progressive capability disclosure.
+
+## Key Components
+
+### Backend (coworker/)
+- `agent.py`: Main engine assembly
+- `agents/`: Different agent personalities (Code, Chat, Cowork, MyHelper)
+- `connectors/`: 25+ integrations (GitHub, Slack, Jira, Notion, HubSpot, etc.)
+- `engine.py`: Turn engine processing agent interactions
+- `mcp/`: Model Context Protocol client for tool integrations
+- `memory/`: Persistent SQLite-based memory storage
+- `providers/`: LLM providers (OpenAI, Anthropic, Gemini, Ollama, etc.)
+- `server/`: FastAPI server exposing agent functionality
+- `skills/`: Progressive disclosure skill system
+- `tools/`: Agent-available tools (file ops, shell, web search, etc.)
+
+### Frontend (surfaces/gui/)
+- `src/`: React/TypeScript frontend
+  - `App.tsx`: Root application component
+  - `components/`: Reusable UI cards, views, modals
+  - `api.ts`: Backend communication layer
+  - `tauri.ts`: Tauri bridge code
+- `src-tauri/`: Rust-based Tauri shell supervising the frontend
+- `e2e/`: Playwright end-to-end tests
+- `e2e-live/`: Live tests requiring actual services
+
+### Other Components
+- `stt/`: Rust-based speech-to-text engine
+- `packaging/`: Installer scripts and dev environment bootstrap
+- `docs/`: Design specs and decision logs
+- `ui-mocks/`: UI mockups/design assets
+- `tests/`: Backend test suite
+
+## Development Guidelines
+
+### Code Style
+- Follow existing code patterns in the codebase
+- Use type annotations in Python (PEP 484) and TypeScript
+- Keep functions focused and single-responsibility
+- Write descriptive variable and function names
+- Add comments for complex logic
+
+### Python Backend
+- Use type hints consistently
+- Follow existing error handling patterns
+- Use the agent system patterns in `coworker/agents/`
+- Follow MCP patterns in `coworker/mcp/` for tool integrations
+- Write unit tests in the `tests/` directory
+
+### Frontend (React/Tauri)
+- Follow existing React component patterns
+- Use TypeScript strictly
+- Follow existing state management patterns
+- Keep components small and reusable
+- Follow existing styling patterns in components
+
+### Making Changes
+1. Create a branch for your changes
+2. Make your changes following the existing patterns
+3. Ensure tests pass (both backend and frontend)
+4. Update documentation if needed
+5. Submit a pull request with clear description
+6. Include screenshots for UI changes
+7. Reference any related issues
+
+### Running the Application
+See `packaging/setup_dev_env.sh` for development environment setup.
+The application uses a client-server architecture where the React/Tauri frontend communicates with the Python backend via WebSocket.
+
+## Issue Reporting
+When reporting issues:
+1. Check if similar issues already exist
+2. Include steps to reproduce
+3. Include screenshots if applicable
+4. Include relevant logs from both frontend and backend
+5. Specify OS and version information
+6. Specify which agent/system is involved
+
+## Pull Request Process
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Ensure all tests pass
+5. Update documentation as needed
+6. Submit pull request with clear description
+7. Reference any related issues
+8. Await review from maintainers
+
+## License
+MIT - see LICENSE file.

--- a/coworker/CLAUDE.md
+++ b/coworker/CLAUDE.md
@@ -1,0 +1,203 @@
+# coworker/ Claude Code Guide
+
+## Overview
+This directory contains the Python backend for OpenWorker - the core agent engine that handles:
+- Agent reasoning and decision making
+- Tool execution and permission checking
+- Memory and conversation storage
+- Integration with external services via connectors
+- Model provider management and routing
+- Skill system and automation framework
+- WebSocket server for GUI communication
+
+## Key Subsystems
+
+### Agent System (`agents/`)
+- `base.py`: Base agent class defining the interface
+- `chat.py`: Conversational agent for general assistance
+- `code.py`: Coding assistant with development tool expertise
+- `cowork.py`: General-purpose coworker agent
+- `myhelper.py`: Personal assistant for individual tasks
+- `registry.py`: Agent discovery and instantiation
+
+### Core Engine (`engine.py`)
+- Main turn processing loop
+- Agent interaction and tool execution coordination
+- Permission checking and user approval workflows
+- Action planning and execution tracking
+
+### Memory System (`memory/`)
+- `sqlite_store.py`: Persistent conversation and context storage
+- `base.py`: Memory interface definition
+- `tools.py`: Memory-related agent tools
+
+### Connectors System (`connectors/`)
+- **Adapters**: Real-time messaging platforms (Slack, Telegram)
+- **Senders**: Stateless message sending to various services
+- **Gateway**: Inbound webhook handling and routing
+- **Relay Clients**: Cloud relay connections for managed services
+- **Tool Definitions**: MCP-compatible tool specifications
+- **Adapters**: Third-party service integrations (GitHub, Jira, etc.)
+
+### Model Providers (`providers/`)
+- **Base Interface**: Standardized provider contract
+- **Specific Providers**: OpenAI, Anthropic, Google Gemini, Ollama, etc.
+- **Router**: Model routing, caching, and capabilities detection
+- **Registry**: Provider discovery and configuration
+- **Matrix**: Curated model recommendations and labels
+
+### Tools System (`tools/`)
+- Individual tool implementations (file operations, web search, etc.)
+- Tool permissions and risk assessment
+- Tool composition and chaining capabilities
+- Custom tool development framework
+
+### Skills System (`skills/`)
+- Progressive capability disclosure mechanism
+- Skill categorization and dependency tracking
+- Skill activation and deactivation workflows
+- Built-in skills for common agent capabilities
+
+### Automation System (`automation/`)
+- Scheduled task management (`scheduler.py`)
+- Persistent storage for automation rules (`store.py`)
+- Automation-specific tools (`tools.py`)
+- Data models for scheduled work (`models.py`)
+
+### Security and Permissions
+- `permissions.py`: Main permission evaluation engine
+- `risk.py`: Risk classification system for tools
+- `secrets.py`: Secure credential storage and management
+- `config.py`: Allowed command lists and security policies
+
+## Development Guidelines
+
+### Adding New Agents
+1. Inherit from `agents.base.BaseAgent`
+2. Implement required methods: `initialize()`, `step()`, `shutdown()`
+3. Register in `agents.registry.AGENT_REGISTRY`
+4. Follow existing patterns for prompt construction and tool usage
+5. Add unit tests in `tests/test_*agent*.py`
+
+### Adding New Connectors
+1. Choose the appropriate integration pattern:
+   - Real-time: Implement `BasePlatformAdapter` (like Slack/Telegram)
+   - Stateless: Extend `connectors.senders` 
+   - Polling: Implement periodic checkers in `connectors.integration_tools`
+2. Follow security patterns for credential handling
+3. Add to `connectors.make_adapter()` factory function
+4. Create corresponding tests in `tests/test_*connectors*.py`
+
+### Adding New Model Providers
+1. Implement `ProviderClient` interface from `providers.base`
+2. Add descriptor to `providers.registry.DESCRIPTORS`
+3. Handle API key resolution following existing patterns
+4. Implement both `complete()` and `stream()` methods
+5. Add model capability detection via `providers.capabilities`
+6. Add to `providers.matrix.MATRIX` if it meets curated criteria
+7. Add comprehensive tests in `tests/test_*provider*.py`
+
+### Adding New Tools
+1. Implement function following tool signature conventions
+2. Add appropriate risk classification in `risk.py`
+3. Register in the appropriate tool category
+4. Add schema documentation for agent consumption
+5. Write tests in `tests/test_tools_*.py`
+6. Consider permission implications and test accordingly
+
+### Modifying Permissions System
+1. Understand the `RiskClass` system in `risk.py`
+2. Follow the principle of least privilege
+3. Test both allowed and denied scenarios
+4. Consider impact on different modes (PLAN, INTERACTIVE, AUTO)
+5. Update corresponding tests in `tests/test_permissions_*.py`
+
+### Working with the Agent Loop
+1. Understand the flow in `engine.py`: perceive → think → act → learn
+2. Respect the permission system - never bypass user approval for consequential actions
+3. Handle `needs_user` decisions properly by pausing for input
+4. Manage state properly across turns using the memory system
+5. Follow the tool result format for consistent agent consumption
+
+## Code Quality Standards
+
+### Type Hints
+- Use Python 3.8+ type hints consistently
+- Import typing constructs only when needed
+- Use `from __future__ import annotations` for forward references
+- Be explicit about Optional types and default values
+
+### Error Handling
+- Catch specific exceptions rather than bare `except:`
+- Provide meaningful error messages to users
+- Log unexpected errors for debugging
+- Fail gracefully and maintain system stability
+- Use custom exception types when appropriate
+
+### Logging
+- Use the standard `logging` module
+- Follow existing logger naming conventions (`logging.getLogger("coworker.subsystem")`)
+- Log at appropriate levels (DEBUG, INFO, WARNING, ERROR)
+- Avoid logging sensitive information (tokens, passwords, etc.)
+
+### Performance Considerations
+- Avoid blocking operations in async contexts
+- Use efficient data structures and algorithms
+- Consider caching for expensive operations
+- Profile before optimizing - measure first
+- Be mindful of memory usage in long-running processes
+
+### Testing Practices
+- Write tests before implementing new features (TDD when possible)
+- Achieve meaningful test coverage (>80% for new code)
+- Test both happy paths and error conditions
+- Use fixtures to reduce test setup duplication
+- Mock external dependencies appropriately
+- Test edge cases and boundary conditions
+
+## Common Patterns to Follow
+
+### Dependency Injection
+- Prefer constructor injection over global state
+- Make dependencies explicit in function signatures
+- Use interfaces/abstract classes for pluggable components
+- Keep classes focused and loosely coupled
+
+### Configuration Handling
+- Use dataclasses for configuration objects
+- Provide sensible defaults
+- Validate configuration at startup
+- Allow override via environment variables or user settings
+
+### Resource Management
+- Properly initialize and clean up resources
+- Use context managers (`with` statements) when applicable
+- Handle async resource cleanup in `__aexit__` or similar
+- Prevent resource leaks in long-running processes
+
+### Event Handling
+- Follow observer/pub-sub patterns for loose coupling
+- Use asyncio primitives for event coordination
+- Handle event ordering and race conditions appropriately
+- Provide clear unsubscription/disposal mechanisms
+
+## Debugging and Troubleshooting
+
+### Logging Strategies
+- Enable debug logging for specific subsystems when needed
+- Trace request/response flows through the system
+- Monitor performance metrics and resource usage
+- Correlate logs across components using request IDs
+
+### Common Issues
+- Circular imports: Refactor to break dependencies
+- Async/await confusion: Ensure proper coroutine handling
+- Permission denied errors: Review risk classifications and allowlists
+- Model provider failures: Check API keys and network connectivity
+- Memory leaks: Monitor object retention and cleanup
+
+### Diagnostic Tools
+- Use Python's built-in `debugger` or IDE debugging tools
+- Profile performance with `cProfile` or similar
+- Inspect state through available introspection methods
+- Check logs in the application data directory

--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -11,9 +11,8 @@ falls back to the conservative heuristics in ``capabilities.py`` at their own ri
 degraded results. Ids verified against vendor/reseller catalogs on 2026-07-04; refresh the
 reseller rows when catalogs rotate (they rename on every model generation).
 
-Resellers: Together + Fireworks for now. TODO: add Groq and OpenRouter entries here AND their
-descriptors in ``registry.py`` once the current provider surface is tested — deliberately
-deferred to bound how much needs verifying at once.
+Resellers: Together + Fireworks, Groq, and OpenRouter.
+See corresponding entries in ``registry.py`` for providers.
 """
 
 from __future__ import annotations
@@ -111,6 +110,47 @@ MATRIX: dict[str, ModelEntry] = {
     ),
     "fireworks:accounts/fireworks/models/llama4-maverick-instruct-basic": ModelEntry(
         "Llama 4 Maverick · via Fireworks"
+    ),
+    # Groq
+    "groq:llama3-8b-8192": ModelEntry(
+        "Llama 3 8B · via Groq"
+    ),
+    "groq:llama3-70b-8192": ModelEntry(
+        "Llama 3 70B · via Groq"
+    ),
+    "groq:mixtral-8x7b-32768": ModelEntry(
+        "Mixtral 8x7B · via Groq"
+    ),
+    "groq:gemma-7b-it": ModelEntry(
+        "Gemma 7B IT · via Groq"
+    ),
+    # OpenRouter
+    "openrouter:anthropic/claude-3.5-sonnet": ModelEntry(
+        "Claude 3.5 Sonnet · via OpenRouter"
+    ),
+    "openrouter:anthropic/claude-3-opus": ModelEntry(
+        "Claude 3 Opus · via OpenRouter"
+    ),
+    "openrouter:anthropic/claude-3-haiku": ModelEntry(
+        "Claude 3 Haiku · via OpenRouter"
+    ),
+    "openrouter:openai/gpt-4o": ModelEntry(
+        "GPT-4o · via OpenRouter"
+    ),
+    "openrouter:openai/gpt-4-turbo": ModelEntry(
+        "GPT-4 Turbo · via OpenRouter"
+    ),
+    "openrouter:openai/gpt-3.5-turbo": ModelEntry(
+        "GPT-3.5 Turbo · via OpenRouter"
+    ),
+    "openrouter:google/gemini-pro-1.5": ModelEntry(
+        "Gemini Pro 1.5 · via OpenRouter"
+    ),
+    "openrouter:meta-llama/llama-3-8b": ModelEntry(
+        "Llama 3 8B · via OpenRouter"
+    ),
+    "openrouter:meta-llama/llama-3-70b": ModelEntry(
+        "Llama 3 70B · via OpenRouter"
     ),
 }
 

--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -315,10 +315,24 @@ DESCRIPTORS: list[ProviderDescriptor] = [
         env_key="META_API_KEY",
         endpoint_help="Prefilled with the Meta Model API endpoint (public preview, US-only as of 2026-07).",
     ),
+    _compat(
+        "groq",
+        "Groq",
+        base_url="https://api.groq.com/openai/v1",
+        recommended_model="llama3-8b-8192",
+        env_key="GROQ_API_KEY",
+        endpoint_help="Prefilled with Groq's OpenAI-compatible API endpoint.",
+    ),
+    _compat(
+        "openrouter",
+        "OpenRouter",
+        base_url="https://openrouter.ai/api/v1",
+        recommended_model="anthropic/claude-3.5-sonnet",
+        env_key="OPENROUTER_API_KEY",
+        endpoint_help="Prefilled with OpenRouter's OpenAI-compatible API endpoint.",
+    ),
     # Resellers: many labs' models behind one key, using THEIR model namespaces (the curated
-    # ids + display labels live in providers/matrix.py). TODO: add Groq and OpenRouter here
-    # (+ their matrix rows) once the current provider surface is tested — deliberately
-    # deferred to bound how much needs verifying at once (owner call, 2026-07-04).
+    # ids + display labels live in providers/matrix.py).
     _compat(
         "together",
         "Together AI",

--- a/surfaces/gui/CLAUDE.md
+++ b/surfaces/gui/CLAUDE.md
@@ -1,0 +1,100 @@
+# surfaces/gui/ Claude Code Guide
+
+## Overview
+This directory contains the desktop application frontend - a React/TypeScript application packaged with Tauri for cross-platform desktop deployment.
+
+## Key Components
+
+### src/
+React/TypeScript frontend code:
+- `App.tsx`: Root application component
+- `components/`: Reusable UI components
+  - `InboxConfigure.tsx`: Connector configuration UI
+  - `SlackDetail.tsx`: Slack workspace configuration
+  - Transcript, chat, settings, and other UI components
+- `api.ts`: Backend communication layer (WebSocket and REST)
+- `tauri.ts`: Tauri bridge for system integration
+- `hooks/`: Custom React hooks
+- `utils/`: Utility functions
+
+### src-tauri/
+Rust-powered Tauri shell:
+- `src/lib.rs`: Main Tauri application logic
+- `Cargo.toml`: Rust dependencies
+- Handles window management, system tray, and native integrations
+
+### e2e/
+Playwright end-to-end tests (hermetic, using mocks):
+- `inbox.spec.ts`: Connector setup and management
+- `slack-workspaces.spec.ts`: Slack integration tests
+- `ui-refill-*.spec.ts`: UI refresh and update tests
+- `fixtures.ts`: Test data and mock servers
+
+### e2e-live/
+Live end-to-end tests (require actual services):
+- `api-smoke.spec.ts`: Basic API connectivity tests
+- Other tests requiring real backend services
+
+## Development Guidelines
+
+### Component Development
+- Follow existing React component patterns in the `components/` directory
+- Use TypeScript strictly - no `any` types unless absolutely necessary
+- Keep components small and focused on a single responsibility
+- Use the existing styling patterns (Tailwind CSS classes)
+- Reuse existing components when possible
+- Add comprehensive PropTypes or TypeScript interfaces for component props
+
+### State Management
+- Follow existing patterns for state and props
+- Use React hooks appropriately (useState, useEffect, etc.)
+- For complex state, consider if existing patterns can be extended
+- Avoid prop drilling - use context or state management solutions when needed
+
+### Backend Communication
+- Use the existing `api.ts` patterns for WebSocket and REST communication
+- Handle connection states and reconnections appropriately
+- Parse and handle server responses consistently
+- Show appropriate loading and error states
+
+### Tauri Integration
+- Follow the patterns in `src-tauri/src/lib.rs`
+- Use the existing Tauri command handlers for backend communication
+- Keep frontend and backend communication contracts clear
+- Handle permissions and security considerations properly
+
+### Testing
+- Write unit tests for components and utilities
+- Add e2e tests for critical user flows
+- Mock external dependencies appropriately
+- Keep tests focused and maintainable
+
+### Styling and UI
+- Follow existing Tailwind CSS patterns in the codebase
+- Use the existing component library for consistency
+- Ensure responsive design works across window sizes
+- Follow accessibility best practices
+- Use existing icon and image patterns
+
+## Common Tasks
+
+### Adding a New UI Feature
+1. Create or modify components in `src/components/`
+2. Update routing or app structure if needed in `App.tsx`
+3. Add necessary API calls in `api.ts` if backend communication is required
+4. Add styles following existing patterns
+5. Write tests for the new functionality
+6. Update any related documentation
+
+### Modifying Existing Components
+1. Understand the existing props and state
+2. Make minimal, focused changes
+3. Ensure backward compatibility where possible
+4. Update tests to reflect changes
+5. Test thoroughly in different states
+
+### Working with Tauri
+1. Understand the bridge between frontend (TypeScript) and backend (Rust)
+2. Follow existing patterns for invoking Tauri commands
+3. Handle asynchronous operations properly
+4. Consider performance implications of frequent bridge crossings

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,124 @@
+# tests/ Claude Code Guide
+
+## Overview
+This directory contains the backend test suite for the OpenWorker Python backend. Tests use pytest and cover:
+- Unit tests for individual components
+- Integration tests for subsystem interactions
+- Mock-based tests for external services
+- Property-based testing where appropriate
+
+## Test Organization
+
+Tests are organized by subsystem, mirroring the main code structure:
+- `test_*.py`: Individual test modules
+- `conftest.py`: Shared pytest fixtures and configuration
+
+## Key Test Areas
+
+### Core Functionality
+- `test_agent.py`: Agent lifecycle and decision making
+- `test_engine.py`: Main turn processing loop
+- `test_permissions_*`: Permission engine and risk assessment
+- `test_memory.py`: Conversation and context storage
+- `test_skills.py`: Skill system functionality
+
+### Providers and Models
+- `test_providers.py`: Base provider interface
+- `test_*_provider.py`: Specific provider tests (openai, anthropic, gemini, etc.)
+- `test_provider_router.py`: Multi-provider routing and caching
+- `test_capabilities.py`: Model capability detection
+
+### Connectors and Integrations
+- `test_connectors.py`: Core connector functionality
+- `test_*_connectors.py`: Specific service integrations (slack, github, etc.)
+- `test_mcp.py`: Model Context Protocol implementation
+- `test_inbox.py`: Message handling and routing
+
+### Tools and Automation
+- `test_tools_*`: Individual tool functionality
+- `test_automation.py`: Scheduling and background tasks
+- `test_shell.py`: Command execution and permissions
+- `test_todo_tool.py`: Todo management tool
+
+### Server and API
+- `test_server.py`: FastAPI server endpoints
+- `test_cloud_server.py`: Cloud relay functionality
+- `test_session*`: Session management
+
+## Testing Guidelines
+
+### Writing Tests
+1. **Follow Arrange-Act-Assert pattern**: Clear setup, execution, and verification
+2. **Use descriptive test names**: `test_what_when_then_expected_result`
+3. **Keep tests focused**: Each test should verify one specific behavior
+4. **Mock external dependencies**: Don't make real network calls in unit tests
+5. **Use fixtures effectively**: Share common setup in `conftest.py`
+6. **Test edge cases**: Boundary conditions, error states, invalid inputs
+7. **Maintain test isolation**: Each test should be able to run independently
+
+### Mocking External Services
+- Use `unittest.mock` or `pytest-mock` for patching
+- Create realistic mock responses that match actual service formats
+- For HTTP services, consider using `responses` or `httpx-mock` if needed
+- Verify that your code handles both success and error responses from mocks
+
+### Database and State Testing
+- Use temporary directories for file-based storage tests
+- Clean up test state after each test when necessary
+- Consider using transactions or rollbacks for database tests
+- Factory boy or similar for test data generation when appropriate
+
+### Async Testing
+- Use `pytest-asyncio` for asynchronous tests
+- Follow the existing patterns in the codebase for async test structure
+- Properly await async operations and handle exceptions
+
+### Performance and Load Testing
+- Generally avoid in unit tests; save for dedicated performance tests
+- If necessary, use appropriate profiling and benchmarking tools
+- Focus on correctness first, performance optimization second
+
+### Test Data and Fixtures
+- Keep test data minimal and focused on what's being tested
+- Use factories or builders for complex test objects
+- Share common fixtures in `conftest.py` when used across multiple test files
+- Consider using fixtures for mock services or temporary resources
+
+## Running Tests
+
+### Backend Tests
+```bash
+# Run all tests
+.venv/bin/pytest
+
+# Run specific test module
+.venv/bin/pytest tests/test_engine.py
+
+# Run tests matching a pattern
+.venv/bin/pytest -k "test_something"
+
+# Run with coverage
+.venv/bin/pytest --cov=coworker tests/
+
+# Run specific test function
+.venv/bin/pytest tests/test_engine.py::test_specific_function
+```
+
+### Frontend Tests
+```bash
+# From surfaces/gui/ directory
+npm test              # Unit tests
+npm run e2e           # End-to-end tests (hermetic)
+npm run e2e-live      # End-to-end tests (requires live services)
+```
+
+## Best Practices
+
+1. **Don't test implementation details**: Focus on behavior and outcomes
+2. **Make tests deterministic**: Avoid timing-dependent tests when possible
+3. **Keep tests fast**: Unit tests should run in milliseconds
+4. **Test failure paths**: Ensure error handling works correctly
+5. **Update tests when fixing bugs**: Add regression tests for fixes
+6. **Remove commented-out code**: Keep test files clean
+7. **Follow existing patterns**: Consistency makes the test suite maintainable
+8. **Write tests before fixing bugs** (TDD approach) when feasible


### PR DESCRIPTION
…provider support

- Add CLAUDE.md files in root, coworker/, surfaces/gui/, and tests/ directories to provide guidance for Claude Code assistant
- Add Groq and OpenRouter as first-class providers in providers/registry.py
- Add corresponding model entries for Groq and OpenRouter in providers/matrix.py
- Update matrix.py TODO comment to reflect that Groq and OpenRouter support has been added