### PR TITLE
Fix macOS Python version check in setup_dev_env.sh (#42)

### DIFF
--- a/packaging/setup_dev_env.sh
+++ b/packaging/setup_dev_env.sh
@@ -10,7 +10,23 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VENV="$ROOT/.venv"
 
-python3 -m venv "$VENV"
+# macOS ships Python 3.9 which is too old — probe for a recent interpreter
+# or use `uv` (the fast Rust venv tool) which manages its own Python version.
+if command -v uv &>/dev/null; then
+  # uv creates the venv using whatever Python it manages (3.12+ guaranteed)
+  uv venv "$VENV"
+elif command -v python3.13 &>/dev/null; then
+  python3.13 -m venv "$VENV"
+elif command -v python3.12 &>/dev/null; then
+  python3.12 -m venv "$VENV"
+elif command -v python3.11 &>/dev/null; then
+  python3.11 -m venv "$VENV"
+elif command -v python3.10 &>/dev/null; then
+  python3.10 -m venv "$VENV"
+else
+  # fallback — will fail on macOS 3.9.x with a clear error
+  python3 -m venv "$VENV"
+fi
 # The coworker package (server, engine, connectors) + inbound-messaging extras.
 # aisuite comes in as a regular dependency (git-pinned in pyproject.toml until
 # the next PyPI release).


### PR DESCRIPTION
macOS ships Python 3.9.6 which is too old (requires >= 3.10). Probe for uv, python3.13/3.12/3.11/3.10 before falling back to the default python3.