### PR TITLE
Add timeout and error state to Settings tab getSettings() (#43)

### DIFF
--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -1202,9 +1202,15 @@ export async function setUnattended(
   return res.json();
 }
 
-export async function getSettings(): Promise<ModelSettings> {
-  const res = await fetch(`${httpBase()}/v1/settings`);
-  return res.json();
+export async function getSettings(timeout = 8_000): Promise<ModelSettings> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeout);
+  try {
+    const res = await fetch(`${httpBase()}/v1/settings`, { signal: ctrl.signal });
+    return res.json();
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export async function setModelKey(

--- a/surfaces/gui/src/components/ManageTabs.tsx
+++ b/surfaces/gui/src/components/ManageTabs.tsx
@@ -77,12 +77,20 @@ const EXAMPLE = `{
 // per-provider ModelChecklist / read-only model preview (form view).
 export function ModelsTab() {
   const [settings, setSettings] = useState<ModelSettings | null>(null);
-  const refreshSettings = () => getSettings().then(setSettings).catch(() => setSettings(null));
+  const [settingsError, setSettingsError] = useState<string | null>(null);
+  const refreshSettings = () => {
+    setSettingsError(null);
+    getSettings().then(setSettings).catch((e) => {
+      setSettings(null);
+      setSettingsError(e instanceof DOMException && e.name === "AbortError" ? "Request timed out — check that the server is running." : "Could not load settings.");
+    });
+  };
   const ps = useProviderSetup({ onSaved: refreshSettings });
   useEffect(() => {
     refreshSettings();
   }, []);
 
+  if (settingsError) return <div className="text-[13px] text-danger/80 p-4">{settingsError}</div>;
   if (!settings) return <div className="text-[13px] text-muted">Loading…</div>;
 
   const info = ps.info;


### PR DESCRIPTION
getSettings() had no timeout — an unreachable server would hang forever showing 'Loading...'. Add an 8-second AbortSignal timeout to the fetch, and a red error message with actionable text in the ModelsTab.