### PR TITLE
fix(gui): keep composer controls within narrow session layout (issue 208)

### DIFF
--- a/surfaces/gui/e2e/composer-overflow.spec.ts
+++ b/surfaces/gui/e2e/composer-overflow.spec.ts
@@ -1,0 +1,21 @@
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+test("running composer keeps Stop within a narrow session column", async ({ page }) => {
+  await page.setViewportSize({ width: 1_100, height: 800 });
+  await page.goto("/");
+  await page.getByText("Draft the launch note").first().click();
+
+  const box = page.getByPlaceholder(/Ask the coworker/);
+  await box.fill("stream the epic");
+  await box.press("Enter");
+
+  const [composer, stop] = await Promise.all([
+    page.locator(".composer").boundingBox(),
+    page.getByRole("button", { name: /Stop/ }).boundingBox(),
+  ]);
+
+  expect(composer).not.toBeNull();
+  expect(stop).not.toBeNull();
+  expect(stop!.x + stop!.width).toBeLessThanOrEqual(composer!.x + composer!.width);
+});

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -399,7 +399,7 @@ export function Composer(props: Props) {
         />
 
         {/* Three-control row (§22): + attach · Mode ⌄ …(right)… model (fresh only) · send */}
-        <div className="px-2.5 pb-2.5 pt-1 flex items-center gap-1.5">
+        <div className="px-2.5 pb-2.5 pt-1 flex min-w-0 items-center gap-1.5">
           {/* + attach menu */}
           <div className="relative">
             <button
@@ -516,7 +516,7 @@ export function Composer(props: Props) {
 
           {/* send / stop */}
           {props.running ? (
-            <button className="btn danger" onClick={props.onInterrupt}>
+            <button className="btn danger shrink-0" onClick={props.onInterrupt}>
               ⏹ Stop
             </button>
           ) : (

--- a/surfaces/gui/src/styles.css
+++ b/surfaces/gui/src/styles.css
@@ -489,6 +489,12 @@ button.btn.danger { color: var(--accent); }
 .pill.chip { background: var(--paper); border: 1px solid var(--line); }
 .pill.chip:hover { border-color: var(--line-strong); background: var(--paper); }
 
+/* The model picker shares the composer's single control row with the send/stop action. When an
+   artifact panel narrows that column, let the model label truncate instead of pushing the action
+   outside the composer (issue #208). */
+.composer .dd { min-width: 0; flex: 0 1 240px; }
+.composer .dd .pill { max-width: 100%; }
+
 /* dropdown popover */
 .dd { position: relative; }
 .dd-backdrop { position: fixed; inset: 0; z-index: 20; }


### PR DESCRIPTION
this pr addresses issue #208 Control button UI overflow by doing the following:
When the side panel is open, the available width for the chat composer becomes smaller. The model picker was allowed to hold onto too much width, so the “Stop” button could be pushed outside the composer.
The fix does three small things:
1. Allows the composer’s control row to shrink.
2. Allows the model dropdown to shrink from its usual maximum width and truncate the model name with ….
3. Marks the “Stop” button as non-shrinking, so it stays fully visible and clickable.
So at narrow widths, the model label becomes shorter rather than the action button overflowing.