### PR TITLE
Fix attachment de-dup stripping real digits from the filename

### DIFF
--- a/coworker/connectors/email_tools.py
+++ b/coworker/connectors/email_tools.py
@@ -555,7 +555,7 @@ def make_email_tools(
                     while target.exists():
                         target = (
                             scratch.path
-                            / f"{target.stem.rstrip('-0123456789') or 'attachment'}-{counter}{target.suffix}"
+                            / f"{re.sub(r'-[0-9]+$', '', target.stem) or 'attachment'}-{counter}{target.suffix}"
                         )
                         counter += 1
                     target.write_bytes(payload)


### PR DESCRIPTION
### What

`email_download_attachment` corrupts the filename when it de-duplicates a name collision. The rename loop:

```python
while target.exists():
    target = (
        scratch.path
        / f"{target.stem.rstrip('-0123456789') or 'attachment'}-{counter}{target.suffix}"
    )
    counter += 1
```

`str.rstrip('-0123456789')` removes **every** trailing digit/dash, including digits that are part of the real name. It was only meant to strip a previously-appended `-N` suffix before adding the next one.

### Why it matters

Downloading two attachments with the same digit-ending name into one session folder mangles the filename:

| attachment | current | expected |
|---|---|---|
| `invoice_2024.pdf` | `invoice_-1.pdf` | `invoice_2024-1.pdf` |
| `IMG_20240115.jpg` | `IMG_-1.jpg` | `IMG_20240115-1.jpg` |
| `image001.png` (Outlook auto-name) | `image-1.png` | `image001-1.png` |
| `report.pdf` (no digits) | `report-1.pdf` | `report-1.pdf` |

The wrong name is written to disk and returned as `path` in the tool result.

### How

Strip only a trailing `-<number>` suffix:

```python
/ f"{re.sub(r'-[0-9]+$', '', target.stem) or 'attachment'}-{counter}{target.suffix}"
```

`re` is already imported. Verified this preserves the original digits and still increments correctly on repeated collisions (`invoice_2024.pdf` → `invoice_2024-1.pdf` → `invoice_2024-2.pdf`). Names without a trailing `-N` are unchanged.
