### PR TITLE
fix: wire up the Tauri opener plugin so external links actually open

### DIFF
--- a/surfaces/gui/src-tauri/Cargo.lock
+++ b/surfaces/gui/src-tauri/Cargo.lock
@@ -1937,6 +1937,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,6 +2684,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "open"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +2711,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
+ "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "uuid",
@@ -4073,6 +4104,28 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows 0.61.3",
+ "zbus",
 ]
 
 [[package]]

--- a/surfaces/gui/src-tauri/Cargo.toml
+++ b/surfaces/gui/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }

--- a/surfaces/gui/src-tauri/capabilities/default.json
+++ b/surfaces/gui/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:window:allow-set-focus",
     "core:window:allow-unminimize",
     "dialog:default",
-    "autostart:default"
+    "autostart:default",
+    "opener:allow-default-urls"
   ]
 }

--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -597,6 +597,7 @@ pub fn run() {
             show_main(app);
         }))
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,

--- a/surfaces/gui/src/tauri.openExternal.test.ts
+++ b/surfaces/gui/src/tauri.openExternal.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { openExternal } from "./tauri";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+it("opens the URL via the Tauri opener plugin when present, not window.open", async () => {
+  const openUrl = vi.fn().mockResolvedValue(undefined);
+  vi.stubGlobal("__TAURI__", { opener: { openUrl } });
+  const windowOpen = vi.fn();
+  vi.stubGlobal("open", windowOpen);
+
+  openExternal("https://console.anthropic.com/settings/keys");
+
+  expect(openUrl).toHaveBeenCalledWith("https://console.anthropic.com/settings/keys");
+  expect(windowOpen).not.toHaveBeenCalled();
+});
+
+it("falls back to window.open if the opener plugin call rejects", async () => {
+  const openUrl = vi.fn().mockRejectedValue(new Error("not permitted"));
+  vi.stubGlobal("__TAURI__", { opener: { openUrl } });
+  const windowOpen = vi.fn();
+  vi.stubGlobal("open", windowOpen);
+
+  openExternal("https://console.anthropic.com/settings/keys");
+  // the fallback runs in the rejection handler of the async openUrl() call
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(windowOpen).toHaveBeenCalledWith(
+    "https://console.anthropic.com/settings/keys",
+    "_blank",
+    "noopener,noreferrer",
+  );
+});
+
+it("uses window.open directly when no Tauri opener plugin is present (browser build)", () => {
+  vi.stubGlobal("__TAURI__", undefined);
+  const windowOpen = vi.fn();
+  vi.stubGlobal("open", windowOpen);
+
+  openExternal("https://ollama.com/download");
+
+  expect(windowOpen).toHaveBeenCalledWith("https://ollama.com/download", "_blank", "noopener,noreferrer");
+});

--- a/surfaces/gui/src/tauri.ts
+++ b/surfaces/gui/src/tauri.ts
@@ -125,9 +125,10 @@ export const clearPendingUpdate = () => invokeStrict<void>("clear_pending_update
  * Windows hands off to the installer). */
 export const installUpdate = () => invokeStrict<void>("install_update");
 
-/** Best-effort open a URL in the user's browser. Uses the Tauri opener plugin if present, else
- * `window.open`. The caller should also render the raw URL so it stays copyable if both no-op
- * (the desktop webview has no opener plugin wired yet). */
+/** Best-effort open a URL in the user's browser. Uses the Tauri opener plugin (now wired up
+ * with the `opener:allow-default-urls` capability, scoped to mailto:/tel:/http(s):) if
+ * present, else falls back to `window.open` for the browser build. The caller should also
+ * render the raw URL so it stays copyable in case both paths no-op for some reason. */
 export function openExternal(url: string): void {
   const opener = (globalThis as any).__TAURI__?.opener;
   if (opener?.openUrl) {


### PR DESCRIPTION
Fixes #227

## Root cause
`openExternal()` in `tauri.ts` already tried `window.__TAURI__.opener.openUrl()` first and fell back to `window.open()` — but `tauri-plugin-opener` was never actually wired into the desktop app: not added as a dependency, not registered as a plugin, and not granted a capability permission. So `__TAURI__.opener` was always `undefined` in the real app, and every external-link click silently fell through to `window.open()`, which does not open the OS browser from inside a Tauri webview for external URLs. This is exactly why clicking "Create one at console.anthropic.com" during Claude provider setup did nothing.

(The existing code comment on `openExternal()` actually said this outright: *"the desktop webview has no opener plugin wired yet"* — the JS-side fallback logic was already correct, it just never had anything to fall back *from*.)

## Fix
- Added `tauri-plugin-opener = "2"` as a dependency in `Cargo.toml`
- Registered it alongside the other plugins in `lib.rs` (`.plugin(tauri_plugin_opener::init())`)
- Granted the **scoped** `opener:allow-default-urls` capability (`mailto:`/`tel:`/`http://`/`https://` only) rather than the broader `opener:allow-open-url` — checked every `openExternal()` call site in `ProviderSetup.tsx` and all of them are plain `https://` links, so the narrower permission is sufficient and more defensible from a least-privilege standpoint
- Updated the now-stale code comment

## Tests
New `tauri.openExternal.test.ts` (3 tests) covering `openExternal()`'s three paths: opener plugin present and succeeds, opener plugin present but rejects (falls back to `window.open`), and no Tauri global at all (browser build).

## Verification — stated honestly, since I want to flag the gap rather than overclaim
I don't have a full Rust/Tauri build environment available (no GTK/webkit system libraries, no sudo to install them, no display) to build and click through the actual desktop app end-to-end. What I did verify:
- `cargo check` dependency resolution succeeded for `tauri-plugin-opener = "2"` — it got as far as compiling an unrelated transitive dependency (`libdbus-sys`) before failing on a missing system `pkg-config`, which is an environment limitation, not a problem with this change
- Cross-checked the exact plugin API (`tauri_plugin_opener::init()`) and the `opener:allow-default-urls` permission identifier directly against the fetched crate's own source (`~/.cargo/registry/src/.../tauri-plugin-opener-2.5.4`) and its permission TOML files, rather than guessing
- Full frontend suite: `npx vitest run` — 71/71 passing, no regressions
- `npx tsc --noEmit` — clean
- `cargo fmt --check` on the lines I touched — clean (there's a pre-existing, unrelated formatting complaint elsewhere in `lib.rs` on a clean checkout too, not introduced by this change)

**The one thing I can't personally confirm is the real end-to-end click-through in a running desktop build** — would appreciate someone with a full build environment smoke-testing this before merge (click the Anthropic console link on the Claude provider setup screen and confirm it opens the default browser).