### PR TITLE
test: fix flaky test_scheduler_runs_due_task_and_advances near minute boundaries

### DIFF
--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -111,14 +111,21 @@ async def test_scheduler_runs_due_task_and_advances(tmp_path):
     store._conn.commit()
 
     ran: list[str] = []
+    ran_once = asyncio.Event()
 
     async def runner(task, trigger):
         ran.append(task.id)
+        ran_once.set()
         return TaskRun(task_id=task.id, status="ok", trigger=trigger)
 
     sched = Scheduler(store, runner, tick_seconds=0.05)
     sched.start()
-    await asyncio.sleep(0.2)
+    # Wait for the run instead of sleeping a fixed window: with an every-minute cron, a
+    # fixed sleep that happens to straddle a minute boundary lets the advanced task come
+    # due AGAIN and legitimately fire twice. Stopping right after the first run (the
+    # advance is synchronous once the runner returns) makes the single-fire assertion
+    # deterministic.
+    await asyncio.wait_for(ran_once.wait(), timeout=5.0)
     await sched.stop()
     assert ran == [t.id]
     advanced = store.get(t.id)


### PR DESCRIPTION
The test forces an every-minute cron task due and sleeps a fixed 0.2s with `tick_seconds=0.05`. After the first (catch-up) run the scheduler correctly advances `next_run` to the next minute boundary; when the test happens to start within ~0.2s of a minute boundary, that recomputed boundary falls inside the sleep window and the task **legitimately** fires a second time, failing `assert ran == [t.id]` with `['task-X','task-X']`.

This is a harness race, not a scheduler bug — the running-guard (`_running_ids`) and the synchronous post-run advance are correct, and the second fire is the next real cron occurrence. Reproduced deterministically by shifting the store clock to 0.1s before a minute boundary.

Fix: wait on an `asyncio.Event` set by the fake runner instead of sleeping a fixed window, and stop the scheduler immediately after the first run — the advance completes synchronously once the runner returns, so no further tick can fire. Verified 15/15 in a loop plus the adversarial minute-boundary repro; the single-fire and advance assertions are unchanged.