### PR TITLE
Add Apify connector with local dataset cache and keyword search

### DIFF
--- a/coworker/connectors/apify_tools.py
+++ b/coworker/connectors/apify_tools.py
@@ -1,0 +1,333 @@
+"""Apify connector: cache one dataset locally so search doesn't re-fetch it.
+
+Read only. One connected account is one dataset. Refresh runs through a
+scheduled task calling apify_refresh_cache, not a background loop.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Any, Callable, Optional
+
+import aisuite as ai
+
+from ..secrets import SecretStore, state_dir
+from .record_cache import FieldMap, RecordCache
+
+_API = "https://api.apify.com/v2"
+_PAGE_SIZE = 1000
+_DEFAULT_MAX_RECORDS = 5000
+_MAX_MAX_RECORDS = 50_000
+_DEFAULT_SEARCH_LIMIT = 10
+_MAX_SEARCH_LIMIT = 100
+
+
+def _http(method: str, url: str, **kw: Any) -> dict[str, Any]:
+    """Call integration_tools._request, imported here rather than at module level
+    to avoid a circular import (integration_tools imports this module) and to keep
+    a single monkeypatch seam for tests."""
+    from . import integration_tools
+
+    return integration_tools._request(method, url, **kw)
+
+
+# -- tool metadata plumbing (same shape as the sibling connector modules) -----------
+def _meta(name: str, *, approval: bool, capabilities: list[str]):
+    return ai.ToolMetadata(
+        name=name,
+        category="connector",
+        risk_level="medium" if approval else "low",
+        capabilities=capabilities,
+        requires_approval=approval,
+    )
+
+
+def _schema(
+    name: str, description: str, properties: dict[str, Any], required: list[str]
+) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+            },
+        },
+    }
+
+
+def _attach(
+    fn: Callable[..., Any],
+    schema: dict[str, Any],
+    *,
+    approval: bool,
+    caps: list[str],
+):
+    from .tool_defs import approval_for_tool
+
+    name = schema["function"]["name"]
+    # §36: the tool registry's read/write kind wins for registered tools — reads
+    # never gate. All three Apify tools are registered "read" in tool_defs.py.
+    approval = approval_for_tool(name, default=approval)
+    fn.__name__ = name
+    fn.__coworker_schema__ = schema
+    fn.__aisuite_tool_metadata__ = _meta(name, approval=approval, capabilities=caps)
+    fn.__doc__ = schema["function"]["description"]
+    return fn
+
+
+_GEN_ACCOUNT_PROP = {
+    "type": "string",
+    "description": "Which connected dataset to use (default when empty)",
+}
+
+
+def _field_map(profile: dict[str, Any]) -> FieldMap:
+    text_fields = tuple(
+        f.strip()
+        for f in str(profile.get("text_fields") or "").split(",")
+        if f.strip()
+    )
+    return FieldMap(
+        key_field=str(profile.get("key_field") or "url").strip() or "url",
+        title_field=str(profile.get("title_field") or "title").strip() or "title",
+        url_field=str(profile.get("url_field") or "url").strip() or "url",
+        text_fields=text_fields,
+    )
+
+
+def _iso(ts: Optional[float]) -> Optional[str]:
+    if ts is None:
+        return None
+    return _dt.datetime.fromtimestamp(ts, tz=_dt.timezone.utc).isoformat()
+
+
+def make_apify_tools(
+    secrets: SecretStore, *, cache_path: Optional[str] = None
+) -> list[Callable[..., Any]]:
+    """Build the Apify tools. `cache_path` is injectable so tests point the cache
+    at a tmp_path file; the default resolves lazily inside each tool call (never
+    at factory-build time, and never before the "not connected" check), so calling
+    these tools against an empty SecretStore — which several existing tests do —
+    never creates a stray cache file on disk."""
+
+    def _cache() -> RecordCache:
+        return RecordCache(cache_path or str(state_dir() / "connector_cache.db"))
+
+    def _resolve(account: str):
+        """(account_id, profile, source_id, err). Runs before any cache access."""
+        from .integration_tools import _account_profile
+
+        aid, profile, err = _account_profile(
+            secrets, "apify", account, "api_token", "dataset_id"
+        )
+        if err:
+            return "", None, "", err
+        return aid, profile, f"apify:{aid}", None
+
+    def apify_refresh_cache(
+        max_records: int = _DEFAULT_MAX_RECORDS, account: str = ""
+    ) -> dict[str, Any]:
+        from .integration_tools import _acct_result, _bearer_headers, _clamp
+
+        aid, profile, source_id, err = _resolve(account)
+        if err:
+            return err
+        # profile["dataset_id"] — NEVER `aid` — is the value the API call needs.
+        # `aid` (the account id) is derived via accounts._norm(), which LOWERCASES
+        # it; Apify dataset ids are case-sensitive, so the stored, verbatim
+        # dataset_id is what must go in the URL.
+        dataset_id = profile["dataset_id"]
+        want = _clamp(max_records, _DEFAULT_MAX_RECORDS, _MAX_MAX_RECORDS)
+        headers = _bearer_headers(profile["api_token"])
+
+        items: list[Any] = []
+        offset = 0
+        while len(items) < want:
+            page = min(_PAGE_SIZE, want - len(items))
+            result = _http(
+                "GET",
+                f"{_API}/datasets/{dataset_id}/items",
+                headers=headers,
+                params={"clean": "true", "limit": page, "offset": offset},
+            )
+            if "error" in result:
+                return _acct_result(aid, result)
+            data = result.get("data")
+            if not isinstance(data, list):
+                return _acct_result(
+                    aid,
+                    {
+                        "error": "unexpected dataset payload; expected a JSON "
+                        "array of items",
+                        "details": type(data).__name__,
+                    },
+                )
+            items.extend(data)
+            if len(data) < page:
+                break  # short page — no more items
+            offset += len(data)
+
+        with _cache() as cache:
+            stats = cache.upsert(
+                source_id,
+                "apify",
+                items,
+                fmap=_field_map(profile),
+                label=dataset_id,
+            )
+
+        return _acct_result(
+            aid,
+            {
+                "ok": True,
+                "source": source_id,
+                "dataset_id": dataset_id,
+                "fetched": stats["fetched"],
+                "new": stats["new"],
+                "updated": stats["updated"],
+                "unchanged": stats["unchanged"],
+                "truncated": stats["truncated"],
+                "total_records": stats["total"],
+                "fetched_at": _iso(stats["fetched_at"]),
+                "search_mode": cache.search_mode,
+            },
+        )
+
+    apify_refresh_cache.__name__ = "apify_refresh_cache"
+    tools = [
+        _attach(
+            apify_refresh_cache,
+            _schema(
+                "apify_refresh_cache",
+                "Pull the connected Apify dataset into the local cache. Idempotent: "
+                "re-running adds no duplicates and reports how many records were "
+                "new vs updated. Run this once, then answer questions with "
+                "apify_search_cache instead of refreshing again.",
+                {
+                    "max_records": {"type": "integer"},
+                    "account": _GEN_ACCOUNT_PROP,
+                },
+                [],
+            ),
+            approval=False,
+            caps=["apify", "read"],
+        )
+    ]
+
+    def apify_search_cache(
+        query: str, max_results: int = _DEFAULT_SEARCH_LIMIT, account: str = ""
+    ) -> dict[str, Any]:
+        from .integration_tools import _acct_result, _clamp
+        from .record_cache import has_terms
+
+        aid, profile, source_id, err = _resolve(account)
+        if err:
+            return err
+        if not has_terms(query):
+            return {"error": "query has no searchable terms"}
+
+        limit = _clamp(max_results, _DEFAULT_SEARCH_LIMIT, _MAX_SEARCH_LIMIT)
+        with _cache() as cache:
+            rows, mode = cache.search(source_id, query, limit=limit)
+            status = cache.status(source_id)
+
+        if not rows and status["records"] == 0:
+            return _acct_result(
+                aid,
+                {
+                    "ok": True,
+                    "query": query,
+                    "search_mode": mode,
+                    "count": 0,
+                    "results": [],
+                    "hint": "cache is empty — run apify_refresh_cache first",
+                },
+            )
+
+        return _acct_result(
+            aid,
+            {
+                "ok": True,
+                "query": query,
+                "search_mode": mode,
+                "fetched_at": _iso(status["fetched_at"]),
+                "count": len(rows),
+                "results": [
+                    {
+                        "key": r.key,
+                        "title": r.title,
+                        "url": r.url,
+                        "rank": r.rank,
+                        "score": r.score,
+                        "snippet": r.snippet,
+                        "fields": r.data,
+                    }
+                    for r in rows
+                ],
+            },
+        )
+
+    apify_search_cache.__name__ = "apify_search_cache"
+    tools.append(
+        _attach(
+            apify_search_cache,
+            _schema(
+                "apify_search_cache",
+                "Keyword-search the locally cached Apify dataset records — ranked, "
+                "no network, no API quota. If the cache is empty, run "
+                "apify_refresh_cache first.",
+                {
+                    "query": {"type": "string"},
+                    "max_results": {"type": "integer"},
+                    "account": _GEN_ACCOUNT_PROP,
+                },
+                ["query"],
+            ),
+            approval=False,
+            caps=["apify", "read"],
+        )
+    )
+
+    def apify_cache_status(account: str = "") -> dict[str, Any]:
+        from .integration_tools import _acct_result
+
+        aid, profile, source_id, err = _resolve(account)
+        if err:
+            return err
+        with _cache() as cache:
+            status = cache.status(source_id)
+        return _acct_result(
+            aid,
+            {
+                "ok": True,
+                "source": source_id,
+                "dataset_id": profile["dataset_id"],
+                "records": status["records"],
+                "fetched_at": _iso(status["fetched_at"]),
+                "last_refresh": status["last_refresh"],
+                "search_mode": status["search_mode"],
+            },
+        )
+
+    apify_cache_status.__name__ = "apify_cache_status"
+    tools.append(
+        _attach(
+            apify_cache_status,
+            _schema(
+                "apify_cache_status",
+                "Report the local Apify cache: how many records are stored, when "
+                "it was last refreshed, and which search engine is active. "
+                "No network.",
+                {"account": _GEN_ACCOUNT_PROP},
+                [],
+            ),
+            approval=False,
+            caps=["apify", "read"],
+        )
+    )
+
+    return tools

--- a/coworker/connectors/catalog_copy.py
+++ b/coworker/connectors/catalog_copy.py
@@ -54,6 +54,11 @@ ABOUT: dict[str, str] = {
     "asana": "Keep up with your Asana work — search and read tasks and "
     "projects, create tasks, and comment. Connects with a personal access "
     "token from the Asana developer console.",
+    "apify": "Pull one Apify dataset — the output of a crawler or scraper you "
+    "already run — into a local cache on this machine, then answer questions "
+    "from that copy instead of re-fetching every time. One connected account "
+    "is one dataset: the agent reads that dataset and nothing else in your "
+    "Apify workspace.",
 }
 
 # What connecting actually grants, as short honest bullets. Write powers always
@@ -201,6 +206,13 @@ ACCESS: dict[str, list[str]] = {
     ],
     "hunter": [
         "Finds and verifies email addresses, using your Hunter quota.",
+    ],
+    "apify": [
+        "Reads items from the one Apify dataset you name — nothing else in your account.",
+        "Stores a copy of those items in a local cache on this machine so "
+        "questions are answered without re-fetching.",
+        "Refreshing the cache re-reads the dataset and uses your Apify API quota.",
+        "Never starts, stops, or edits Apify actors, runs, or storage.",
     ],
 }
 

--- a/coworker/connectors/descriptors.py
+++ b/coworker/connectors/descriptors.py
@@ -241,6 +241,15 @@ def _validate_hunter(creds: dict) -> ValidationResult:
     )
 
 
+def _validate_apify(creds: dict) -> ValidationResult:
+    return _validate_whoami(
+        "GET",
+        "https://api.apify.com/v2/users/me",
+        headers={"Authorization": f"Bearer {creds.get('api_token', '')}"},
+        identity=lambda d: "@" + str(d["data"]["username"]),
+    )
+
+
 def _validate_linear(creds: dict) -> ValidationResult:
     return _validate_whoami(
         "POST",
@@ -1426,6 +1435,88 @@ DESCRIPTORS: list[ConnectorDescriptor] = [
         brand_color="#fa5320",
         logo="hunter",
         account_field="@identity",
+    ),
+    ConnectorDescriptor(
+        name="apify",
+        title="Apify",
+        icon="◈",
+        blurb="Search data scraped by your Apify web crawler, cached locally.",
+        auth="api_token",
+        two_way=False,
+        fields=[
+            Field(
+                "api_token",
+                "API token",
+                secret=True,
+                help="Apify Console → Settings → API & Integrations → Personal API token.",
+                placeholder="apify_api_…",
+            ),
+            Field(
+                "dataset_id",
+                "Dataset",
+                help="Dataset id, or the stable username~dataset-name form. One "
+                "dataset per account — connect again to add another. "
+                "Case-sensitive — kept exactly as entered.",
+                placeholder="alice~job-openings",
+            ),
+            Field(
+                "key_field",
+                "Unique field",
+                required=False,
+                help="Field that identifies a record, so refreshes update instead "
+                "of duplicating. Dotted paths work (e.g. meta.id). Leave empty to "
+                "use 'url'; records with no value there fall back to a hash of "
+                "the whole item.",
+                placeholder="url",
+            ),
+            Field(
+                "title_field",
+                "Title field",
+                required=False,
+                help="Field shown as each result's title. Leave empty for 'title'.",
+                placeholder="title",
+            ),
+            Field(
+                "url_field",
+                "Link field",
+                required=False,
+                help="Field holding each record's link. Leave empty for 'url'.",
+                placeholder="url",
+            ),
+            Field(
+                "text_fields",
+                "Searchable fields",
+                required=False,
+                help="Comma-separated fields to index for search. Leave empty to "
+                "index every text value in the record.",
+                placeholder="title, description, location",
+            ),
+        ],
+        instructions=[
+            "In Apify Console, open Settings → API & Integrations and copy your "
+            "personal API token.",
+            "Open the dataset you want (Storage → Datasets, or an actor run's "
+            "output) and copy its id.",
+            "Leave the field settings empty unless the dataset has no `url` — "
+            "the defaults suit typical web-crawler output.",
+            "After connecting, ask the agent to refresh the cache once; later "
+            "questions are answered from the local copy without hitting Apify "
+            "again.",
+        ],
+        validate=_validate_apify,
+        brand_color="#97d700",
+        logo="apify",
+        aliases=(
+            "scraper",
+            "scraping",
+            "crawler",
+            "crawl",
+            "dataset",
+            "actor",
+            "web scraping",
+        ),
+        # One connected account == one cached dataset (tools call this a "source").
+        account_field="dataset_id",
     ),
     ConnectorDescriptor(
         name="pagerduty",

--- a/coworker/connectors/integration_tools.py
+++ b/coworker/connectors/integration_tools.py
@@ -19,6 +19,7 @@ from urllib.parse import quote
 import aisuite as ai
 
 from ..secrets import SecretStore
+from .apify_tools import make_apify_tools
 from .browser_automation import make_browser_automation_tools
 from .email_tools import make_email_tools
 from .tool_defs import approval_for_tool, connector_for_tool
@@ -529,6 +530,9 @@ def make_integration_tools(
     # Email needs the session roots: attachment downloads land in the primary scratch
     # and outgoing attachments must resolve inside a granted directory.
     tools.extend(make_email_tools(secrets, roots=roots))
+    # Apify's dataset reads plus the local FTS5 record cache are substantial
+    # non-HTTP logic, so they live in their own module (email_tools precedent).
+    tools.extend(make_apify_tools(secrets))
 
     def browser_read_url(url: str, max_chars: int = 20000) -> dict[str, Any]:
         if not url.lower().startswith(("http://", "https://")):

--- a/coworker/connectors/record_cache.py
+++ b/coworker/connectors/record_cache.py
@@ -1,0 +1,496 @@
+"""Local record cache with keyword (FTS5) search, not tied to any connector.
+
+Pulls an external dataset into a SQLite table once, then serves searches from
+that copy instead of re-fetching the source each time. Rows are scoped by
+source_id so multiple sources can share one cache file.
+
+upsert() is keyed on (source_id, record_key) and idempotent. Falls back to a
+LIKE scan if FTS5 isn't available.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+_MAX_TEXT_CHARS = 20_000
+_MAX_TITLE_CHARS = 500
+_MAX_URL_CHARS = 2_000
+
+_TOKEN_RE = re.compile(r"[\w][\w'-]*\*?", re.UNICODE)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS cache_sources (
+    source_id    TEXT PRIMARY KEY,
+    connector    TEXT NOT NULL,
+    label        TEXT NOT NULL DEFAULT '',
+    fetched_at   REAL,
+    record_count INTEGER NOT NULL DEFAULT 0,
+    data         TEXT NOT NULL DEFAULT '{}'
+);
+CREATE TABLE IF NOT EXISTS records (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id    TEXT NOT NULL,
+    record_key   TEXT NOT NULL,
+    title        TEXT NOT NULL DEFAULT '',
+    url          TEXT NOT NULL DEFAULT '',
+    search_text  TEXT NOT NULL DEFAULT '',
+    content_hash TEXT NOT NULL,
+    data         TEXT NOT NULL,
+    first_seen   REAL NOT NULL,
+    fetched_at   REAL NOT NULL,
+    UNIQUE(source_id, record_key)
+);
+CREATE INDEX IF NOT EXISTS idx_records_source ON records(source_id, fetched_at DESC);
+"""
+
+
+@dataclass(frozen=True)
+class FieldMap:
+    """Which fields of an arbitrary JSON item become the cache's indexed columns.
+
+    `key_field`/`title_field`/`url_field` are dotted paths ("meta.id", a numeric
+    segment indexes into a list). `text_fields` is a tuple of dotted paths to index
+    for search; an empty tuple means "flatten every string value in the item".
+    """
+
+    key_field: str = "url"
+    title_field: str = "title"
+    url_field: str = "url"
+    text_fields: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CachedRecord:
+    key: str
+    title: str
+    url: str
+    data: dict[str, Any]
+    rank: int  # 1-based position in this result set
+    score: float  # higher is better; 0.0 in "like" mode (no numeric score available)
+    snippet: str
+    fetched_at: float
+
+
+def extract(item: Any, path: str) -> Any:
+    """Dotted-path lookup ("meta.id", "items.0.name" — a numeric segment indexes a
+    list). Returns None on any miss instead of raising, since field-mapping config
+    is user-supplied and a wrong path must degrade gracefully, not crash a refresh."""
+    if not path:
+        return None
+    cur = item
+    for part in path.split("."):
+        if isinstance(cur, dict):
+            cur = cur.get(part)
+        elif isinstance(cur, (list, tuple)):
+            try:
+                idx = int(part)
+            except ValueError:
+                return None
+            if idx < 0 or idx >= len(cur):
+                return None
+            cur = cur[idx]
+        else:
+            return None
+        if cur is None:
+            return None
+    return cur
+
+
+def flatten_strings(value: Any) -> str:
+    """Every string leaf in `value`, newline-joined. Dict KEYS are excluded — they
+    are schema (field names), not content, and would pollute every query with the
+    item's own shape. No length cap here; callers cap the result themselves."""
+    parts: list[str] = []
+
+    def _walk(v: Any) -> None:
+        if isinstance(v, str):
+            s = v.strip()
+            if s:
+                parts.append(s)
+        elif isinstance(v, dict):
+            for vv in v.values():
+                _walk(vv)
+        elif isinstance(v, (list, tuple)):
+            for vv in v:
+                _walk(vv)
+        elif v is None or isinstance(v, bool):
+            return
+        elif isinstance(v, (int, float)):
+            return  # numbers alone are rarely useful search terms; skip them
+        else:
+            parts.append(str(v))
+
+    _walk(value)
+    return "\n".join(parts)
+
+
+def _canonical_json(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _content_hash(item: Any, title: str, url: str, search_text: str) -> str:
+    # Hashes the derived columns TOO, not just the raw item: if a user edits the
+    # field-mapping config (e.g. widens text_fields), the same raw item must count
+    # as "updated" so its derived columns aren't left stale behind an unchanged hash.
+    h = hashlib.sha256()
+    for part in (_canonical_json(item), title, url, search_text):
+        h.update(part.encode("utf-8"))
+        h.update(b"\x00")
+    return h.hexdigest()[:32]
+
+
+def map_item(item: Any, fmap: FieldMap) -> dict[str, Any]:
+    """Map one arbitrary JSON item to cache columns. Never raises, never drops data:
+    a missing/blank key field falls back to a stable hash of the whole item, so a
+    keyless dataset still caches (and re-runs stay idempotent) rather than losing
+    records or crashing the refresh."""
+    title = str(extract(item, fmap.title_field) or "")[:_MAX_TITLE_CHARS]
+    url = str(extract(item, fmap.url_field) or "")[:_MAX_URL_CHARS]
+
+    if fmap.text_fields:
+        parts = [flatten_strings(extract(item, f)) for f in fmap.text_fields]
+        full_text = "\n".join(p for p in parts if p)
+    else:
+        full_text = flatten_strings(item)
+    truncated = len(full_text) > _MAX_TEXT_CHARS
+    search_text = full_text[:_MAX_TEXT_CHARS]
+
+    key_raw = extract(item, fmap.key_field)
+    key = str(key_raw).strip() if key_raw not in (None, "") else ""
+    if not key:
+        key = "sha1:" + hashlib.sha1(_canonical_json(item).encode("utf-8")).hexdigest()[:16]
+
+    return {
+        "record_key": key,
+        "title": title,
+        "url": url,
+        "search_text": search_text,
+        "content_hash": _content_hash(item, title, url, search_text),
+        "data": _canonical_json(item),
+        "truncated": truncated,
+    }
+
+
+def _terms(query: str) -> list[str]:
+    return _TOKEN_RE.findall(query)
+
+
+def has_terms(query: str) -> bool:
+    """Whether `query` contains anything a search could match on — callers use this
+    to distinguish "no results" from "nothing to search for" before calling search()."""
+    return bool(_terms(query))
+
+
+def fts_query(raw: str) -> str:
+    """Sanitize free text into safe FTS5 MATCH syntax. A query fully wrapped in
+    double quotes becomes one quoted phrase; a token ending in '*' becomes a prefix
+    term; otherwise tokens are quoted and AND-joined. Returns "" for no searchable
+    terms. Without this, a query like "what's open?" is an FTS5 syntax error, not
+    a search."""
+    raw = raw.strip()
+    if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+        inner = raw[1:-1].strip()
+        return ('"' + inner.replace('"', '""') + '"') if inner else ""
+    parts = []
+    for tok in _terms(raw):
+        if tok.endswith("*") and len(tok) > 1:
+            parts.append('"' + tok[:-1].replace('"', '""') + '"*')
+        else:
+            parts.append('"' + tok.replace('"', '""') + '"')
+    return " AND ".join(parts)
+
+
+def _clean_term(term: str) -> str:
+    """Strip the FTS5 prefix-match suffix for LIKE-mode use — a literal trailing
+    '*' would never appear in cached text, so left uncleaned it would make the
+    term impossible to match in the fallback path."""
+    return term[:-1] if term.endswith("*") and len(term) > 1 else term
+
+
+def _like_snippet(text: str, terms: list[str], *, window: int = 100) -> str:
+    lower = text.lower()
+    pos = -1
+    for t in terms:
+        idx = lower.find(t.lower())
+        if idx != -1 and (pos == -1 or idx < pos):
+            pos = idx
+    if pos == -1:
+        return text[:window].strip()
+    start = max(0, pos - window // 2)
+    end = min(len(text), pos + window // 2)
+    return text[start:end].strip()
+
+
+class RecordCache:
+    """A local SQLite-backed cache of external records, keyword-searchable via
+    FTS5 (falling back to LIKE when FTS5 isn't compiled in). `path` is never
+    resolved internally — callers pass the full path (repo convention, see
+    `coworker/automation/store.py`, `coworker/memory/sqlite_store.py`) so the
+    store stays trivially testable against a tmp_path file."""
+
+    def __init__(self, path: str | Path, *, allow_fts5: bool = True) -> None:
+        self.path = str(path)
+        if self.path != ":memory:":
+            Path(self.path).expanduser().parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(self.path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+        self.search_mode = "like"
+        if allow_fts5:
+            try:
+                self._conn.execute(
+                    "CREATE VIRTUAL TABLE IF NOT EXISTS records_fts USING fts5("
+                    "title, search_text, tokenize='unicode61')"
+                )
+                self._conn.commit()
+                self.search_mode = "fts5"
+            except sqlite3.OperationalError:
+                self._conn.rollback()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> "RecordCache":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def upsert(
+        self,
+        source_id: str,
+        connector: str,
+        items: list[Any],
+        *,
+        fmap: FieldMap,
+        label: str = "",
+        fetched_at: Optional[float] = None,
+    ) -> dict[str, Any]:
+        """Idempotent upsert keyed on (source_id, record_key). One transaction, one
+        commit: a mid-batch failure leaves the cache exactly as it was before the
+        call, and it is far faster than committing per row."""
+        ts = fetched_at if fetched_at is not None else time.time()
+
+        seen: dict[str, dict[str, Any]] = {}
+        for item in items:
+            mapped = map_item(item, fmap)
+            seen.setdefault(mapped["record_key"], mapped)  # first occurrence wins
+
+        new = updated = unchanged = truncated = 0
+        with self._lock:
+            try:
+                self._conn.execute("BEGIN")
+                for key, mapped in seen.items():
+                    if mapped["truncated"]:
+                        truncated += 1
+                    row = self._conn.execute(
+                        "SELECT id, content_hash FROM records "
+                        "WHERE source_id = ? AND record_key = ?",
+                        (source_id, key),
+                    ).fetchone()
+                    if row is None:
+                        cur = self._conn.execute(
+                            "INSERT INTO records (source_id, record_key, title, url, "
+                            "search_text, content_hash, data, first_seen, fetched_at) "
+                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                            (
+                                source_id,
+                                key,
+                                mapped["title"],
+                                mapped["url"],
+                                mapped["search_text"],
+                                mapped["content_hash"],
+                                mapped["data"],
+                                ts,
+                                ts,
+                            ),
+                        )
+                        if self.search_mode == "fts5":
+                            self._conn.execute(
+                                "INSERT INTO records_fts (rowid, title, search_text) "
+                                "VALUES (?, ?, ?)",
+                                (cur.lastrowid, mapped["title"], mapped["search_text"]),
+                            )
+                        new += 1
+                    elif row["content_hash"] == mapped["content_hash"]:
+                        self._conn.execute(
+                            "UPDATE records SET fetched_at = ? WHERE id = ?",
+                            (ts, row["id"]),
+                        )
+                        unchanged += 1
+                    else:
+                        self._conn.execute(
+                            "UPDATE records SET title = ?, url = ?, search_text = ?, "
+                            "content_hash = ?, data = ?, fetched_at = ? WHERE id = ?",
+                            (
+                                mapped["title"],
+                                mapped["url"],
+                                mapped["search_text"],
+                                mapped["content_hash"],
+                                mapped["data"],
+                                ts,
+                                row["id"],
+                            ),
+                        )
+                        if self.search_mode == "fts5":
+                            self._conn.execute(
+                                "DELETE FROM records_fts WHERE rowid = ?", (row["id"],)
+                            )
+                            self._conn.execute(
+                                "INSERT INTO records_fts (rowid, title, search_text) "
+                                "VALUES (?, ?, ?)",
+                                (row["id"], mapped["title"], mapped["search_text"]),
+                            )
+                        updated += 1
+
+                total = self._conn.execute(
+                    "SELECT count(*) FROM records WHERE source_id = ?", (source_id,)
+                ).fetchone()[0]
+                stats = {
+                    "new": new,
+                    "updated": updated,
+                    "unchanged": unchanged,
+                    "truncated": truncated,
+                    "fetched": len(items),
+                    "total": total,
+                    "fetched_at": ts,
+                }
+                self._conn.execute(
+                    "INSERT INTO cache_sources (source_id, connector, label, "
+                    "fetched_at, record_count, data) VALUES (?, ?, ?, ?, ?, ?) "
+                    "ON CONFLICT(source_id) DO UPDATE SET connector = excluded.connector, "
+                    "label = excluded.label, fetched_at = excluded.fetched_at, "
+                    "record_count = excluded.record_count, data = excluded.data",
+                    (source_id, connector, label, ts, total, json.dumps(stats)),
+                )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+        return stats
+
+    def search(
+        self, source_id: str, query: str, *, limit: int = 10
+    ) -> tuple[list[CachedRecord], str]:
+        """Keyword search scoped to one source. Never touches the network — this
+        only ever reads the local table. Returns (results, search_mode)."""
+        terms = _terms(query)
+        if not terms:
+            return [], self.search_mode
+        limit = max(1, int(limit))
+
+        with self._lock:
+            if self.search_mode == "fts5":
+                fq = fts_query(query)
+                if not fq:
+                    return [], self.search_mode
+                rows = self._conn.execute(
+                    """
+                    SELECT r.record_key, r.title, r.url, r.data, r.fetched_at,
+                           bm25(records_fts, 5.0, 1.0) AS rnk,
+                           snippet(records_fts, 1, '', '', '…', 20) AS snip
+                      FROM records_fts
+                      JOIN records r ON r.id = records_fts.rowid
+                     WHERE records_fts MATCH ? AND r.source_id = ?
+                     ORDER BY rnk
+                     LIMIT ?
+                    """,
+                    (fq, source_id, limit),
+                ).fetchall()
+                results = [
+                    CachedRecord(
+                        key=row["record_key"],
+                        title=row["title"],
+                        url=row["url"],
+                        data=json.loads(row["data"]),
+                        rank=i,
+                        score=-float(row["rnk"]),
+                        snippet=row["snip"],
+                        fetched_at=row["fetched_at"],
+                    )
+                    for i, row in enumerate(rows, start=1)
+                ]
+                return results, "fts5"
+
+            stems = [_clean_term(t) for t in terms]
+            patterns = [f"%{s.lower()}%" for s in stems]
+            term_clauses = " AND ".join(
+                "(lower(title) LIKE ? OR lower(search_text) LIKE ?)" for _ in patterns
+            )
+            sql = (
+                "SELECT record_key, title, url, data, fetched_at, search_text, "
+                "(CASE WHEN lower(title) LIKE ? THEN 0 ELSE 1 END) AS rnk "
+                "FROM records WHERE source_id = ? AND " + term_clauses + " "
+                "ORDER BY rnk ASC, length(search_text) ASC, record_key ASC LIMIT ?"
+            )
+            params: list[Any] = [patterns[0], source_id]
+            for p in patterns:
+                params.extend([p, p])
+            params.append(limit)
+            rows = self._conn.execute(sql, params).fetchall()
+            results = [
+                CachedRecord(
+                    key=row["record_key"],
+                    title=row["title"],
+                    url=row["url"],
+                    data=json.loads(row["data"]),
+                    rank=i,
+                    score=0.0,
+                    snippet=_like_snippet(row["search_text"], stems),
+                    fetched_at=row["fetched_at"],
+                )
+                for i, row in enumerate(rows, start=1)
+            ]
+            return results, "like"
+
+    def status(self, source_id: str) -> dict[str, Any]:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM cache_sources WHERE source_id = ?", (source_id,)
+            ).fetchone()
+            count = self._conn.execute(
+                "SELECT count(*) FROM records WHERE source_id = ?", (source_id,)
+            ).fetchone()[0]
+        return {
+            "records": count,
+            "fetched_at": row["fetched_at"] if row else None,
+            "label": row["label"] if row else "",
+            "search_mode": self.search_mode,
+            "last_refresh": json.loads(row["data"]) if row and row["data"] else {},
+        }
+
+    def clear_source(self, source_id: str) -> int:
+        """Delete every row for one source. Not wired into any connector's
+        disconnect flow yet — exposed so a caller can prune orphaned rows
+        without a schema change."""
+        with self._lock:
+            ids = [
+                r[0]
+                for r in self._conn.execute(
+                    "SELECT id FROM records WHERE source_id = ?", (source_id,)
+                ).fetchall()
+            ]
+            if self.search_mode == "fts5":
+                for rid in ids:
+                    self._conn.execute(
+                        "DELETE FROM records_fts WHERE rowid = ?", (rid,)
+                    )
+            cur = self._conn.execute(
+                "DELETE FROM records WHERE source_id = ?", (source_id,)
+            )
+            self._conn.execute(
+                "DELETE FROM cache_sources WHERE source_id = ?", (source_id,)
+            )
+            self._conn.commit()
+        return cur.rowcount

--- a/coworker/connectors/tool_defs.py
+++ b/coworker/connectors/tool_defs.py
@@ -1089,6 +1089,30 @@ TOOL_DEFS: tuple[ConnectorToolDef, ...] = (
         "read",
         "Poll an export job for download URLs.",
     ),
+    # apify_refresh_cache only writes the local cache — nothing in the user's Apify
+    # account changes — so it's "read" like the others, and a scheduled hourly
+    # refresh can run unattended instead of parking on an approval card.
+    ConnectorToolDef(
+        "apify",
+        "apify_refresh_cache",
+        "Refresh cache",
+        "read",
+        "Pull the connected Apify dataset into the local cache (idempotent upsert).",
+    ),
+    ConnectorToolDef(
+        "apify",
+        "apify_search_cache",
+        "Search cache",
+        "read",
+        "Keyword-search the locally cached dataset records. Never hits the network.",
+    ),
+    ConnectorToolDef(
+        "apify",
+        "apify_cache_status",
+        "Cache status",
+        "read",
+        "Report cached record count, last refresh time, and search mode.",
+    ),
 )
 
 _KIND_BY_NAME = {d.name: d.kind for d in TOOL_DEFS}

--- a/tests/test_apify_connector.py
+++ b/tests/test_apify_connector.py
@@ -1,0 +1,321 @@
+"""Tests for the Apify connector — descriptor/registry wiring, tool behavior, and
+the sample scheduled-refresh task.
+
+No network (coworker.connectors.integration_tools._request is monkeypatched — the
+same seam tests/test_connectors.py uses) and no LLM. Every test gets its own
+tmp_path secrets file and cache DB file.
+"""
+
+from __future__ import annotations
+
+import coworker.connectors.integration_tools as it
+from coworker.automation import Schedule, ScheduledTask
+from coworker.connectors.apify_tools import make_apify_tools
+from coworker.connectors.descriptors import get_descriptor
+from coworker.connectors.tool_defs import TOOL_DEFS, approval_for_tool
+from coworker.secrets import SecretStore
+
+
+def _put_profile(secrets, **overrides):
+    fields = {"api_token": "apify_api_x", "dataset_id": "acme~jobs"}
+    fields.update(overrides)
+    secrets.put("apify:default", {**fields, "enabled": True})
+
+
+def _fake_request(pages, calls):
+    queue = list(pages)
+
+    def fake(method, url, *, headers=None, params=None, json=None, auth=None):
+        calls.append(
+            {"method": method, "url": url, "headers": headers or {}, "params": params}
+        )
+        if not queue:
+            return {"ok": True, "data": []}
+        page = queue.pop(0)
+        if isinstance(page, dict):
+            return page  # a raw {"error": ...} or a wrong-shape payload
+        # Mirror a real API: never return more than the caller's requested limit,
+        # even if the queued fixture page is larger.
+        want = (params or {}).get("limit")
+        if isinstance(want, int):
+            page = page[:want]
+        return {"ok": True, "data": page}
+
+    return fake
+
+
+def _tools(tmp_path, monkeypatch, pages=(), *, profile_overrides=None, cache_name="cache.db"):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    if profile_overrides is not False:
+        _put_profile(secrets, **(profile_overrides or {}))
+    calls: list = []
+    monkeypatch.setattr(it, "_request", _fake_request(pages, calls))
+    tools = {
+        t.__name__: t
+        for t in make_apify_tools(secrets, cache_path=str(tmp_path / cache_name))
+    }
+    return tools, calls
+
+
+# -- registry / descriptor wiring -------------------------------------------------
+def test_descriptor_registered_and_tools_are_read_only():
+    d = get_descriptor("apify")
+    assert d is not None
+    assert d.available is True
+    assert d.two_way is False
+    assert d.account_field == "dataset_id"
+    assert d.instructions
+    import re
+
+    assert re.match(r"^#[0-9a-fA-F]{6}$", d.brand_color)
+    assert d.logo == "apify"
+    assert d.validate is not None
+
+    apify_defs = [t for t in TOOL_DEFS if t.connector == "apify"]
+    names = {t.name for t in apify_defs}
+    assert names == {"apify_refresh_cache", "apify_search_cache", "apify_cache_status"}
+    assert all(t.kind == "read" for t in apify_defs)
+    assert all(approval_for_tool(t.name) is False for t in apify_defs)
+
+
+def test_validate_apify_identity(monkeypatch):
+    import coworker.connectors.descriptors as d
+
+    class _Resp:
+        def __init__(self, status, payload):
+            self.status_code = status
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    def fake(status, payload):
+        import httpx
+
+        monkeypatch.setattr(httpx, "request", lambda *a, **k: _Resp(status, payload))
+
+    fake(200, {"data": {"username": "alice"}})
+    res = d._validate_apify({"api_token": "t"})
+    assert res.ok and res.identity == "@alice"
+
+    fake(401, {"error": "token not found"})
+    res = d._validate_apify({"api_token": "bad"})
+    assert not res.ok and "not found" in res.error
+
+    fake(200, {})  # unexpected shape must not pass
+    res = d._validate_apify({"api_token": "bad"})
+    assert not res.ok
+
+
+# -- not-connected guard -----------------------------------------------------------
+def test_tools_error_when_not_connected(tmp_path, monkeypatch):
+    tools, calls = _tools(tmp_path, monkeypatch, profile_overrides=False)
+
+    assert "not connected" in tools["apify_refresh_cache"]()["error"]
+    assert "not connected" in tools["apify_search_cache"]("jobs")["error"]
+    assert "not connected" in tools["apify_cache_status"]()["error"]
+    assert calls == []
+    assert not (tmp_path / "cache.db").exists()  # guard runs before any cache access
+
+
+# -- refresh: upsert, idempotency, pagination --------------------------------------
+def test_refresh_upserts_and_is_idempotent(tmp_path, monkeypatch):
+    page = [
+        {"title": "Backend Engineer", "url": "https://x/1", "location": "Remote"},
+        {"title": "Data Scientist", "url": "https://x/2", "location": "NYC"},
+    ]
+    tools, calls = _tools(tmp_path, monkeypatch, pages=[page])
+    result = tools["apify_refresh_cache"]()
+    assert result["ok"] is True
+    assert result["new"] == 2 and result["updated"] == 0
+    assert result["total_records"] == 2
+    assert result["search_mode"] == "fts5"
+
+    tools2, calls2 = _tools(tmp_path, monkeypatch, pages=[page])
+    result2 = tools2["apify_refresh_cache"]()
+    assert result2["new"] == 0 and result2["updated"] == 0 and result2["unchanged"] == 2
+    assert result2["total_records"] == 2  # no duplicates
+
+
+def test_refresh_detects_updates(tmp_path, monkeypatch):
+    v1 = [{"title": "Backend Engineer", "url": "https://x/1", "desc": "Python role"}]
+    tools, _ = _tools(tmp_path, monkeypatch, pages=[v1])
+    tools["apify_refresh_cache"]()
+
+    v2 = [{"title": "Backend Engineer", "url": "https://x/1", "desc": "Golang role"}]
+    tools2, _ = _tools(tmp_path, monkeypatch, pages=[v2])
+    result = tools2["apify_refresh_cache"]()
+    assert result["new"] == 0 and result["updated"] == 1
+
+    search_result = tools2["apify_search_cache"]("golang")
+    assert search_result["count"] == 1
+
+
+def test_refresh_paginates_until_short_page(tmp_path, monkeypatch):
+    page1 = [{"title": f"Role {i}", "url": f"https://x/{i}"} for i in range(1000)]
+    page2 = [{"title": f"Role {i}", "url": f"https://x/{i}"} for i in range(1000, 2000)]
+    page3 = [{"title": "Role 2000", "url": "https://x/2000"}]  # short — stops the loop
+    tools, calls = _tools(tmp_path, monkeypatch, pages=[page1, page2, page3])
+
+    result = tools["apify_refresh_cache"](max_records=10_000)
+    assert result["fetched"] == 2001
+    offsets = [c["params"]["offset"] for c in calls]
+    assert offsets == [0, 1000, 2000]
+
+
+def test_refresh_max_records_caps_pagination(tmp_path, monkeypatch):
+    page1 = [{"title": f"Role {i}", "url": f"https://x/{i}"} for i in range(1000)]
+    page2 = [{"title": f"Role {i}", "url": f"https://x/{i}"} for i in range(1000, 2000)]
+    tools, calls = _tools(tmp_path, monkeypatch, pages=[page1, page2])
+
+    result = tools["apify_refresh_cache"](max_records=1500)
+    assert result["fetched"] == 1500
+    assert len(calls) == 2  # stops once `want` items collected, no third page fetched
+
+
+def test_refresh_rejects_non_list_payload(tmp_path, monkeypatch):
+    tools, _ = _tools(tmp_path, monkeypatch, pages=[{"ok": True, "data": {"oops": True}}])
+    result = tools["apify_refresh_cache"]()
+    assert "error" in result
+    status = tools["apify_cache_status"]()
+    assert status["records"] == 0  # cache untouched
+
+
+def test_refresh_http_error_leaves_cache_intact(tmp_path, monkeypatch):
+    good = [{"title": "Engineer", "url": "https://x/1"}]
+    tools, _ = _tools(tmp_path, monkeypatch, pages=[good])
+    tools["apify_refresh_cache"]()
+
+    tools2, _ = _tools(tmp_path, monkeypatch, pages=[{"error": "HTTP 401"}])
+    result = tools2["apify_refresh_cache"]()
+    assert result["error"] == "HTTP 401"
+    status = tools2["apify_cache_status"]()
+    assert status["records"] == 1  # unchanged from the earlier successful refresh
+
+
+def test_missing_key_field_falls_back_to_hash_and_drops_nothing(tmp_path, monkeypatch):
+    items = [{"title": "No URL role A"}, {"title": "No URL role A"}, {"title": "No URL role B"}]
+    tools, _ = _tools(tmp_path, monkeypatch, pages=[items])
+    result = tools["apify_refresh_cache"]()
+    # two identical items collapse to one row; the distinct one is separate — 2 total
+    assert result["total_records"] == 2
+
+    tools2, _ = _tools(tmp_path, monkeypatch, pages=[items])
+    result2 = tools2["apify_refresh_cache"]()
+    assert result2["new"] == 0 and result2["total_records"] == 2  # stable across runs
+
+
+def test_dataset_id_case_preserved_despite_lowercased_account(tmp_path, monkeypatch):
+    tools, calls = _tools(
+        tmp_path,
+        monkeypatch,
+        pages=[[{"title": "Engineer", "url": "https://x/1"}]],
+        profile_overrides={"dataset_id": "AcMe~JobsMixedCase"},
+    )
+    result = tools["apify_refresh_cache"]()
+    assert result["dataset_id"] == "AcMe~JobsMixedCase"
+    assert result["account"] == "acme~jobsmixedcase"  # accounts._norm lowercases it
+    assert "AcMe~JobsMixedCase" in calls[0]["url"]  # request used the original case
+
+
+# -- search -------------------------------------------------------------------------
+def test_search_ranks_and_scopes_per_account(tmp_path, monkeypatch):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    secrets.put(
+        "apify:account:acme~jobs",
+        {"api_token": "t", "dataset_id": "acme~jobs", "account": "acme~jobs"},
+    )
+    secrets.put(
+        "apify:account:other~jobs",
+        {"api_token": "t", "dataset_id": "other~jobs", "account": "other~jobs"},
+    )
+    calls: list = []
+    monkeypatch.setattr(
+        it,
+        "_request",
+        _fake_request(
+            [
+                [{"title": "Engineering Manager", "url": "https://a/1"}],
+                [{"title": "Support engineering ticket", "url": "https://b/1"}],
+            ],
+            calls,
+        ),
+    )
+    tools = {
+        t.__name__: t
+        for t in make_apify_tools(secrets, cache_path=str(tmp_path / "cache.db"))
+    }
+    tools["apify_refresh_cache"](account="acme~jobs")
+    tools["apify_refresh_cache"](account="other~jobs")
+
+    r1 = tools["apify_search_cache"]("engineering", account="acme~jobs")
+    r2 = tools["apify_search_cache"]("engineering", account="other~jobs")
+    assert r1["count"] == 1 and r1["results"][0]["url"] == "https://a/1"
+    assert r1["account"] == "acme~jobs"
+    assert r2["count"] == 1 and r2["results"][0]["url"] == "https://b/1"
+
+
+def test_search_never_touches_network(tmp_path, monkeypatch):
+    tools, _ = _tools(
+        tmp_path, monkeypatch, pages=[[{"title": "Engineer", "url": "https://x/1"}]]
+    )
+    tools["apify_refresh_cache"]()
+
+    def _boom(*a, **kw):
+        raise AssertionError("apify_search_cache must never call the network")
+
+    monkeypatch.setattr(it, "_request", _boom)
+    result = tools["apify_search_cache"]("engineer")
+    assert result["count"] == 1
+
+
+def test_search_empty_cache_hints_to_refresh(tmp_path, monkeypatch):
+    tools, _ = _tools(tmp_path, monkeypatch, pages=[])
+    result = tools["apify_search_cache"]("anything")
+    assert result["ok"] is True
+    assert result["results"] == []
+    assert "refresh" in result["hint"]
+
+
+def test_search_no_terms_returns_error(tmp_path, monkeypatch):
+    tools, _ = _tools(tmp_path, monkeypatch)
+    result = tools["apify_search_cache"]("???")
+    assert "no searchable terms" in result["error"]
+
+
+# -- status ---------------------------------------------------------------------
+def test_cache_status_before_and_after_refresh(tmp_path, monkeypatch):
+    tools, _ = _tools(
+        tmp_path, monkeypatch, pages=[[{"title": "Engineer", "url": "https://x/1"}]]
+    )
+    before = tools["apify_cache_status"]()
+    assert before["records"] == 0 and before["fetched_at"] is None
+
+    tools["apify_refresh_cache"]()
+    after = tools["apify_cache_status"]()
+    assert after["records"] == 1
+    assert after["fetched_at"] is not None
+    assert after["search_mode"] == "fts5"
+    assert after["last_refresh"]["new"] == 1
+
+
+# -- sample scheduled-refresh task -------------------------------------------------
+def test_hourly_refresh_scheduled_task_shape(tmp_path):
+    task = ScheduledTask(
+        title="Refresh Apify cache",
+        instructions=(
+            "Call apify_refresh_cache to pull the latest items from the connected "
+            "Apify dataset into the local cache, then report how many records "
+            "were added or updated."
+        ),
+        schedule=Schedule(kind="cron", cron="0 * * * *"),
+        workspace=str(tmp_path),
+    )
+    assert "apify_refresh_cache" in task.instructions
+    # timing belongs in cron, never restated in the prompt text
+    for word in ("hour", "hourly", "every"):
+        assert word not in task.instructions.lower()
+    assert task.task_session_id == f"__task__{task.id}"
+    # refresh is kind="read" -> never gated -> nothing needs pre-granting
+    assert approval_for_tool("apify_refresh_cache") is False
+    assert task.always_allowed_tools == []

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -749,6 +749,9 @@ _NEW_CONNECTORS = {
         "base_uri": "https://demo.docusign.net",
     },
     "canva": {"access_token": "cnv_x"},
+    # Batch 4 — cached-dataset connector (flat :default on purpose, see posthog
+    # comment above; the accounts layer migrates it lazily on first tool call).
+    "apify": {"api_token": "apify_api_x", "dataset_id": "acme~jobs"},
 }
 
 
@@ -772,6 +775,8 @@ def test_new_connector_descriptors_listed(tmp_path):
     # google_drive (scope discipline) and canva (exports are renders) too
     assert all(t["kind"] == "read" for t in by_name["google_drive"]["tools"])
     assert all(t["kind"] == "read" for t in by_name["canva"]["tools"])
+    # apify: refresh only writes the LOCAL cache, nothing external mutates
+    assert all(t["kind"] == "read" for t in by_name["apify"]["tools"])
 
 
 def test_new_connectors_connect_and_gate_tools(tmp_path):
@@ -823,6 +828,7 @@ def test_new_tools_error_when_not_connected(tmp_path):
     assert "not connected" in tools["drive_search_files"]("plan")["error"]
     assert "not connected" in tools["docusign_list_envelopes"]()["error"]
     assert "not connected" in tools["canva_list_designs"]()["error"]
+    assert "not connected" in tools["apify_search_cache"]("jobs")["error"]
 
 
 def _connected_tools(tmp_path, monkeypatch, calls):
@@ -1569,6 +1575,7 @@ def test_new_connector_validators_wired():
         "google_drive",
         "docusign",
         "canva",
+        "apify",
     ):
         assert get_descriptor(name).validate is not None, name
     # stripe restricted-key permissions vary, so it has no whoami validator

--- a/tests/test_record_cache.py
+++ b/tests/test_record_cache.py
@@ -1,0 +1,269 @@
+"""Tests for the generic (connector-agnostic) local record cache.
+
+No network, no LLM — this only exercises SQLite + FTS5/LIKE search directly.
+Every test gets its own tmp_path DB file; ":memory:" is never used because these
+stores are meant to be reopened across calls (mirroring how apify_tools opens a
+short-lived connection per tool call).
+"""
+
+from __future__ import annotations
+
+from coworker.connectors.record_cache import (
+    FieldMap,
+    RecordCache,
+    extract,
+    flatten_strings,
+    fts_query,
+    has_terms,
+    map_item,
+)
+
+
+# -- pure helpers ----------------------------------------------------------------
+def test_extract_dotted_path_and_list_index():
+    item = {"meta": {"id": "abc"}, "items": [{"name": "first"}, {"name": "second"}]}
+    assert extract(item, "meta.id") == "abc"
+    assert extract(item, "items.1.name") == "second"
+    assert extract(item, "missing.path") is None
+    assert extract(item, "items.9.name") is None
+    assert extract({"a": 1}, "a.b") is None  # can't descend into a non-container
+
+
+def test_flatten_strings_excludes_keys_and_numbers():
+    text = flatten_strings(
+        {"title": "Senior Engineer", "count": 3, "tags": ["python", "remote"]}
+    )
+    assert "Senior Engineer" in text
+    assert "python" in text and "remote" in text
+    assert "title" not in text  # keys are schema, not content
+    assert "count" not in text and "3" not in text  # bare numbers excluded
+
+
+def test_map_item_uses_configured_fields():
+    fmap = FieldMap(
+        key_field="url", title_field="title", url_field="url", text_fields=("title",)
+    )
+    mapped = map_item({"title": "Backend Engineer", "url": "https://x/1"}, fmap)
+    assert mapped["record_key"] == "https://x/1"
+    assert mapped["title"] == "Backend Engineer"
+    assert mapped["search_text"] == "Backend Engineer"
+
+
+def test_map_item_missing_key_falls_back_to_stable_hash():
+    fmap = FieldMap()
+    mapped_a = map_item({"title": "No URL role"}, fmap)
+    mapped_b = map_item({"title": "No URL role"}, fmap)
+    assert mapped_a["record_key"].startswith("sha1:")
+    assert mapped_a["record_key"] == mapped_b["record_key"]  # stable, not random
+
+    mapped_c = map_item({"title": "Different role"}, fmap)
+    assert mapped_c["record_key"] != mapped_a["record_key"]
+
+
+def test_has_terms_and_fts_query():
+    assert has_terms("engineering roles")
+    assert not has_terms("???")
+    assert not has_terms("")
+    assert fts_query('"exact phrase"') == '"exact phrase"'
+    assert fts_query("what's open?") == '"what\'s" AND "open"'
+    assert fts_query("eng*") == '"eng"*'
+    assert fts_query("???") == ""
+
+
+# -- RecordCache: upsert idempotency ---------------------------------------------
+def test_upsert_is_idempotent_and_no_duplicates(tmp_path):
+    cache = RecordCache(tmp_path / "cache.db")
+    items = [
+        {"title": "Backend Engineer", "url": "https://x/1", "location": "Remote"},
+        {"title": "Data Scientist", "url": "https://x/2", "location": "NYC"},
+    ]
+    fmap = FieldMap()
+
+    stats1 = cache.upsert("apify:acme", "apify", items, fmap=fmap)
+    assert stats1["new"] == 2 and stats1["updated"] == 0 and stats1["total"] == 2
+
+    stats2 = cache.upsert("apify:acme", "apify", items, fmap=fmap)
+    assert stats2["new"] == 0
+    assert stats2["updated"] == 0
+    assert stats2["unchanged"] == 2
+    assert stats2["total"] == 2  # still 2 rows, no duplicates
+
+    cache.close()
+
+
+def test_upsert_detects_updates_and_refreshes_fts(tmp_path):
+    cache = RecordCache(tmp_path / "cache.db")
+    fmap = FieldMap()
+    v1 = [{"title": "Backend Engineer", "url": "https://x/1", "desc": "Python role"}]
+    cache.upsert("apify:acme", "apify", v1, fmap=fmap)
+
+    results, _ = cache.search("apify:acme", "python")
+    assert len(results) == 1
+
+    v2 = [{"title": "Backend Engineer", "url": "https://x/1", "desc": "Golang role"}]
+    stats = cache.upsert("apify:acme", "apify", v2, fmap=fmap)
+    assert stats["new"] == 0 and stats["updated"] == 1 and stats["unchanged"] == 0
+
+    # old text no longer matches, new text does — proves the FTS index was resynced
+    assert cache.search("apify:acme", "python")[0] == []
+    golang_hits, _ = cache.search("apify:acme", "golang")
+    assert len(golang_hits) == 1
+    assert golang_hits[0].key == "https://x/1"
+
+    cache.close()
+
+
+def test_duplicate_record_key_within_one_batch_collapses(tmp_path):
+    cache = RecordCache(tmp_path / "cache.db")
+    items = [
+        {"title": "A", "url": "https://x/1"},
+        {"title": "A again", "url": "https://x/1"},  # same key, later in the batch
+    ]
+    stats = cache.upsert("apify:acme", "apify", items, fmap=FieldMap())
+    assert stats["new"] == 1 and stats["total"] == 1
+    cache.close()
+
+
+def test_upsert_scoped_per_source(tmp_path):
+    cache = RecordCache(tmp_path / "cache.db")
+    fmap = FieldMap()
+    cache.upsert(
+        "apify:one", "apify", [{"title": "Role One", "url": "https://a/1"}], fmap=fmap
+    )
+    cache.upsert(
+        "apify:two", "apify", [{"title": "Role Two", "url": "https://b/1"}], fmap=fmap
+    )
+
+    one, _ = cache.search("apify:one", "role")
+    two, _ = cache.search("apify:two", "role")
+    assert {r.key for r in one} == {"https://a/1"}
+    assert {r.key for r in two} == {"https://b/1"}
+    cache.close()
+
+
+# -- RecordCache: search ranking --------------------------------------------------
+def test_search_ranks_title_matches_first(tmp_path):
+    cache = RecordCache(tmp_path / "cache.db")
+    items = [
+        {"title": "Engineering Manager", "url": "https://x/1", "desc": "leads a team"},
+        {"title": "Sales Lead", "url": "https://x/2", "desc": "engineering support role"},
+        {"title": "Support Rep", "url": "https://x/3", "desc": "handles engineering tickets"},
+    ]
+    cache.upsert("apify:acme", "apify", items, fmap=FieldMap())
+
+    results, mode = cache.search("apify:acme", "engineering")
+    assert mode == "fts5"
+    assert len(results) == 3
+    assert results[0].key == "https://x/1"  # title match ranks first
+    assert [r.rank for r in results] == [1, 2, 3]
+    cache.close()
+
+
+def test_search_never_touches_network(tmp_path, monkeypatch):
+    cache = RecordCache(tmp_path / "cache.db")
+    cache.upsert(
+        "apify:acme",
+        "apify",
+        [{"title": "Engineer", "url": "https://x/1"}],
+        fmap=FieldMap(),
+    )
+
+    def _boom(*a, **kw):
+        raise AssertionError("search must never make a network call")
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "request", _boom)
+    monkeypatch.setattr(httpx, "get", _boom)
+    results, _ = cache.search("apify:acme", "engineer")
+    assert len(results) == 1
+    cache.close()
+
+
+def test_search_no_terms_returns_empty(tmp_path):
+    cache = RecordCache(tmp_path / "cache.db")
+    cache.upsert(
+        "apify:acme", "apify", [{"title": "Engineer", "url": "https://x/1"}], fmap=FieldMap()
+    )
+    results, _ = cache.search("apify:acme", "???")
+    assert results == []
+    cache.close()
+
+
+def test_dotted_paths_and_text_fields_scope_search(tmp_path):
+    cache = RecordCache(tmp_path / "cache.db")
+    fmap = FieldMap(
+        key_field="meta.id",
+        title_field="meta.title",
+        url_field="meta.link",
+        text_fields=("meta.title",),
+    )
+    items = [
+        {
+            "meta": {"id": "r1", "title": "Engineer", "link": "https://x/1"},
+            "hidden": "unsearchable secret text",
+        }
+    ]
+    cache.upsert("apify:acme", "apify", items, fmap=fmap)
+
+    hits, _ = cache.search("apify:acme", "engineer")
+    assert len(hits) == 1 and hits[0].key == "r1"
+    # a term present only in an unmapped field must not match
+    hidden_hits, _ = cache.search("apify:acme", "secret")
+    assert hidden_hits == []
+    cache.close()
+
+
+# -- FTS5 vs LIKE fallback ---------------------------------------------------------
+def test_like_fallback_matches_fts5_result_set_and_is_deterministic(tmp_path):
+    items = [
+        {"title": "Engineering Manager", "url": "https://x/1", "desc": "leads a team"},
+        {"title": "Sales Lead", "url": "https://x/2", "desc": "engineering support role"},
+        {"title": "Support Rep", "url": "https://x/3", "desc": "handles engineering tickets"},
+    ]
+
+    fts = RecordCache(tmp_path / "fts.db", allow_fts5=True)
+    fts.upsert("apify:acme", "apify", items, fmap=FieldMap())
+    fts_hits, fts_mode = fts.search("apify:acme", "engineering")
+    fts.close()
+
+    like = RecordCache(tmp_path / "like.db", allow_fts5=False)
+    like.upsert("apify:acme", "apify", items, fmap=FieldMap())
+    like_hits1, like_mode = like.search("apify:acme", "engineering")
+    like_hits2, _ = like.search("apify:acme", "engineering")
+    like.close()
+
+    assert fts_mode == "fts5"
+    assert like_mode == "like"
+    assert {r.key for r in fts_hits} == {r.key for r in like_hits1}
+    # deterministic ordering across repeated calls
+    assert [r.key for r in like_hits1] == [r.key for r in like_hits2]
+    assert like_hits1[0].key == "https://x/1"  # title match still ranked first
+
+
+def test_cache_status_reports_counts_and_time(tmp_path):
+    cache = RecordCache(tmp_path / "cache.db")
+    empty = cache.status("apify:acme")
+    assert empty["records"] == 0 and empty["fetched_at"] is None
+
+    cache.upsert(
+        "apify:acme", "apify", [{"title": "Engineer", "url": "https://x/1"}], fmap=FieldMap()
+    )
+    status = cache.status("apify:acme")
+    assert status["records"] == 1
+    assert status["fetched_at"] is not None
+    assert status["last_refresh"]["new"] == 1
+    cache.close()
+
+
+def test_clear_source_removes_only_that_source(tmp_path):
+    cache = RecordCache(tmp_path / "cache.db")
+    fmap = FieldMap()
+    cache.upsert("apify:one", "apify", [{"title": "A", "url": "https://a/1"}], fmap=fmap)
+    cache.upsert("apify:two", "apify", [{"title": "B", "url": "https://b/1"}], fmap=fmap)
+
+    deleted = cache.clear_source("apify:one")
+    assert deleted == 1
+    assert cache.status("apify:one")["records"] == 0
+    assert cache.status("apify:two")["records"] == 1
+    cache.close()


### PR DESCRIPTION
## What this solves

If an agent needs to answer questions against a large or slow-changing dataset that an Apify actor scrapes (job listings, a product catalog, docs pages), the only option today is calling the live Apify API on every single question. That burns API quota and adds an extra round trip for data that has not changed since the last check.

## What this adds

1. A new Apify connector. Setup asks for a personal API token and a dataset ID, plus optional field-mapping settings for datasets that do not use the usual title/url fields. One connected account is one dataset.
2. A local SQLite cache with FTS5 keyword search, falling back to a LIKE scan on installs where FTS5 is not compiled in. This cache is written as its own module, not tied to Apify at all, so any future connector with the same "poll an API, then answer from a local copy" shape can reuse it without duplicating the SQLite work.
3. Three tools:
   - `apify_refresh_cache` pulls the connected dataset into the local cache. It is an upsert keyed on each record's id (or a hash of the record if the dataset has no stable id field), so calling it again does not create duplicates, it only reports how many records were new or changed.
   - `apify_search_cache` answers a query from the local cache only. It never makes a network call.
   - `apify_cache_status` reports how many records are cached and when they were last refreshed.
4. Descriptor, catalog copy, and tool registry entries following the same pattern every other connector in this repo already uses.
5. Tests covering descriptor validation, the refresh upsert being idempotent on a second run, update detection when a record's content changes, search ranking, and the FTS5 to LIKE fallback.
6. A test that builds a sample hourly ScheduledTask, showing how someone would wire periodic refresh through the existing automation system rather than a background loop.

## A couple of choices worth explaining

The refresh tool is registered as a read tool, not a write tool, even though it writes to the local cache. Nothing in the user's actual Apify account changes when it runs. Registering it as read also means a scheduled hourly refresh can run on its own instead of stopping every hour to ask for approval.

This connector is read-only on purpose. It cannot start, stop, or change anything on Apify's side; it only reads the dataset the user names.

Known limitation, worth flagging rather than hiding. If a record disappears from the source dataset (a job posting closes, for example), it stays in the local cache until something clears it. There is a clear_source method already in place for that; it is just not wired into anything automatically yet. Happy to follow up on this if it matters.

## How I tested this

Full test suite passes locally with these additions plus the existing suite (912 passed; the 10 failures I saw are pre-existing on main and unrelated to this change, confirmed by running them against a clean checkout).

Beyond the test suite, I ran the actual tool functions end to end with a realistic job listings dataset (first refresh, a repeat refresh to confirm no duplicates, a changed dataset to confirm update detection, and searches against the cache). I also ran the real backend server and the real GUI locally, connected Apify with test credentials, and confirmed it shows up correctly in the connectors catalog and detail pages. Finally, I asked the agent directly, through actual chat, to call apify_search_cache, and it returned correct ranked results from the cache. I also tested the refresh tool against Apify's real API with an invalid token to confirm it fails cleanly instead of crashing, and that a failed refresh leaves the existing cache untouched.

## Screenshots

**Apify connected in the catalog**

<img width="959" height="443" alt="apify-connected-in-catalog" src="https://github.com/user-attachments/assets/540708a8-ed30-460a-b28a-a833fd4e9772" />

**The three tools exposed to the agent**

<img width="956" height="439" alt="apify-tools-detail" src="https://github.com/user-attachments/assets/530323fa-f3e1-45bc-93f1-1af1bd8241d8" />

**Working end to end**

A real chat turn where the agent calls `apify_search_cache` and returns matching records straight from the local cache, no live Apify call.

<img width="959" height="292" alt="apify-search-working" src="https://github.com/user-attachments/assets/febe3678-5dea-43a8-bb93-8770391f72c0" />