### PR TITLE
deps: raise mcp floor to >=1.28.1 (PYSEC-2026-3481/3482/3483)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "docstring_parser",
     "pyyaml>=6",  # persona manifest frontmatter (YAML)
     "pydantic>=2",
-    "mcp>=1.1,<2",  # MCP client (stdio + streamable-http); 2.0 removed streamablehttp_client
+    "mcp>=1.28.1,<2",  # MCP client (stdio + streamable-http); floor >=1.28.1 avoids PYSEC-2026-3481/3482/3483 (fixed in 1.27.2/1.28.1); <2 since 2.0.0 removed streamablehttp_client
     "httpx>=0.27",  # sync outbound senders for messaging connectors (send_message tool)
     "websockets>=13",  # managed Slack relay client transport (relay_client.py)
     "ddgs>=9",  # keyless default web-search provider (DuckDuckGo); Tavily/Brave use httpx


### PR DESCRIPTION
Raises the `mcp` floor to `>=1.28.1` to remediate **PYSEC-2026-3481 / 3482 / 3483** (fixed in mcp `1.27.2` / `1.28.1`). The current `main` constraint `mcp>=1.1,<2` still resolves to vulnerable `1.x` versions below the fix (e.g. 1.23.3).

Rebased on current `main`, so it stacks cleanly on the recent `<2` cap (`8674e301`, *"Pin mcp<2"*): the constraint becomes **`mcp>=1.28.1,<2`**. The two are complementary —

- the `<2` cap addressed the mcp 2.0 `streamablehttp_client` import breakage (#298);
- this adds the CVE **floor** the cap did not, so a fresh resolve lands on a patched `1.x`, not a vulnerable `>=1.1`.

One-line dependency-constraint change in `pyproject.toml`; no functional change. Verified the full backend suite passes on `mcp==1.28.1`.
