### PR TITLE
fix: preserve exception chain in wait_dispatched timeout

### DIFF
--- a/coworker/connectors/relay_client.py
+++ b/coworker/connectors/relay_client.py
@@ -204,10 +204,10 @@ class RelayHub:
                 )
             try:
                 await asyncio.wait_for(self._progress.wait(), timeout=remaining)
-            except asyncio.TimeoutError:
+            except asyncio.TimeoutError as exc:
                 raise TimeoutError(
                     f"only {self._dispatched} frames dispatched (< {at_least})"
-                )
+                ) from exc
 
     # -- default transport ---------------------------------------------------
     def _default_transport_factory(self) -> RelayTransport:


### PR DESCRIPTION
## Summary
- `RelayHub.wait_dispatched` re-raised a fresh `TimeoutError` without chaining it to the caught `asyncio.TimeoutError`, so the original exception and its context were lost.
- Add `as exc` and `raise ... from exc` so `__cause__` is preserved, making flaky relay timeouts easier to debug.

Fixes #167

## Test plan
- [x] `pytest tests/test_slack_relay.py` — no new failures vs. baseline (the 4
  pre-existing timeouts are network/environment-related and unchanged by this fix)
- [x] Verified the raised `TimeoutError.__cause__` is now the original
  `asyncio.TimeoutError` (it was `None` before)
Before:
<img width="882" height="1099" alt="Snipaste_2026-07-27_11-04-58" src="https://github.com/user-attachments/assets/61604036-5784-4ac7-9858-d24a497af33f" />
After:
<img width="882" height="982" alt="Snipaste_2026-07-27_11-05-15" src="https://github.com/user-attachments/assets/3d864c52-fcb4-4e09-a1a6-fb4c21070b03" />

