### PR TITLE
fix(gui): keep sidebar toggle stable during artifact preview

### DIFF
--- a/surfaces/gui/e2e/nav-collapse.spec.ts
+++ b/surfaces/gui/e2e/nav-collapse.spec.ts
@@ -29,6 +29,28 @@ test("⌘B toggles the sidebar collapse", async ({ page }) => {
   await expect(app).not.toHaveClass(/nav-collapsed/);
 });
 
+test("sidebar can stay expanded while an artifact preview is open", async ({ page }) => {
+  await page.goto("/");
+  const app = page.locator(".app");
+  await expect(page.locator(".sidebar")).toBeVisible();
+
+  // Opening a full preview auto-collapses the nav to make room.
+  await page.evaluate(() => {
+    window.dispatchEvent(
+      new CustomEvent("ocw-open-artifact", { detail: { path: "reports/summary.md" } }),
+    );
+  });
+  await expect(page.locator(".right-rail.artifact-mode")).toBeVisible();
+  await expect(app).toHaveClass(/nav-collapsed/);
+
+  // A manual toggle owns the state from this point on. The preview notification callback must
+  // stay referentially stable, or RightRail's effect fires again and immediately re-collapses it.
+  await page.getByRole("button", { name: "Show sidebar" }).click();
+  await page.waitForTimeout(250);
+  await expect(app).not.toHaveClass(/nav-collapsed/);
+  await expect(page.locator(".right-rail.artifact-mode")).toBeVisible();
+});
+
 test("RECENT header group/filter popover: switch grouping + see coworker filters", async ({
   page,
 }) => {

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -227,6 +227,8 @@ export function App() {
   const [navCollapsed, setNavCollapsed] = useState<boolean>(() => {
     try { return localStorage.getItem(NAV_COLLAPSED_KEY) === "1"; } catch { return false; }
   });
+  const navCollapsedRef = useRef(navCollapsed);
+  navCollapsedRef.current = navCollapsed;
   const [navPeek, setNavPeek] = useState(false);
   // While an artifact preview is open we auto-collapse the nav (#3). Remember the pre-preview
   // collapse state so we can restore it on close — unless the user re-opened the nav meanwhile.
@@ -244,14 +246,14 @@ export function App() {
   // user manually toggled meanwhile). The collapse is transient — it never overwrites the pref.
   const onArtifactPreview = useCallback((open: boolean) => {
     if (open) {
-      if (navBeforePreview.current === null) navBeforePreview.current = navCollapsed;
+      if (navBeforePreview.current === null) navBeforePreview.current = navCollapsedRef.current;
       setNavPeek(false);
       setNavCollapsed(true);
     } else if (navBeforePreview.current !== null) {
       setNavCollapsed(navBeforePreview.current);
       navBeforePreview.current = null;
     }
-  }, [navCollapsed]);
+  }, []);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "b") {


### PR DESCRIPTION
## Summary

  Fixes the sidebar flickering and immediately collapsing when expanded during an artifact preview.

  - Keeps the preview callback stable across navigation state changes
  - Preserves manual sidebar toggles while a preview remains open
  - Adds an end-to-end regression test

  Fixes #230