### PR TITLE
test: fix flaky ui-refresh e2e by quiescing the auto-title call before mute assertions

### DIFF
--- a/tests/test_ui_refresh_e2e.py
+++ b/tests/test_ui_refresh_e2e.py
@@ -260,6 +260,10 @@ async def test_ui_refresh_cross_cutting_e2e(fake_slack, tmp_path, monkeypatch):
         assert mgr.inbox.get(item_id).state == "resolved"
 
         # -- Step 4: mute Slack for the session -> a further post does NOT wake it, still buffered -
+        # The turn's mark_idle fired an auto-title completion (fire-and-forget, on a worker
+        # thread); let it settle so its provider call can't land between the snapshot below
+        # and the "provider not re-invoked" assertion.
+        assert await _wait_until(lambda: SID not in mgr._autotitle_inflight)
         msgcount_before = len(mgr.session_messages(SID))
         calls_before = len(provider.calls)
         resp = client.post(


### PR DESCRIPTION
When the approved turn completes, `mark_idle` spawns the auto-title completion as a fire-and-forget task that runs `provider.complete` via `asyncio.to_thread`. The scripted `E2EProvider` records that call (then raises on the exhausted turn queue, which autotitle swallows), so one extra `provider.calls` entry lands at a nondeterministic time — frequently between the `calls_before` snapshot and the "provider not re-invoked" assertion in the mute step. On an idle machine this failed ~6/8 runs.

Fix: wait for the session to leave `mgr._autotitle_inflight` (the same settling idiom `tests/test_autotitle.py` already uses) before taking the snapshot, so the title call is deterministically included in the baseline. The mute guarantee — a muted inbound must not deliver a turn or re-invoke the provider — is asserted exactly as before. Verified 15/15 in a loop.