### PR TITLE
fix: seed always_allowed_commands into permission engine for scheduled tasks

### DIFF
--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -2565,6 +2565,8 @@ class SessionManager:
         engine.permissions.task_rules = task.standing_rules()
         for tool in task.name_allowed_tools():
             engine.permissions.allow_tool_for_session(tool)
+        for cmd in task.always_allowed_commands:
+            engine.permissions.allow_command_for_session(cmd)
 
     def _build_task_engine(self, task, *, session_id: str) -> TurnEngine:
         ag = get_agent(task.agent)


### PR DESCRIPTION
The ScheduledTask model has an always_allowed_commands field, but it was never wired into the permission engine. `_seed_task_permissions` only seeded `always_allowed_tools`, so scheduled tasks with pre-approved shell commands still hung forever on approval.

The permission engine already supports session-level command allowlisting (`permissions.py:155` checks `session_allow_commands`), so the fix is to also call `allow_command_for_session(cmd)` for each entry.

Fixes #228