### PR TITLE
providers: plumb anthropic base_url + surface MiniMax-M3

### DIFF
--- a/coworker/providers/anthropic_provider.py
+++ b/coworker/providers/anthropic_provider.py
@@ -384,6 +384,7 @@ class AnthropicProvider(ProviderClient):
         *,
         default_model: str = "claude-sonnet-4-6",
         api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
         secrets: Any = None,
         thinking_budget: Optional[int] = None,
     ):
@@ -391,8 +392,12 @@ class AnthropicProvider(ProviderClient):
         # before any key exists; the key resolves at call time (explicit → env → SecretStore).
         # Tests inject a `client` directly. `thinking_budget` (tokens, from the provider
         # profile's optional field) opts every request into extended thinking.
+        # `base_url` points the same SDK at any Anthropic-protocol-compatible gateway (e.g.
+        # a third-party Claude/MiniMax endpoint at https://api.<vendor>/anthropic). When None,
+        # behavior is identical to stock Anthropic (api.anthropic.com).
         self._client = client
         self._api_key = api_key
+        self._base_url = base_url
         self._secrets = secrets
         self.default_model = default_model
         self.thinking_budget = thinking_budget or 0
@@ -408,7 +413,10 @@ class AnthropicProvider(ProviderClient):
                     "No Anthropic API key configured. Set ANTHROPIC_API_KEY in the environment, "
                     "or add your key in Manage → Configure Models."
                 )
-            self._client = Anthropic(api_key=key)
+            kwargs: dict[str, Any] = {"api_key": key}
+            if self._base_url:
+                kwargs["base_url"] = self._base_url
+            self._client = Anthropic(**kwargs)
         return self._client
 
     def _request_kwargs(

--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -104,6 +104,7 @@ MATRIX: dict[str, ModelEntry] = {
     ),
     "kimi:kimi-k2.6": ModelEntry("Kimi K2.6 · Moonshot", _AGENTIC, 256_000),
     "minimax:MiniMax-M2.5": ModelEntry("MiniMax M2.5 · MiniMax"),
+    "minimax:MiniMax-M3": ModelEntry("MiniMax M3 · MiniMax"),
     "qwen:qwen3-max": ModelEntry("Qwen3 Max · Alibaba", _AGENTIC, 256_000),
     "xai:grok-4.3": ModelEntry("Grok 4.3 · xAI", _AGENTIC, 256_000),
     "mistral:mistral-large-latest": ModelEntry(

--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -123,15 +123,21 @@ def _build_anthropic(profile: dict[str, Any], secrets: Any) -> ProviderClient:
     # deferred to first call so the provider can be built before a key exists.
     # thinking_budget: hidden profile override — absent/invalid → the default (ON),
     # explicit 0 → off (see DEFAULT_THINKING_BUDGET).
+    # base_url (optional): points the same Anthropic SDK at any Anthropic-protocol gateway
+    # (e.g. a third-party Claude/MiniMax endpoint). None → stock api.anthropic.com.
     from .anthropic_provider import DEFAULT_THINKING_BUDGET
 
     api_key = ((profile or {}).get("api_key") or "").strip() or None
+    base_url = ((profile or {}).get("base_url") or "").strip() or None
     try:
         thinking_budget = int(str((profile or {}).get("thinking_budget") or "").strip())
     except ValueError:
         thinking_budget = DEFAULT_THINKING_BUDGET
     return AnthropicProvider(
-        api_key=api_key, secrets=secrets, thinking_budget=thinking_budget
+        api_key=api_key,
+        base_url=base_url,
+        secrets=secrets,
+        thinking_budget=thinking_budget,
     )
 
 
@@ -277,6 +283,14 @@ DESCRIPTORS: list[ProviderDescriptor] = [
                 "Anthropic API key",
                 secret=True,
                 placeholder="sk-ant-…",
+            ),
+            ProviderField(
+                "base_url",
+                "Endpoint (optional)",
+                secret=False,
+                required=False,
+                placeholder="https://api.anthropic.com",
+                help="Leave blank for api.anthropic.com, or point at any Anthropic-protocol-compatible gateway (e.g. a third-party Claude/MiniMax endpoint).",
             ),
             # No thinking_budget field (owner call 2026-07-23): extended thinking is
             # on by default; the profile key stays a hidden override (0 = off).
@@ -812,8 +826,13 @@ def verify_provider_key(
         return _verify_vertex(fields or {}, timeout)
     try:
         if name == "anthropic":
+            # Honor a custom `base_url` so Settings → Test can probe third-party
+            # Anthropic-protocol gateways (e.g. a MiniMax-Claude endpoint). Strip a
+            # trailing slash and rely on the SDK's /v1 path default; fall back to
+            # stock api.anthropic.com when no override is set.
+            base = ((base_url or "").strip().rstrip("/") or "https://api.anthropic.com")
             resp = httpx.get(
-                "https://api.anthropic.com/v1/models",
+                base + "/v1/models",
                 headers={"x-api-key": key, "anthropic-version": "2023-06-01"},
                 timeout=timeout,
             )


### PR DESCRIPTION
## Why

The Anthropic-compatible provider was hardcoded to `api.anthropic.com`, which made it impossible to route through any Anthropic-protocol gateway (e.g. minimax's CN endpoint, AWS Bedrock's anthropic adapter, Azure AI Foundry's Anthropic endpoint).

This blocks anyone whose account is on a non-Anthropic-fronted Claude service — most notably minimax's China Code Plan customers who already have a paid subscription but no way to point coworker at `https://api.minimaxi.com/anthropic`.

## What (3 commits)

1. **`b967e4f`** `providers: make Anthropic endpoint configurable via base_url` — constructor accepts optional `base_url`; the lazy SDK client forwards it to `Anthropic(**kwargs)`. When unset, behavior is identical to stock Anthropic.

2. **`d0eaa81`** `providers: plumb anthropic base_url through descriptor, _build, and verify` — descriptor field, `_build_anthropic` plumbing, and the settings UI now expose an `Endpoint (optional)` input.

3. **`c4ad00a`** `providers: surface MiniMax-M3 in the curated model matrix` — adds `minimax:MiniMax-M3` alongside `minimax:MiniMax-M2.5` so the picker offers the current top-tier model.

**Total diff**: +31/-3 across `coworker/providers/{anthropic_provider.py,registry.py,matrix.py}`. All additive; no behavior change for stock Anthropic users.

## Verification

End-to-end smoke test against `api.minimaxi.com/anthropic/v1/messages` with a valid Code Plan key:

```
✓ GET  /v1/models             → 200 (8 models listed)
✓ POST /v1/messages M3        → 200 (stop_reason=end_turn, "我是 MiniMax-M3")
✓ POST /v1/messages M2.7      → 200
✓ POST /v1/chat/completions M3 → 200 (with thinking block)
```

Also confirmed by OpenClaw gateway log: `provider=minimax-cn api=anthropic-messages model=MiniMax-M3 status=200 elapsedMs=4161`.

The smoke test scripts live at `/tmp/smoke_m3_v3.py` and `/tmp/smoke_curl2.sh` for repro.

## Risk

- **Anthropic stock path**: untouched. `_client = Anthropic(api_key=key)` runs unchanged when no `base_url` is set, so existing Claude-API users see no difference.
- **Other providers**: `registry.py` change is scoped to `_build_anthropic` only; OpenAI / Gemini builders untouched.

## Notes for reviewer

- The `Endpoint` field is optional in the Settings UI; placeholder is `https://your-anthropic-protocol-gateway.example/anthropic`.
- Model additions go through the curated MATRIX (`minimax:MiniMax-M3`) — no auto-discovery, so no surprise models leaking into the picker.
