### PR TITLE
Recover truncated tool calls, and never pass a leaked one off as an answer

### DIFF
--- a/coworker/engine.py
+++ b/coworker/engine.py
@@ -23,6 +23,7 @@ from .events import Event, EventType
 from .permissions import Mode, PermissionEngine
 from .providers import AssistantTurn, ProviderClient, ToolCall
 from .providers.errors import friendly_model_error
+from .providers.openai_provider import looks_like_unparsed_tool_call
 from .tools import ToolRegistry
 
 
@@ -366,6 +367,25 @@ class TurnEngine:
                 if self._steering:
                     self._inject_steering()
                     continue
+                # The model tried to call a tool and the syntax never parsed — salvage already
+                # had its go. Ending as "completed" here would present a half-written call as
+                # the answer, which is indistinguishable from the model deciding it was done;
+                # the user just sees narration trailing off into stray tags. Fail loudly
+                # instead, on the error path so the GUI offers Retry — this is drift, not a
+                # deterministic failure, so retrying the same model usually works.
+                if looks_like_unparsed_tool_call(turn.text, self.registry.schemas() or None):
+                    message = (
+                        f"{self.model} replied with a tool call this endpoint couldn't parse, "
+                        "so the turn was stopped rather than answered from a partial call. "
+                        "Retry, or switch to a larger model — smaller local models drift off "
+                        "the tool-call format, especially with many tools in play."
+                    )
+                    self._append_notice("error", message)
+                    yield Event(
+                        EventType.ERROR,
+                        {"error": message, "error_type": "UnparsedToolCall"},
+                    )
+                    return
                 yield Event(
                     EventType.TURN_END,
                     {"status": "completed", "iterations": iterations},

--- a/coworker/providers/openai_provider.py
+++ b/coworker/providers/openai_provider.py
@@ -306,6 +306,45 @@ _PARAM_BLOCK = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+# A `<function=NAME>` that never closes — the model ran out of tokens (or drifted) partway
+# through writing the call. Anchored to end-of-text so it only matches a genuinely unfinished
+# tail, never a well-formed block earlier in the message. Small local models hit this often on
+# a large tool schema, and the turn used to end silently on the leftover text.
+_FUNCTION_OPEN_TRUNCATED = re.compile(
+    r"<function\s*=\s*(?P<name>[^>\s]+)\s*>(?P<body>(?:(?!</function\s*>).)*)$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Markers that mean "this text IS a tool call the endpoint failed to parse", used to tell a
+# real answer from a leaked one. Fenced code is stripped first: a model *explaining* tool-call
+# syntax in a ``` block is answering, not calling.
+_LEAKED_TOOL_SYNTAX = (
+    "<tool_call>",
+    "</tool_call>",
+    "<function=",
+    "</function>",
+    "<parameter=",
+    "</parameter>",
+    "<function_calls>",
+    "<invoke ",
+)
+_FENCED = re.compile(r"```.*?```|~~~.*?~~~|`[^`\n]*`", re.DOTALL)
+
+
+def looks_like_unparsed_tool_call(
+    text: Optional[str], tools: Optional[list[dict[str, Any]]] = None
+) -> bool:
+    """True when assistant text still carries tool-call markup that salvage couldn't turn into
+    a call — i.e. the model tried to call a tool and the syntax was mangled or cut off.
+
+    Only meaningful when tools were actually offered, and only over OpenAI-compatible endpoints
+    that parse tool calls out of the model's raw output (LM Studio, Ollama, vLLM). The caller
+    uses it to end the turn as a retriable error instead of presenting the fragment as an answer.
+    """
+    if not tools or not text:
+        return False
+    return any(m in _FENCED.sub("", text).lower() for m in _LEAKED_TOOL_SYNTAX)
+
 
 def _coerce_param(raw: str) -> Any:
     """Keep free-text verbatim (the common case: file content), but recover real JSON values when
@@ -477,6 +516,22 @@ def _salvage_tool_calls_from_text(
         calls.append(ToolCall(id="", name=name, arguments=args))
     if calls:
         return _renumber(calls)
+
+    # 1c) A TRUNCATED XML call: `<function=NAME>` with no closing tag, because the model ran
+    # out of tokens mid-call. Take the name plus every parameter that DID close; a trailing
+    # unterminated `<parameter=…>` is dropped rather than guessed, so a half-written path or
+    # file body can never reach a tool. If that leaves a required argument missing the call
+    # fails validation and the model gets a corrective tool error — which is the agent loop
+    # working, and strictly better than the turn ending on the leftover fragment.
+    tm = _FUNCTION_OPEN_TRUNCATED.search(text)
+    if tm:
+        name = tm.group("name").strip()
+        if names is None or name in names:
+            args = {
+                pm.group("key").strip(): _coerce_param(pm.group("val"))
+                for pm in _PARAM_BLOCK.finditer(tm.group("body"))
+            }
+            return _renumber([ToolCall(id="", name=name, arguments=args)])
 
     # 2) Embedded {"name": …, "arguments": …} objects, even surrounded by prose.
     for sub in _iter_top_objects(text):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -439,3 +439,39 @@ def test_outbound_replaces_images_for_non_vision_models(tmp_path):
     assert all(p["type"] != "image_url" for p in parts)
     assert "not viewable" in parts[-1]["text"]
     assert engine.messages[-1]["content"][1]["type"] == "image_url"  # history untouched
+
+
+def test_leaked_tool_call_ends_the_turn_as_a_retriable_error(tmp_path):
+    """A tool call the endpoint couldn't parse must not pass as an answer. Ending "completed"
+    made a half-written call indistinguishable from the model deciding it was done — the user
+    saw narration trailing off into stray tags (owner report 2026-07-26, qwen3.5-9b on LM
+    Studio). It ends on the error path so the GUI offers Retry; the drift is probabilistic, so
+    retrying the same model usually works."""
+    leaked = "Let me read the key files.\n<tool_call>\n<function=nope_not_a_tool>\n<parameter="
+    engine, _ = _engine(tmp_path, [_text_turn(leaked)])
+    events = _collect(engine, "explore the codebase")
+
+    assert EventType.ERROR in _types(events)
+    assert EventType.TURN_END not in _types(events)
+    err = next(ev for ev in events if ev.type == EventType.ERROR)
+    assert err.data["error_type"] == "UnparsedToolCall"
+    assert "couldn't parse" in err.data["error"]
+    # Persisted as an error notice, which is what unlocks retry().
+    assert engine.messages[-1] == {
+        **engine.messages[-1],
+        "role": "notice",
+        "kind": "error",
+    }
+    assert engine._tail_is_retriable_error() is True
+
+
+def test_ordinary_text_answer_still_completes(tmp_path):
+    """Guard the other side: prose that merely mentions tool syntax inside code fences is a
+    real answer and must still complete normally."""
+    engine, _ = _engine(
+        tmp_path,
+        [_text_turn("Qwen writes calls like:\n```\n<tool_call><function=x>\n```\nThat's it.")],
+    )
+    events = _collect(engine, "how does qwen format tool calls?")
+    assert EventType.ERROR not in _types(events)
+    assert next(ev for ev in events if ev.type == EventType.TURN_END).data["status"] == "completed"

--- a/tests/test_provider_router.py
+++ b/tests/test_provider_router.py
@@ -15,7 +15,10 @@ from coworker.providers import (
     capabilities_for,
 )
 from coworker.providers.registry import _normalize_ollama_url, build_provider_client
-from coworker.providers.openai_provider import _salvage_tool_calls_from_text
+from coworker.providers.openai_provider import (
+    _salvage_tool_calls_from_text,
+    looks_like_unparsed_tool_call,
+)
 
 
 # -- base_url passthrough -------------------------------------------------------
@@ -219,6 +222,21 @@ _TODO_TOOLS = [
 ]
 
 
+_GREP_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "grep",
+            "parameters": {
+                "type": "object",
+                "properties": {"pattern": {"type": "string"}, "path": {"type": "string"}},
+                "required": ["pattern"],
+            },
+        },
+    }
+]
+
+
 def test_salvage_mixed_prose_and_object():
     # The model wrote prose THEN a bare-JSON tool call in one message.
     text = 'It seems the workspace is empty. {"name": "list_files", "arguments": {"recursive": true}}'
@@ -252,6 +270,39 @@ def test_salvage_filters_unknown_tool_name():
     # A {name,arguments} object whose name isn't an offered tool must NOT be salvaged.
     text = '{"name": "rm_rf", "arguments": {"path": "/"}}'
     assert _salvage_tool_calls_from_text(text, _TODO_TOOLS) == []
+
+
+def test_salvage_truncated_xml_call_keeps_only_complete_parameters():
+    """A local model that runs out of tokens mid-call leaves `<function=…>` unclosed. Take the
+    name and every parameter that DID close; NEVER the half-written trailing one — a truncated
+    path or file body reaching a tool is worse than no call at all."""
+    text = "<tool_call>\n<function=grep>\n<parameter=pattern>TODO</parameter>\n<parameter=path>sr"
+    calls = _salvage_tool_calls_from_text(text, _TODO_TOOLS + _GREP_TOOL)
+    assert len(calls) == 1 and calls[0].name == "grep"
+    assert calls[0].arguments == {"pattern": "TODO"}  # the partial `path` is gone
+
+
+def test_salvage_truncated_xml_prefers_a_complete_call_and_filters_unknown_names():
+    complete_then_cut = (
+        "<tool_call><function=list_files><parameter=recursive>true</parameter>"
+        "</function></tool_call>\n<tool_call>\n<function=grep>"
+    )
+    calls = _salvage_tool_calls_from_text(complete_then_cut, _TODO_TOOLS + _GREP_TOOL)
+    assert [c.name for c in calls] == ["list_files"]  # the finished one wins
+    # An unfinished call naming something we never offered stays text (no false positives).
+    assert _salvage_tool_calls_from_text("<function=rm_rf>\n<parameter=p>/", _TODO_TOOLS) == []
+
+
+def test_looks_like_unparsed_tool_call_ignores_code_and_needs_tools():
+    """Distinguishes a leaked call from a model *explaining* tool syntax — the latter is a real
+    answer and must not be turned into an error."""
+    leaked = "Let me read the files.\n</parameter>\n</function>\n</tool_call>"
+    assert looks_like_unparsed_tool_call(leaked, _TODO_TOOLS) is True
+    assert looks_like_unparsed_tool_call("A CLI that greets people.", _TODO_TOOLS) is False
+    fenced = "Qwen writes calls like:\n```\n<tool_call><function=x>\n```\nThat's the shape."
+    assert looks_like_unparsed_tool_call(fenced, _TODO_TOOLS) is False
+    assert looks_like_unparsed_tool_call("The `<tool_call>` wrapper.", _TODO_TOOLS) is False
+    assert looks_like_unparsed_tool_call(leaked, None) is False  # no tools offered → not a call
 
 
 def test_salvage_nested_braces_in_tag():


### PR DESCRIPTION
Two failures that both end a turn looking like the model simply stopped mid-sentence. Reported against `qwen3.5-9b` on LM Studio, but the cause is model-agnostic: small local models drift off the tool-call format, especially with a large tool schema in play.

Independent of #206 — this is a bug fix in the salvage path and the turn loop, and touches no provider descriptor. Either can land first.

## 1. Truncated calls are now recovered

`_salvage_tool_calls_from_text` already handled well-formed Qwen/Hermes XML, but gave up entirely on a call cut off partway through — which is exactly what a small model produces when it runs out of room mid-call.

It now takes the function name plus every parameter that actually closed. **A trailing unterminated `<parameter=…>` is dropped rather than guessed**, so a half-written path or file body can never reach a tool:

```
<function=grep><parameter=pattern>TODO</parameter><parameter=path>sr
  before: nothing salvaged
  after:  grep{pattern: "TODO"}     ← the partial `path` is discarded
```

If dropping it leaves a required argument missing, the call fails validation and the model gets a corrective tool error — the agent loop working, and strictly better than the turn dying on the fragment. Unknown tool names are still filtered, so there are no new false positives.

## 2. A leaked call is no longer reported as a completed answer

This is the worse half. When salvage found nothing, the turn ended `status: completed` — indistinguishable from the model deciding it was done. The user was left with narration trailing off into stray closing tags:

```
Let me start with the documentation files and package.json.

</parameter>
</function>
</tool_call>
```

It now ends on the **error path**, so the GUI offers Retry. That is the right affordance: the drift is probabilistic rather than deterministic, so retrying the same model usually succeeds. The message names the likely cause and suggests a larger model.

Detection strips fenced and inline code first — a model *explaining* tool-call syntax is giving a real answer and must not be turned into an error — and requires that tools were offered at all. Both directions are pinned by tests.

## Testing

`894 passed` (+5: three in `test_provider_router.py` for the salvage and detector edges, two in `test_engine.py` for the turn-end behaviour in both directions).

Also verified end-to-end against a live LM Studio: a real Developer-persona turn ran reasoning → `read_file` → answer → `completed`, with the new detector correctly silent on a legitimate answer.

Worth being straight about what I could **not** do: I couldn't force the leak on demand. Capping `max_tokens` truncates during narration, before the XML starts, and LM Studio's parser handles that boundary cleanly — which is itself evidence that this is genuine drift rather than a reproducible boundary condition. So the leak path is covered by unit tests against captured output, not by a live reproduction.

## Unrelated observation

`tests/test_automation.py::test_scheduler_runs_due_task_and_advances` is a pre-existing timing flake — it asserts on a 200 ms wall-clock window with a 50 ms tick, and misses occasionally under full-suite load. Passes in isolation every time. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)