### PR TITLE
fix(gui): respect selected model readiness

### DIFF
--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1748,8 +1748,9 @@ class SessionManager:
                 return self._ollama_alive()
             return self._provider_configured(provider)
 
-        selectable = [m for m in self._curated_models() if _selectable(m)]
-        if self.model not in selectable:
+        ready_models = [m for m in self._curated_models() if _selectable(m)]
+        selectable = list(ready_models)
+        if self.model not in ready_models:
             selectable.insert(0, self.model)
         from ..providers.matrix import model_labels
 
@@ -1757,6 +1758,10 @@ class SessionManager:
             "provider": "openai",
             "model": self.model,
             "models": selectable,
+            # Models that can run right now.  `models` also retains the active default
+            # when its provider is unavailable, so the picker can explain the "No model"
+            # state; consumers must use this separate list for a session-selected model.
+            "ready_models": ready_models,
             # Curated-matrix display names ({full id → "GLM-5.2 · via Together"}) so every
             # picker shows human labels; custom models absent here render their raw id.
             "model_labels": model_labels(),

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -200,6 +200,10 @@ export function App() {
   // composer's "No model connected" chip. Default true so we don't flash the chip before settings
   // load; corrected by loadSettings.
   const [modelReady, setModelReady] = useState(true);
+  // `models` deliberately includes an unavailable default so the picker can show it. Keep
+  // the runnable set separately: sessions may select a different, ready provider (such as
+  // Ollama) without changing that global default.
+  const [readyModels, setReadyModels] = useState<string[] | null>(null);
   const [surface, setSurface] = useState<
     "session" | "scheduled" | "integrations" | "audit" | "inbox" | "persona" | "settings"
   >("session");
@@ -484,6 +488,7 @@ export function App() {
         setModels(s.models || []);
         setModelLabels(s.model_labels || {});
         setModelReady(s.model_ready);
+        setReadyModels(s.ready_models || null);
         if (s.surfaces) setSurfaces(s.surfaces);
       })
       .catch(() => {});
@@ -1523,7 +1528,7 @@ export function App() {
               modelLabels={modelLabels}
               running={running}
               connected={connected}
-              modelReady={modelReady}
+              modelReady={readyModels === null ? modelReady : readyModels.includes(model)}
               onConnectModel={openModelSetup}
               onConfigureVoiceInput={() => openSettings("voice")}
               onSend={send}

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -676,6 +676,8 @@ export interface ModelSettings {
   provider: string;
   model: string;
   models: string[];
+  // Models whose providers can run now. `models` also keeps an unavailable default visible.
+  ready_models?: string[];
   has_key: boolean;
   model_ready: boolean; // can the default model's provider actually run (any provider)?
   source: "env" | "store" | null;

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -173,4 +173,10 @@ def test_ollama_models_gated_on_liveness(tmp_path, monkeypatch):
     assert "ollama:llama3.3" not in manager.get_settings()["models"]
 
     monkeypatch.setattr(SessionManager, "_ollama_alive", lambda self: True)
-    assert "ollama:llama3.3" in manager.get_settings()["models"]
+    settings = manager.get_settings()
+    assert "ollama:llama3.3" in settings["models"]
+    # The default OpenAI model remains visible while unconfigured, but only the live
+    # Ollama selection may submit a session turn.
+    assert settings["model_ready"] is False
+    assert "gpt-5.6-sol" not in settings["ready_models"]
+    assert "ollama:llama3.3" in settings["ready_models"]


### PR DESCRIPTION
Fixes #180.

The composer previously derived readiness from the global default model. If that provider was not configured, selecting a live local model in the session could still route Send to model setup.

This change returns the currently runnable model ids from settings and uses that set for the selected session model.

Tests:
- pytest -q tests/test_settings.py
- npm test -- --run src/components/Composer.voice.test.tsx
- npm run build