### PR TITLE
docs: add Claude Code guidance files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# OpenWorker Development Guide
+
+## Repository Overview
+
+OpenWorker is a Python-based project with multiple application surfaces and supporting components.
+
+## Repository Structure
+
+- `coworker/` - Core application and backend functionality.
+- `surfaces/gui/` - GUI application and related frontend components.
+- `tests/` - Automated tests.
+- `stt/` - Speech-to-text functionality.
+- `ui-mocks/` - UI mock resources and components.
+- `packaging/` - Packaging and distribution configuration.
+- `docs/` - Project documentation.
+- `.github/` - GitHub workflows and repository configuration.
+
+## General Development Guidelines
+
+- Read the relevant existing code before making changes.
+- Keep changes focused on the requested issue.
+- Follow existing project structure and coding conventions.
+- Avoid unrelated refactoring or modifications.
+- Prefer small, focused changes that are easy to review.
+- Do not modify generated files unless the issue specifically requires it.
+- Preserve existing behavior outside the scope of the change.
+
+## Testing
+
+- Run relevant tests for the area being modified.
+- Run the full test suite when practical after making changes.
+- Do not consider a change complete until the relevant tests pass.
+
+## Pull Requests
+
+- Keep pull requests focused on one issue or feature.
+- Clearly describe what was changed and why.
+- Include the tests or validation performed.
+- Avoid unrelated changes in the same pull request.

--- a/coworker/CLAUDE.md
+++ b/coworker/CLAUDE.md
@@ -1,0 +1,32 @@
+# Coworker Development Guide
+
+## Overview
+
+The `coworker/` directory contains the core application and backend functionality of OpenWorker.
+
+## Guidelines
+
+- Understand the existing module and its dependencies before making changes.
+- Follow the existing architecture and coding patterns.
+- Keep changes limited to the requested functionality.
+- Avoid unnecessary refactoring.
+- Preserve existing public behavior unless the issue explicitly requires a change.
+- Reuse existing utilities and abstractions when appropriate instead of introducing duplicate implementations.
+- Handle errors consistently with the surrounding code.
+- Keep code readable and maintainable.
+
+## Testing
+
+When modifying code in this directory:
+
+1. Run the most relevant tests for the changed functionality.
+2. Run additional related tests when the change affects shared functionality.
+3. Run the full test suite when practical.
+
+## Change Validation
+
+Before submitting changes:
+
+- Check for linting or formatting issues.
+- Verify that imports and dependencies remain correct.
+- Confirm that existing functionality is not unintentionally broken.

--- a/surfaces/gui/CLAUDE.md
+++ b/surfaces/gui/CLAUDE.md
@@ -1,0 +1,33 @@
+# GUI Development Guide
+
+## Overview
+
+The `surfaces/gui/` directory contains the graphical user interface components of OpenWorker.
+
+## Guidelines
+
+- Understand the existing GUI structure before making changes.
+- Follow the existing component organization and conventions.
+- Keep UI changes focused on the requested issue.
+- Avoid unrelated changes to the GUI.
+- Reuse existing components and utilities where possible.
+- Preserve existing user workflows and behavior unless the issue requires a change.
+- Keep UI and application logic separated according to the existing project architecture.
+
+## Testing
+
+When modifying GUI functionality:
+
+- Test the affected functionality directly.
+- Run relevant automated tests when available.
+- Check that existing GUI behavior remains functional.
+- For changes affecting user interactions, verify the relevant user flow before submitting the change.
+
+## Change Validation
+
+Before submitting GUI changes:
+
+- Check for formatting or linting issues.
+- Verify that imports and dependencies are correct.
+- Ensure the change does not introduce unrelated UI regressions.
+- Keep the pull request focused on the requested GUI change.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,35 @@
+# Testing Guide
+
+## Overview
+
+The `tests/` directory contains automated tests for the OpenWorker project.
+
+## Guidelines
+
+- Add or update tests when changing application behavior.
+- Keep tests focused on the behavior being changed.
+- Follow the existing test organization and conventions.
+- Prefer clear and deterministic tests.
+- Avoid tests that depend unnecessarily on external services or unstable conditions.
+- Reuse existing test helpers and fixtures when appropriate.
+
+## Running Tests
+
+Run the tests relevant to the code being modified first.
+
+After making broader changes, run the complete test suite when practical.
+
+## Test Changes
+
+When adding a new feature:
+
+1. Add tests covering the expected behavior.
+2. Include important edge cases where appropriate.
+3. Verify that existing tests continue to pass.
+
+When fixing a bug:
+
+1. Add a regression test that reproduces the problem when practical.
+2. Make the smallest appropriate code change.
+3. Verify that the regression test passes.
+4. Run related tests to ensure the fix does not break existing behavior.


### PR DESCRIPTION
## Summary

Adds Claude Code guidance files at the repository root and key project areas.

## Changes

- Added root `CLAUDE.md` with repository-level development guidance.
- Added `coworker/CLAUDE.md` with guidance for core application development.
- Added `surfaces/gui/CLAUDE.md` with GUI development guidance.
- Added `tests/CLAUDE.md` with testing guidance.

## Testing

Documentation-only change. No application code was modified.