### PR TITLE
Add WeChat ClawBot connector

### DIFF
--- a/coworker/connectors/__init__.py
+++ b/coworker/connectors/__init__.py
@@ -1,4 +1,4 @@
-"""Messaging connectors — Slack/Telegram adapters, the gateway, and the send_message tool."""
+"""Messaging connectors — Slack/Telegram/WeChat adapters, the gateway, and send_message."""
 
 from __future__ import annotations
 
@@ -31,12 +31,14 @@ from .setup import (
     connector_list,
     disconnect_connector,
     experimental_enabled,
+    save_weixin_qr_credentials,
     set_experimental_enabled,
     update_connector_tools,
 )
 from .integration_tools import make_integration_tools
 from .tools import make_send_file_tool, make_send_message_tool
 from .tool_defs import connector_for_tool
+from .weixin_adapter import WeixinAdapter, weixin_message_to_event
 
 __all__ = [
     "BasePlatformAdapter",
@@ -61,6 +63,7 @@ __all__ = [
     "connector_list",
     "disconnect_connector",
     "experimental_enabled",
+    "save_weixin_qr_credentials",
     "set_experimental_enabled",
     "update_connector_tools",
     "make_integration_tools",
@@ -70,9 +73,11 @@ __all__ = [
     "SlackAdapter",
     "SlackRelayAdapter",
     "TelegramAdapter",
+    "WeixinAdapter",
     "make_adapter",
     "slack_event_to_event",
     "telegram_message_to_event",
+    "weixin_message_to_event",
     "slack_qualify",
     "slack_split",
 ]

--- a/coworker/connectors/adapters.py
+++ b/coworker/connectors/adapters.py
@@ -477,4 +477,11 @@ def make_adapter(
         return GitHubRelayAdapter(
             hub, installs=installs, token_client=github_token_client
         )
+    if platform == "weixin" and profile.get("bot_token"):
+        from .weixin_adapter import WeixinAdapter
+
+        return WeixinAdapter(
+            profile["bot_token"],
+            base_url=profile.get("baseurl") or profile.get("base_url") or None,
+        )
     return None

--- a/coworker/connectors/catalog_copy.py
+++ b/coworker/connectors/catalog_copy.py
@@ -16,6 +16,9 @@ ABOUT: dict[str, str] = {
     "telegram": "Chat with your coworker from Telegram. Messages to your bot "
     "reach the agent and replies come back to the same chat — only senders on "
     "your allow-list get through.",
+    "weixin": "Chat with your coworker from WeChat via the official ClawBot "
+    "(iLink) channel. Scan a QR code once; DMs on your phone reach the agent "
+    "on this computer. Group chats are not supported in v1.",
     "slack": "Bring your coworker into Slack: mention it in a channel or DM it, "
     "and replies land in-thread. Any number of workspaces can be connected, "
     "each with its own allow-list of who may talk to the agent.",
@@ -62,6 +65,11 @@ ACCESS: dict[str, list[str]] = {
     "telegram": [
         "Reads messages sent to your bot — never your personal chats.",
         "Sends messages as the bot.",
+        "Only senders on your allow-list are answered.",
+    ],
+    "weixin": [
+        "Reads DMs sent to your WeChat ClawBot identity — not your other chats.",
+        "Sends replies as the ClawBot (requires a prior inbound message).",
         "Only senders on your allow-list are answered.",
     ],
     "slack": [

--- a/coworker/connectors/config.py
+++ b/coworker/connectors/config.py
@@ -14,7 +14,7 @@ from typing import Optional
 from ..secrets import SecretStore
 from .base import SessionSource
 
-PLATFORMS = ("telegram", "slack", "github")
+PLATFORMS = ("telegram", "slack", "github", "weixin")
 
 
 @dataclass

--- a/coworker/connectors/descriptors.py
+++ b/coworker/connectors/descriptors.py
@@ -48,7 +48,7 @@ class ConnectorDescriptor:
     title: str
     icon: str
     blurb: str
-    auth: str  # "bot_token" | "socket_app" | "oauth" | "token" | "api_token" | "none"
+    auth: str  # "bot_token" | "socket_app" | "oauth" | "token" | "api_token" | "none" | "qrcode"
     two_way: bool
     fields: list[Field]
     instructions: list[str]
@@ -109,6 +109,15 @@ def _validate_telegram(creds: dict) -> ValidationResult:
             True, identity="@" + str(data["result"].get("username", "bot"))
         )
     return ValidationResult(False, error=data.get("description") or "invalid bot token")
+
+
+def _validate_weixin(creds: dict) -> ValidationResult:
+    """ClawBot tokens are minted via QR — presence of bot_token is enough to connect."""
+    token = (creds.get("bot_token") or "").strip()
+    if not token:
+        return ValidationResult(False, error="missing bot_token — scan the ClawBot QR code")
+    identity = (creds.get("ilink_bot_id") or creds.get("account") or "weixin").strip()
+    return ValidationResult(True, identity=identity)
 
 
 def _validate_email(creds: dict) -> ValidationResult:
@@ -445,6 +454,26 @@ DESCRIPTORS: list[ConnectorDescriptor] = [
             "After connecting, DM your new bot once, then use Capture to grab your user ID.",
         ],
         validate=_validate_telegram,
+    ),
+    ConnectorDescriptor(
+        name="weixin",
+        title="WeChat",
+        icon="💬",
+        blurb="Two-way DM with WeChat ClawBot (iLink) — scan a QR code on your phone.",
+        auth="qrcode",
+        two_way=True,
+        channels=False,
+        brand_color="#07c160",
+        logo="weixin",
+        aliases=("wechat", "clawbot", "ilink"),
+        fields=[_ALLOWED_FIELD],
+        instructions=[
+            "Use the WeChat mobile app (iOS ≈8.0.70+ / Android ≈8.0.69+) to scan the QR code.",
+            "Confirm authorization — a ClawBot chat appears in WeChat.",
+            "The account that scans is allow-listed automatically; other senders need Capture.",
+            "Message the bot once so replies can carry a context_token.",
+        ],
+        validate=_validate_weixin,
     ),
     ConnectorDescriptor(
         name="slack",

--- a/coworker/connectors/senders.py
+++ b/coworker/connectors/senders.py
@@ -138,9 +138,35 @@ def _send_slack_interactive(
     return SendResult(False, error=data.get("error") or "slack send failed")
 
 
+def _send_weixin(
+    token: str, chat_id: str, text: str, thread_id: Optional[str] = None
+) -> SendResult:
+    """Outbound ClawBot text via iLink. Requires a stored context_token for chat_id."""
+    _ = thread_id
+    from ..secrets import SecretStore
+    from . import weixin_ilink as ilink
+
+    ctx = ilink.context_token_store().get(chat_id)
+    if not ctx:
+        return SendResult(
+            False,
+            error=(
+                "no context_token for this WeChat chat — ask the user to message "
+                "the ClawBot once first"
+            ),
+        )
+    profile = SecretStore().get("weixin:default") or {}
+    base = profile.get("baseurl") or profile.get("base_url") or None
+    result = ilink.send_text(token, chat_id, text, ctx, base_url=base)
+    if result.get("ok"):
+        return SendResult(True, message_id=str(result.get("message_id") or "") or None)
+    return SendResult(False, error=result.get("error") or "weixin send failed")
+
+
 DEFAULT_SENDERS: dict[str, Sender] = {
     "telegram": _send_telegram,
     "slack": _send_slack,
+    "weixin": _send_weixin,
 }
 
 

--- a/coworker/connectors/setup.py
+++ b/coworker/connectors/setup.py
@@ -32,6 +32,9 @@ def _profile_connected(descriptor, profile: dict[str, Any]) -> bool:
         return False
     if descriptor.auth == "none":
         return True
+    # ClawBot / iLink: credentials arrive via QR scan, not descriptor fields.
+    if descriptor.auth == "qrcode":
+        return bool(profile.get("bot_token"))
     # Managed relay (e.g. Slack cloud relay) carries no manual credential in the
     # :default profile — the tokens live per-team (slack:team:*). The relay-mode
     # flag is what marks it connected, so don't require the manual fields.
@@ -512,6 +515,10 @@ def disconnect_connector(secrets: SecretStore, name: str) -> dict[str, Any]:
                 secrets.delete(github_installs.PREFIX + installation_id)
                 or dropped_accounts
             )
+    if name == "weixin":
+        from .weixin_ilink import context_token_store
+
+        context_token_store().clear()
     profile = secrets.get(f"{name}:default") or {}
     if profile.get("mode") == "mcp":
         # MCP-backed connect: forget the OAuth tokens + DCR registration and remove
@@ -522,3 +529,39 @@ def disconnect_connector(secrets: SecretStore, name: str) -> dict[str, Any]:
         dropped_accounts = mcp_oauth.sign_out(name, secrets) or dropped_accounts
         mcp_config.delete_global_server(name)
     return {"ok": secrets.delete(f"{name}:default") or dropped_accounts}
+
+
+def save_weixin_qr_credentials(
+    secrets: SecretStore,
+    *,
+    bot_token: str,
+    ilink_bot_id: str = "",
+    ilink_user_id: str = "",
+    baseurl: str = "",
+) -> dict[str, Any]:
+    """Persist ClawBot credentials from a confirmed QR scan and mark the connector connected.
+
+    Pre-adds `ilink_user_id` to the allow-list (same idea as Slack's installer pre-allow):
+    scanning the QR is consent to talk to your own ClawBot — without this, the first DM parks.
+    """
+    if not (bot_token or "").strip():
+        return {"ok": False, "error": "missing bot_token"}
+    existing = secrets.get("weixin:default") or {}
+    allowed = {str(u).strip() for u in (existing.get("allowed_users") or []) if str(u).strip()}
+    scanner = (ilink_user_id or "").strip()
+    if scanner:
+        allowed.add(scanner)
+    profile = {
+        "bot_token": bot_token.strip(),
+        "ilink_bot_id": (ilink_bot_id or "").strip(),
+        "ilink_user_id": scanner,
+        "baseurl": (baseurl or "").rstrip("/"),
+        "account": (ilink_bot_id or ilink_user_id or "weixin").strip(),
+        "enabled": True,
+        "mode": "qrcode",
+        "allowed_users": sorted(allowed),
+    }
+    if existing.get("allow_all"):
+        profile["allow_all"] = True
+    secrets.put("weixin:default", profile)
+    return {"ok": True, "account": profile["account"]}

--- a/coworker/connectors/tools.py
+++ b/coworker/connectors/tools.py
@@ -22,18 +22,20 @@ _SCHEMA = {
     "function": {
         "name": "send_message",
         "description": (
-            "Send a message to a connected chat (Slack or Telegram). `target` is the "
-            "reply handle from an inbound message (e.g. 'telegram:12345' or 'slack:C0123', "
-            "optionally with a ':<thread>' suffix) — or, for Slack, just the channel NAME "
-            "('#general' or 'general'; resolved against the connected workspaces). Use this to "
-            "actually reach a person — plain assistant text is not delivered anywhere."
+            "Send a message to a connected chat (Slack, Telegram, or WeChat ClawBot). "
+            "`target` is the reply handle from an inbound message (e.g. 'telegram:12345', "
+            "'slack:C0123', or 'weixin:user@im.wechat', optionally with a ':<thread>' suffix) "
+            "— or, for Slack, just the channel NAME ('#general' or 'general'; resolved against "
+            "the connected workspaces). Use this to actually reach a person — plain assistant "
+            "text is not delivered anywhere. WeChat replies need a prior inbound message "
+            "(context_token)."
         ),
         "parameters": {
             "type": "object",
             "properties": {
                 "target": {
                     "type": "string",
-                    "description": "Destination handle 'platform:chat_id[:thread]', e.g. 'telegram:12345'.",
+                    "description": "Destination handle 'platform:chat_id[:thread]', e.g. 'telegram:12345' or 'weixin:user@im.wechat'.",
                 },
                 "text": {"type": "string", "description": "The message text to send."},
             },

--- a/coworker/connectors/weixin_adapter.py
+++ b/coworker/connectors/weixin_adapter.py
@@ -1,0 +1,129 @@
+"""WeChat ClawBot adapter — long-poll iLink getupdates into Gateway MessageEvents."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Optional
+
+from .base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    SessionSource,
+)
+from . import weixin_ilink as ilink
+
+logger = logging.getLogger(__name__)
+
+
+def weixin_message_to_event(msg: dict[str, Any]) -> Optional[MessageEvent]:
+    """Map an iLink inbound message to a Gateway MessageEvent (DM-only v1)."""
+    # message_type 1 = user; skip bot echoes
+    mtype = msg.get("message_type")
+    if mtype is not None and int(mtype) != 1:
+        return None
+    user_id = str(msg.get("from_user_id") or "").strip()
+    if not user_id:
+        return None
+    text = ilink.extract_text(msg)
+    if not text:
+        return None
+    ctx = msg.get("context_token") or ""
+    if ctx:
+        ilink.context_token_store().put(user_id, str(ctx))
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform="weixin",
+            chat_id=user_id,
+            user_id=user_id,
+            user_name=user_id.split("@")[0] if "@" in user_id else user_id,
+            chat_type="dm",
+        ),
+        message_id=str(msg.get("client_id") or msg.get("msg_id") or "") or None,
+        message_type=MessageType.TEXT,
+        raw=msg,
+        mentions_me=True,  # ClawBot DMs are always addressed to the bot
+    )
+
+
+class WeixinAdapter(BasePlatformAdapter):
+    platform = "weixin"
+
+    def __init__(
+        self,
+        bot_token: str,
+        *,
+        base_url: Optional[str] = None,
+        poll_interval: float = 0.5,
+    ) -> None:
+        super().__init__()
+        self.bot_token = bot_token
+        self.base_url = (base_url or "").rstrip("/") or None
+        self._poll_interval = poll_interval
+        self._task: Optional[asyncio.Task] = None
+        self._closing = False
+        self._buf = ""
+
+    async def connect(self) -> bool:
+        if not self.bot_token:
+            return False
+        self._closing = False
+        self._task = asyncio.create_task(self._poll_loop(), name="weixin-ilink-poll")
+        logger.info("weixin adapter polling (iLink ClawBot)")
+        return True
+
+    async def disconnect(self) -> None:
+        self._closing = True
+        task = self._task
+        self._task = None
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    async def send(
+        self, chat_id: str, text: str, *, thread_id: Optional[str] = None
+    ) -> SendResult:
+        _ = thread_id
+        ctx = ilink.context_token_store().get(chat_id)
+        result = await asyncio.to_thread(
+            ilink.send_text,
+            self.bot_token,
+            chat_id,
+            text,
+            ctx or "",
+            base_url=self.base_url,
+        )
+        if result.get("ok"):
+            return SendResult(True, message_id=str(result.get("message_id") or "") or None)
+        return SendResult(False, error=result.get("error") or "weixin send failed")
+
+    async def _poll_loop(self) -> None:
+        while not self._closing:
+            try:
+                data = await asyncio.to_thread(
+                    ilink.get_updates,
+                    self.bot_token,
+                    self._buf,
+                    base_url=self.base_url,
+                )
+                self._buf = data.get("get_updates_buf") or self._buf
+                for msg in data.get("msgs") or []:
+                    if not isinstance(msg, dict):
+                        continue
+                    event = weixin_message_to_event(msg)
+                    if event is not None:
+                        await self.handle_message(event)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("weixin getupdates failed")
+                await asyncio.sleep(max(2.0, self._poll_interval))
+                continue
+            await asyncio.sleep(self._poll_interval)

--- a/coworker/connectors/weixin_ilink.py
+++ b/coworker/connectors/weixin_ilink.py
@@ -1,0 +1,289 @@
+"""WeChat ClawBot (iLink) HTTP client — QR login, long-poll inbound, text send.
+
+Protocol base: https://ilinkai.weixin.qq.com (Tencent official). Independent of the
+OpenClaw npm plugin; same wire format so OpenWorker can host a first-class connector.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import random
+import threading
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+from ..secrets import state_dir
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE = "https://ilinkai.weixin.qq.com"
+CHANNEL_VERSION = "1.0.3"
+BOT_TYPE = "3"
+_TIMEOUT_QR = 35.0
+_TIMEOUT_UPDATES = 40.0
+_TIMEOUT_SEND = 30.0
+
+
+def _random_wechat_uin() -> str:
+    """X-WECHAT-UIN: base64(decimal string of a random uint32)."""
+    n = random.randint(0, 0xFFFFFFFF)
+    return base64.b64encode(str(n).encode("ascii")).decode("ascii")
+
+
+def _headers(bot_token: Optional[str] = None) -> dict[str, str]:
+    h = {
+        "Content-Type": "application/json",
+        "AuthorizationType": "ilink_bot_token",
+        "X-WECHAT-UIN": _random_wechat_uin(),
+    }
+    if bot_token:
+        h["Authorization"] = f"Bearer {bot_token}"
+    return h
+
+
+def _base_url(override: Optional[str] = None) -> str:
+    env = os.environ.get("WEIXIN_ILINK_BASE", "").rstrip("/")
+    if override:
+        return override.rstrip("/")
+    if env:
+        return env
+    return DEFAULT_BASE
+
+
+def _qr_png_data_url(payload: str) -> str:
+    """Encode `payload` (iLink qrcode_img_content) into a PNG data URL for <img src>."""
+    import io
+
+    import qrcode
+
+    img = qrcode.make(payload, box_size=6, border=2)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def get_bot_qrcode(*, base_url: Optional[str] = None) -> dict[str, Any]:
+    """GET /ilink/bot/get_bot_qrcode?bot_type=3 → poll token + scan payload + PNG data URL.
+
+    iLink returns `qrcode_img_content` as a **scan payload URL** (liteapp.weixin.qq.com/…),
+    not an image. The GUI must render a QR of that string — we return `qrcode_data_url`.
+    """
+    import httpx
+
+    base = _base_url(base_url)
+    resp = httpx.get(
+        f"{base}/ilink/bot/get_bot_qrcode",
+        params={"bot_type": BOT_TYPE},
+        headers=_headers(),
+        timeout=_TIMEOUT_QR,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    qrcode = data.get("qrcode") or data.get("qrcode_token") or ""
+    # Protocol field name is misleading: this is the string WeChat scans, not an <img> URL.
+    img_content = (
+        data.get("qrcode_img_content") or data.get("qrcode_url") or data.get("qrcode_content") or ""
+    )
+    data_url = _qr_png_data_url(img_content) if img_content else ""
+    return {
+        "qrcode": qrcode,
+        "qrcode_img_content": img_content,
+        # qrcode_url is the PNG data URL for <img src> (not the iLink scan payload).
+        "qrcode_url": data_url,
+        "qrcode_data_url": data_url,
+        "raw": data,
+    }
+
+
+def get_qrcode_status(qrcode: str, *, base_url: Optional[str] = None) -> dict[str, Any]:
+    """Poll QR status. On confirmed, returns bot_token / ids / baseurl."""
+    import httpx
+
+    base = _base_url(base_url)
+    headers = {**_headers(), "iLink-App-ClientVersion": "1"}
+    resp = httpx.get(
+        f"{base}/ilink/bot/get_qrcode_status",
+        params={"qrcode": qrcode},
+        headers=headers,
+        timeout=_TIMEOUT_QR,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    status = data.get("status") or "wait"
+    # Normalize credential field names across observed response shapes.
+    creds = data.get("credentials") or {}
+    bot_token = (
+        data.get("bot_token")
+        or creds.get("bot_token")
+        or data.get("token")
+        or ""
+    )
+    out = {
+        "status": status,
+        "bot_token": bot_token,
+        "ilink_bot_id": data.get("ilink_bot_id")
+        or creds.get("ilink_bot_id")
+        or data.get("bot_id")
+        or "",
+        "ilink_user_id": data.get("ilink_user_id")
+        or creds.get("ilink_user_id")
+        or data.get("user_id")
+        or "",
+        "baseurl": (data.get("baseurl") or data.get("base_url") or base).rstrip("/"),
+        "raw": data,
+    }
+    return out
+
+
+def get_updates(
+    bot_token: str,
+    get_updates_buf: str = "",
+    *,
+    base_url: Optional[str] = None,
+) -> dict[str, Any]:
+    """Long-poll getupdates. Returns msgs + next get_updates_buf."""
+    import httpx
+
+    base = _base_url(base_url)
+    payload = {
+        "get_updates_buf": get_updates_buf or "",
+        "base_info": {"channel_version": CHANNEL_VERSION},
+    }
+    resp = httpx.post(
+        f"{base}/ilink/bot/getupdates",
+        headers=_headers(bot_token),
+        json=payload,
+        timeout=_TIMEOUT_UPDATES,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return {
+        "ret": data.get("ret", 0),
+        "msgs": data.get("msgs") or [],
+        "get_updates_buf": data.get("get_updates_buf") or get_updates_buf or "",
+        "raw": data,
+    }
+
+
+def extract_text(msg: dict[str, Any]) -> str:
+    """Pull plain text from an inbound WeixinMessage item_list."""
+    parts: list[str] = []
+    for item in msg.get("item_list") or []:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == 1 or "text_item" in item:
+            text = (item.get("text_item") or {}).get("text") or ""
+            if text:
+                parts.append(str(text))
+    return "\n".join(parts).strip()
+
+
+def send_text(
+    bot_token: str,
+    to_user_id: str,
+    text: str,
+    context_token: str,
+    *,
+    base_url: Optional[str] = None,
+) -> dict[str, Any]:
+    """POST sendmessage with required routing fields. Raises/returns ret on failure."""
+    import httpx
+
+    if not context_token:
+        return {
+            "ok": False,
+            "error": (
+                "no context_token for this chat — ask the user to message "
+                "the WeChat ClawBot once first"
+            ),
+        }
+    base = _base_url(base_url)
+    payload = {
+        "msg": {
+            "from_user_id": "",
+            "to_user_id": to_user_id,
+            "client_id": f"bot-{uuid.uuid4().hex[:12]}",
+            "message_type": 2,
+            "message_state": 2,
+            "context_token": context_token,
+            "item_list": [{"type": 1, "text_item": {"text": text}}],
+        },
+        "base_info": {"channel_version": CHANNEL_VERSION},
+    }
+    try:
+        resp = httpx.post(
+            f"{base}/ilink/bot/sendmessage",
+            headers=_headers(bot_token),
+            json=payload,
+            timeout=_TIMEOUT_SEND,
+        )
+        data = resp.json()
+        status_code = resp.status_code
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+    ret = data.get("ret", 0)
+    if ret in (0, None) and status_code < 400:
+        return {
+            "ok": True,
+            "message_id": data.get("msg_id") or data.get("client_id"),
+            "raw": data,
+        }
+    err = data.get("errmsg") or data.get("error") or f"weixin send failed (ret={ret})"
+    return {"ok": False, "error": err, "raw": data}
+
+
+class ContextTokenStore:
+    """Persist per-chat context_token under state_dir (required for outbound)."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self.path = path or (state_dir() / "weixin_context_tokens.json")
+        self._lock = threading.Lock()
+        self._data: dict[str, str] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if self.path.is_file():
+            try:
+                self._data = json.loads(self.path.read_text(encoding="utf-8"))
+            except Exception:
+                self._data = {}
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(
+            json.dumps(self._data, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+
+    def get(self, chat_id: str) -> Optional[str]:
+        with self._lock:
+            return self._data.get(chat_id) or None
+
+    def put(self, chat_id: str, token: str) -> None:
+        if not chat_id or not token:
+            return
+        with self._lock:
+            self._data[chat_id] = token
+            self._save()
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data = {}
+            if self.path.is_file():
+                try:
+                    self.path.unlink()
+                except OSError:
+                    pass
+
+
+_STORE: Optional[ContextTokenStore] = None
+
+
+def context_token_store() -> ContextTokenStore:
+    global _STORE
+    if _STORE is None:
+        _STORE = ContextTokenStore()
+    return _STORE

--- a/coworker/inbox_routing.py
+++ b/coworker/inbox_routing.py
@@ -28,7 +28,7 @@ _ID_TOKEN = re.compile(r"\[o(?:c)?w:([0-9a-f]{6,})\]")
 @dataclass
 class InboxBinding:
     name: str
-    channel: Optional[str] = None  # None (in-app only) | "slack" | "telegram"
+    channel: Optional[str] = None  # None (in-app only) | "slack" | "telegram" | "weixin"
     target: str = ""  # channel id / chat id for the binding
 
 

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -403,16 +403,24 @@ def create_app(manager: SessionManager) -> FastAPI:
         connector = str(body.get("connector", "")).strip()
         if not connector:
             return {"ok": False, "error": "connector required"}
+        enabled = bool(body.get("enabled", False))
         if body.get("clear"):
             manager.session_connections.clear(session_id, connector)
         else:
-            manager.session_connections.set(
-                session_id, connector, bool(body.get("enabled", False))
-            )
+            manager.session_connections.set(session_id, connector, enabled)
+            # Turning on a DM-capable messaging connector without a designated DM session
+            # used to silently park every inbound (reason: "no DM session designated") —
+            # WeChat/Telegram users hit this constantly after enabling Access → WeChat.
+            # Claim this session as the DM route when none is set yet (same surface the
+            # Inbox "DM routing" card uses). Slack channel traffic still uses subscriptions.
+            if enabled and connector in ("weixin", "telegram", "slack"):
+                if not manager.dm_session():
+                    manager.set_dm_session(session_id)
         persona = str(body.get("persona", "")) or None
         return {
             "ok": True,
             "connections": manager.session_connections_view(session_id, persona),
+            "dm_session": manager.dm_session(),
         }
 
     @app.post("/v1/personas/install")
@@ -766,6 +774,60 @@ def create_app(manager: SessionManager) -> FastAPI:
         if result.get("ok"):
             await _refresh_listeners_if_two_way(name)
         return result
+
+    @app.post("/v1/connectors/weixin/qrcode")
+    async def weixin_qrcode() -> dict[str, Any]:
+        """Start a WeChat ClawBot (iLink) QR login — returns poll token + PNG data URL."""
+        from ..connectors import weixin_ilink as ilink
+
+        try:
+            data = await asyncio.to_thread(ilink.get_bot_qrcode)
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+        if not data.get("qrcode"):
+            return {"ok": False, "error": "iLink did not return a qrcode"}
+        if not data.get("qrcode_data_url"):
+            return {"ok": False, "error": "iLink did not return qrcode_img_content"}
+        return {
+            "ok": True,
+            "qrcode": data["qrcode"],
+            "qrcode_img_content": data.get("qrcode_img_content") or "",
+            "qrcode_data_url": data.get("qrcode_data_url") or "",
+            # Alias for older GUI builds that read qrcode_url as <img src>.
+            "qrcode_url": data.get("qrcode_data_url") or "",
+        }
+
+    @app.post("/v1/connectors/weixin/qrcode/status")
+    async def weixin_qrcode_status(body: dict) -> dict[str, Any]:
+        """Poll QR status; on confirmed, save credentials and reload the gateway."""
+        from ..connectors import weixin_ilink as ilink
+        from ..connectors.setup import save_weixin_qr_credentials
+
+        qrcode = (body or {}).get("qrcode") if isinstance(body, dict) else None
+        if not qrcode:
+            return {"ok": False, "error": "missing qrcode"}
+        try:
+            status = await asyncio.to_thread(ilink.get_qrcode_status, str(qrcode))
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+        st = status.get("status") or "wait"
+        out: dict[str, Any] = {"ok": True, "status": st}
+        if st == "confirmed" and status.get("bot_token"):
+            saved = await asyncio.to_thread(
+                lambda: save_weixin_qr_credentials(
+                    manager.secrets,
+                    bot_token=status["bot_token"],
+                    ilink_bot_id=status.get("ilink_bot_id") or "",
+                    ilink_user_id=status.get("ilink_user_id") or "",
+                    baseurl=status.get("baseurl") or "",
+                )
+            )
+            if not saved.get("ok"):
+                return {"ok": False, "error": saved.get("error") or "save failed", "status": st}
+            await _refresh_listeners_if_two_way("weixin")
+            out["connected"] = True
+            out["account"] = saved.get("account")
+        return out
 
     @app.post("/v1/connectors/{name}/mcp-connect")
     async def connector_mcp_connect(name: str) -> dict[str, Any]:

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -2748,8 +2748,18 @@ class SessionManager:
         by self-wake and channel-subscription delivery. `source` is the display-only MessageSource
         sidecar for connector messages (framed `message` stays the model-facing text).
         """
+        # Background delivery often targets a Cowork scratch session that was never opened as
+        # Code. get_engine defaults to agent="code", which returns None without a repo workspace
+        # — WeChat/Telegram DMs then vanished silently. Prefer the in-memory engine, then a
+        # recorded session, then Cowork (knowledge family auto-provisions scratch).
         engine = self.get_engine(session_id)
         if engine is None:
+            engine = self.get_engine(session_id, agent="cowork")
+        if engine is None:
+            logger.warning("deliver_to_session: no engine for %s", session_id)
+            self.unrouted.record(
+                session_id, "-", message, reason="no engine for DM session"
+            )
             return
         if not self.try_mark_running(session_id):
             engine.queue_steering(message, source)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pydantic>=2",
     "mcp>=1.1",  # MCP client (stdio + streamable-http); we use our own async layer on it
     "httpx>=0.27",  # sync outbound senders for messaging connectors (send_message tool)
+    "qrcode[pil]>=7.4",  # WeChat ClawBot QR login — encode iLink scan payload to PNG
     "websockets>=13",  # managed Slack relay client transport (relay_client.py)
     "ddgs>=9",  # keyless default web-search provider (DuckDuckGo); Tavily/Brave use httpx
     "croniter>=2",  # cron next-fire math for the automation scheduler

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -586,6 +586,37 @@ export async function connectConnector(
   return res.json();
 }
 
+/** Start WeChat ClawBot (iLink) QR login. */
+export async function startWeixinQr(): Promise<{
+  ok: boolean;
+  qrcode?: string;
+  /** PNG data URL for <img src> (iLink payload encoded server-side). */
+  qrcode_data_url?: string;
+  /** @deprecated alias of qrcode_data_url */
+  qrcode_url?: string;
+  qrcode_img_content?: string;
+  error?: string;
+}> {
+  const res = await fetch(`${httpBase()}/v1/connectors/weixin/qrcode`, { method: "POST" });
+  return res.json();
+}
+
+/** Poll WeChat QR status; on confirmed the server saves credentials and reloads listeners. */
+export async function pollWeixinQrStatus(qrcode: string): Promise<{
+  ok: boolean;
+  status?: string;
+  connected?: boolean;
+  account?: string;
+  error?: string;
+}> {
+  const res = await fetch(`${httpBase()}/v1/connectors/weixin/qrcode/status`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ qrcode }),
+  });
+  return res.json();
+}
+
 export async function disconnectConnector(name: string): Promise<{ ok: boolean }> {
   const res = await fetch(`${httpBase()}/v1/connectors/${encodeURIComponent(name)}/disconnect`, {
     method: "POST",

--- a/surfaces/gui/src/components/AccessSection.tsx
+++ b/surfaces/gui/src/components/AccessSection.tsx
@@ -15,8 +15,10 @@ import {
   getCloudStatus,
   getConnectors,
   getRecentChannels,
+  getDmRoute,
   getSessionConnections,
   getSubscriptions,
+  setDmRoute,
   setSessionConnection,
   subscribeChannel,
   unsubscribeChannel,
@@ -163,6 +165,17 @@ export function AccessSection({
 
   const toggleSession = async (connector: string, next: boolean) => {
     await setSessionConnection(sessionId, connector, next);
+    // WeChat/Telegram/Slack DMs only land if a DM session is designated. Enabling the
+    // connector here is the user's clear intent that THIS chat should receive them —
+    // claim the route when none is set (backend does the same; GUI covers older sidecars).
+    if (next && (connector === "weixin" || connector === "telegram" || connector === "slack")) {
+      try {
+        const current = await getDmRoute();
+        if (!current) await setDmRoute(sessionId);
+      } catch {
+        /* ignore — connector toggle still applied */
+      }
+    }
     reload();
   };
   const channelsOf = (connector: string) =>

--- a/surfaces/gui/src/components/connectors/AddConnectionModal.tsx
+++ b/surfaces/gui/src/components/connectors/AddConnectionModal.tsx
@@ -4,6 +4,8 @@ import {
   connectManaged,
   connectMcpBacked,
   getConnectors,
+  pollWeixinQrStatus,
+  startWeixinQr,
   type CloudStatus,
   type Connector,
 } from "../../api";
@@ -109,6 +111,8 @@ export function AddConnectionModal({
               </div>
             )}
           </>
+        ) : c.auth === "qrcode" || c.name === "weixin" ? (
+          <WeixinQrConnect onConnected={() => { onChanged(); onClose(); }} />
         ) : mcpBacked ? (
           /* MCP-backed with no manual fields (monday): one-click IS the flow. */
           <McpOneClick c={c} onConnected={() => { onChanged(); onClose(); }} />
@@ -119,6 +123,125 @@ export function AddConnectionModal({
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+/** WeChat ClawBot iLink QR login — scan with the WeChat mobile app. */
+function WeixinQrConnect({ onConnected }: { onConnected: () => void }) {
+  const [qrcode, setQrcode] = useState("");
+  const [qrcodeUrl, setQrcodeUrl] = useState("");
+  const [status, setStatus] = useState<"loading" | "wait" | "scaned" | "scanned" | "confirmed" | "expired" | "error">(
+    "loading",
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const loadQr = async () => {
+    setError(null);
+    setStatus("loading");
+    setQrcode("");
+    setQrcodeUrl("");
+    const res = await startWeixinQr();
+    const img = res.qrcode_data_url || res.qrcode_url || "";
+    if (!res.ok || !res.qrcode || !img.startsWith("data:image/")) {
+      setStatus("error");
+      setError(res.error || "Could not load QR code");
+      return;
+    }
+    setQrcode(res.qrcode);
+    setQrcodeUrl(img);
+    setStatus("wait");
+  };
+
+  useEffect(() => {
+    void loadQr();
+  }, []);
+
+  useEffect(() => {
+    if (!qrcode || status === "confirmed" || status === "expired" || status === "error" || status === "loading") {
+      return;
+    }
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await pollWeixinQrStatus(qrcode);
+        if (cancelled) return;
+        if (!res.ok) {
+          setError(res.error || "QR login failed");
+          return;
+        }
+        const raw = res.status || "wait";
+        const st = raw === "scanned" ? "scaned" : raw;
+        if (res.connected || st === "confirmed") {
+          setStatus("confirmed");
+          onConnected();
+          return;
+        }
+        if (st === "expired") {
+          setStatus("expired");
+          return;
+        }
+        if (st === "scaned" || st === "wait") {
+          setStatus((prev) => (prev === st ? prev : (st as typeof prev)));
+        }
+      } catch {
+        /* keep polling */
+      }
+    };
+    const id = setInterval(tick, 2000);
+    void tick();
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [qrcode, status, onConnected]);
+
+  const statusLabel =
+    status === "loading"
+      ? "Loading QR code…"
+      : status === "wait"
+        ? "Scan with WeChat on your phone"
+        : status === "scaned" || status === "scanned"
+          ? "Scanned — confirm on your phone"
+          : status === "confirmed"
+            ? "Connected"
+            : status === "expired"
+              ? "QR expired"
+              : "QR login failed";
+
+  return (
+    <div className="px-5 py-4 space-y-3" data-testid="weixin-qr-connect">
+      <p className="text-[13px] text-muted">
+        Scan once with the WeChat app to link your ClawBot (iLink). Direct messages to the bot reach
+        this coworker; group chats are not supported yet.
+      </p>
+      <div className="flex flex-col items-center gap-3 py-2">
+        {qrcodeUrl ? (
+          <img
+            src={qrcodeUrl}
+            alt="WeChat ClawBot QR code"
+            className="w-[220px] h-[220px] rounded-lg bg-white p-2 border border-line"
+            data-testid="weixin-qr-image"
+          />
+        ) : (
+          <div className="w-[220px] h-[220px] rounded-lg border border-line bg-paper grid place-items-center text-[13px] text-muted">
+            {status === "loading" ? "Loading QR code…" : "—"}
+          </div>
+        )}
+        <div className="text-[13px] text-ink" data-testid="weixin-qr-status">
+          {statusLabel}
+        </div>
+      </div>
+      {error && <div className="text-[12.5px] text-danger">{error}</div>}
+      {(status === "expired" || status === "error") && (
+        <button className={PILL_ACCENT + " w-full justify-center"} onClick={() => void loadQr()}>
+          Refresh QR code
+        </button>
+      )}
+      <p className="text-[12px] text-faint leading-snug">
+        The account that scans is allow-listed automatically. Replies need a prior inbound message
+        (WeChat 24h window).
+      </p>
     </div>
   );
 }

--- a/surfaces/gui/src/connectors/registry.tsx
+++ b/surfaces/gui/src/connectors/registry.tsx
@@ -38,6 +38,7 @@ import {
   siQuickbooks,
   siStripe,
   siTelegram,
+  siWechat,
   siWhatsapp,
   siZendesk,
 } from "simple-icons";
@@ -215,6 +216,7 @@ export const CONNECTORS: Record<string, ConnectorRegistryEntry> = {
   quickbooks: brand(siQuickbooks),
   stripe: brand(siStripe),
   telegram: brand(siTelegram),
+  weixin: brand(siWechat),
   whatsapp: brand(siWhatsapp),
   zendesk: brand(siZendesk),
   // Real brand marks vendored from simple-icons v9.

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -309,6 +309,9 @@ def test_connector_list_descriptors(tmp_path):
     assert (
         by_name["github"]["two_way"] is True and by_name["github"]["channels"] is False
     )
+    # WeChat ClawBot is DM-only (no channel subscriptions).
+    assert by_name["weixin"]["two_way"] is True and by_name["weixin"]["channels"] is False
+    assert by_name["weixin"]["auth"] == "qrcode"
     assert (
         by_name["gmail"]["available"] is True and by_name["gmail"]["connected"] is False
     )
@@ -608,13 +611,16 @@ def test_slack_event_mapper_and_loop_guard():
 
 def test_make_adapter():
     from coworker.connectors import SlackAdapter, TelegramAdapter, make_adapter
+    from coworker.connectors.weixin_adapter import WeixinAdapter
 
     assert isinstance(make_adapter("telegram", {"bot_token": "T"}), TelegramAdapter)
     assert isinstance(
         make_adapter("slack", {"bot_token": "x", "app_token": "y"}), SlackAdapter
     )
+    assert isinstance(make_adapter("weixin", {"bot_token": "W"}), WeixinAdapter)
     assert make_adapter("slack", {"bot_token": "x"}) is None  # app_token missing
     assert make_adapter("telegram", {}) is None
+    assert make_adapter("weixin", {}) is None
 
 
 async def test_slack_resolves_and_caches_display_name():

--- a/tests/test_weixin_ilink.py
+++ b/tests/test_weixin_ilink.py
@@ -1,0 +1,174 @@
+"""Unit tests for WeChat ClawBot (iLink) client + ContextTokenStore."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from coworker.connectors import weixin_ilink as ilink
+from coworker.connectors.setup import save_weixin_qr_credentials
+from coworker.connectors.weixin_adapter import weixin_message_to_event
+from coworker.secrets import SecretStore
+
+
+def test_extract_text_from_item_list():
+    msg = {
+        "item_list": [
+            {"type": 1, "text_item": {"text": "hello"}},
+            {"type": 1, "text_item": {"text": "world"}},
+        ]
+    }
+    assert ilink.extract_text(msg) == "hello\nworld"
+
+
+def test_context_token_store_roundtrip(tmp_path: Path):
+    store = ilink.ContextTokenStore(tmp_path / "tokens.json")
+    assert store.get("u1") is None
+    store.put("u1", "ctx-abc")
+    assert store.get("u1") == "ctx-abc"
+    store2 = ilink.ContextTokenStore(tmp_path / "tokens.json")
+    assert store2.get("u1") == "ctx-abc"
+    store2.clear()
+    assert store2.get("u1") is None
+
+
+def test_send_text_requires_context_token():
+    out = ilink.send_text("tok", "user@im.wechat", "hi", "")
+    assert out["ok"] is False
+    assert "context_token" in out["error"]
+
+
+def test_send_text_includes_required_fields():
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        m = MagicMock()
+        m.status_code = 200
+        m.json.return_value = {"ret": 0, "msg_id": "m1"}
+        return m
+
+    with patch("httpx.post", side_effect=fake_post):
+        out = ilink.send_text(
+            "bot-tok",
+            "user@im.wechat",
+            "hello",
+            "ctx-1",
+            base_url="https://ilink.test",
+        )
+    assert out["ok"] is True
+    msg = captured["json"]["msg"]
+    assert msg["to_user_id"] == "user@im.wechat"
+    assert msg["context_token"] == "ctx-1"
+    assert msg["message_type"] == 2
+    assert msg["message_state"] == 2
+    assert msg["from_user_id"] == ""
+    assert msg["client_id"]
+    assert captured["headers"]["Authorization"] == "Bearer bot-tok"
+    assert captured["headers"]["AuthorizationType"] == "ilink_bot_token"
+
+
+def test_get_updates_advances_buf():
+    def fake_post(url, headers=None, json=None, timeout=None):
+        m = MagicMock()
+        m.status_code = 200
+        m.raise_for_status = lambda: None
+        m.json.return_value = {
+            "ret": 0,
+            "msgs": [{"from_user_id": "u@im.wechat", "message_type": 1}],
+            "get_updates_buf": "cursor-2",
+        }
+        return m
+
+    with patch("httpx.post", side_effect=fake_post):
+        data = ilink.get_updates("tok", "cursor-1", base_url="https://ilink.test")
+    assert data["get_updates_buf"] == "cursor-2"
+    assert len(data["msgs"]) == 1
+
+
+def test_weixin_message_to_event_and_stores_token(tmp_path: Path, monkeypatch):
+    store = ilink.ContextTokenStore(tmp_path / "t.json")
+    monkeypatch.setattr(ilink, "context_token_store", lambda: store)
+    msg = {
+        "from_user_id": "alice@im.wechat",
+        "message_type": 1,
+        "context_token": "CTX",
+        "client_id": "c1",
+        "item_list": [{"type": 1, "text_item": {"text": "分析一下"}}],
+    }
+    ev = weixin_message_to_event(msg)
+    assert ev is not None
+    assert ev.source.platform == "weixin"
+    assert ev.source.chat_id == "alice@im.wechat"
+    assert ev.source.chat_type == "dm"
+    assert ev.text == "分析一下"
+    assert store.get("alice@im.wechat") == "CTX"
+
+
+def test_weixin_message_skips_bot_echo():
+    assert (
+        weixin_message_to_event(
+            {
+                "from_user_id": "bot@im.bot",
+                "message_type": 2,
+                "item_list": [{"type": 1, "text_item": {"text": "x"}}],
+            }
+        )
+        is None
+    )
+
+
+def test_save_weixin_qr_credentials(tmp_path: Path, monkeypatch):
+    secrets = SecretStore(path=tmp_path / "secrets.json")
+    out = save_weixin_qr_credentials(
+        secrets,
+        bot_token="tok",
+        ilink_bot_id="b@im.bot",
+        ilink_user_id="u@im.wechat",
+        baseurl="https://ilink.test/",
+    )
+    assert out["ok"] is True
+    profile = secrets.get("weixin:default")
+    assert profile["bot_token"] == "tok"
+    assert profile["baseurl"] == "https://ilink.test"
+    assert profile["mode"] == "qrcode"
+    # QR scanner is pre-allowed (parity with Slack installer) so the first DM is not parked.
+    assert profile["allowed_users"] == ["u@im.wechat"]
+
+
+def test_descriptor_and_platforms():
+    from coworker.connectors.config import PLATFORMS
+    from coworker.connectors.descriptors import get_descriptor
+    from coworker.connectors.catalog_copy import ACCESS
+
+    assert "weixin" in PLATFORMS
+    d = get_descriptor("weixin")
+    assert d is not None
+    assert d.auth == "qrcode"
+    assert d.two_way is True
+    assert d.channels is False
+    assert "weixin" in ACCESS
+
+
+def test_get_bot_qrcode_encodes_payload_as_png_data_url():
+    """iLink qrcode_img_content is a scan URL — must become a data:image PNG, not used as img src."""
+    payload = "https://liteapp.weixin.qq.com/q/7GiQu1?qrcode=abc&bot_type=3"
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        m = MagicMock()
+        m.status_code = 200
+        m.raise_for_status = lambda: None
+        m.json.return_value = {"qrcode": "abc", "qrcode_img_content": payload, "ret": 0}
+        return m
+
+    with patch("httpx.get", side_effect=fake_get):
+        out = ilink.get_bot_qrcode(base_url="https://ilink.test")
+    assert out["qrcode"] == "abc"
+    assert out["qrcode_img_content"] == payload
+    assert out["qrcode_data_url"].startswith("data:image/png;base64,")
+    assert out["qrcode_url"] == out["qrcode_data_url"]
+    assert "liteapp.weixin.qq.com" not in out["qrcode_data_url"]


### PR DESCRIPTION
## Summary

Adds a two-way WeChat ClawBot connector on Tencent’s iLink API (`ilinkai.weixin.qq.com`), so DMs on your phone can reach a local OpenWorker session.

- QR login in the Connectors UI (`POST /v1/connectors/weixin/qrcode` + status poll); server turns the scan payload into a PNG data URL
- Inbound long-poll via `getupdates`; outbound through `send_message` with a per-chat `context_token`
- The account that confirms the QR is pre-added to the allow-list (same idea as Slack’s installer)
- Enabling WeChat / Telegram / Slack on a session claims it as the DM route when none is set yet

**v1:** DMs only (no groups). Outbound needs a prior inbound message (WeChat’s ~24h window).

## Test plan

- [x] `pytest tests/test_weixin_ilink.py tests/test_connectors.py tests/test_connectors_allowlist.py tests/test_connector_registry.py tests/test_connections.py tests/test_gateway_inbox_reply.py tests/test_message_source.py` (88 passed locally)
- [x] `npx tsc --noEmit` in `surfaces/gui`
- [ ] Connectors → WeChat → scan QR → connected
- [ ] Enable WeChat on a Cowork session → DM the ClawBot → message lands in that session
- [ ] Agent replies with `send_message` target `weixin:…`
- [ ] Disconnect clears stored context tokens