### PR TITLE
ci: run backend + GUI unit tests on Linux arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,14 @@ on: [push, pull_request]
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    # Run the backend suite on both x64 and Linux arm64 (GitHub-hosted arm
+    # runners). The Python backend has no x86 assumption; this keeps aarch64
+    # (Apple-silicon dev machines, ARM servers/CI) a supported target.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -21,7 +28,11 @@ jobs:
         run: pytest tests -q
 
   gui-unit:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
OpenWorker has no Linux CI target today, yet the Python backend and the GUI unit suite run cleanly on aarch64 — I validated the full `pytest tests` backend suite and `npm test` GUI unit suite on a Linux arm64 host (Ubuntu, Python 3.12, Node). This adds a `ubuntu-24.04-arm` leg to the `pytest` and `gui-unit` jobs via a small matrix, using GitHub's hosted arm64 runners.

- Backend has no x86 assumption (pure-python deps + arm64 wheels for pypdfium2 etc.).
- `fail-fast: false` so an arm-specific issue surfaces without masking the x64 result.
- `gui-e2e` left x64-only for now (Playwright browser provisioning on arm is a separate step).

This makes aarch64 — Apple-silicon dev machines and ARM servers — a continuously-tested target rather than a best-effort one. Happy to adjust the runner label if you prefer a different arm image.