### PR TITLE
fix: write gallery persona manifests as UTF-8

### DIFF
--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -445,14 +445,21 @@ def create_app(manager: SessionManager) -> FastAPI:
                         "error": "gallery requires cloud sign-in (or the cloud is unreachable)",
                     }
                 markdown = manifest.get("manifest_markdown", "")
-                digest = "sha256:" + hashlib.sha256(markdown.encode()).hexdigest()
+                digest = (
+                    "sha256:" + hashlib.sha256(markdown.encode("utf-8")).hexdigest()
+                )
                 if (
                     manifest.get("manifest_hash")
                     and manifest["manifest_hash"] != digest
                 ):
                     return {"ok": False, "error": "manifest hash mismatch"}
                 with tempfile.TemporaryDirectory() as td:
-                    (Path(td) / f"{slug}.md").write_text(markdown)
+                    # UTF-8 explicitly: the hash above and `load_manifest_file` both
+                    # treat this markdown as UTF-8, so the file between them must match.
+                    # Defaulting to the locale encoding breaks on Windows (cp1252),
+                    # where CJK/emoji fail to encode and an em-dash writes as a byte the
+                    # UTF-8 read then rejects.
+                    (Path(td) / f"{slug}.md").write_text(markdown, encoding="utf-8")
                     summaries = reg.install_from_dir(td)
                 cloud.gallery_install_event(manager.secrets, load_config(), slug)
             else:

--- a/tests/test_cloud_server.py
+++ b/tests/test_cloud_server.py
@@ -174,6 +174,36 @@ def test_gallery_install_runs_consent_flow(client, monkeypatch):
     assert events == ["sales"]  # install event fired
 
 
+NON_ASCII_MANIFEST = """---
+id: sales
+name: Sales Coworker — 销售
+icon: chart
+tagline: It’s a “quality” pitch — 你好
+family: knowledge
+workspace: deliverable
+tools: [files, search, todo]
+description: d
+---
+You are the Sales Coworker. \U0001f680"""
+
+
+def test_gallery_install_handles_non_ascii_manifest(client, monkeypatch):
+    """Gallery copy carries em-dashes, curly quotes, CJK and emoji.
+
+    The install path hashes the markdown as UTF-8 and `personas/manifest.py` reads it
+    back as UTF-8, so the temp file in between must be written as UTF-8 too. Writing it
+    with the locale encoding works on Linux/macOS but not on Windows, where the default
+    is cp1252: CJK and emoji fail to encode outright, while an em-dash silently writes
+    as a single cp1252 byte that the UTF-8 read then rejects.
+    """
+    _stub_gallery(monkeypatch, markdown=NON_ASCII_MANIFEST)
+    body = client.post("/v1/personas/install", json={"gallery_slug": "sales"}).json()
+    assert body["ok"], body
+    installed = {p["id"]: p for p in body["personas"]}
+    assert installed["sales"]["name"] == "Sales Coworker — 销售"
+    assert installed["sales"]["tagline"] == "It’s a “quality” pitch — 你好"
+
+
 def test_gallery_install_rejects_hash_mismatch(client, monkeypatch):
     _stub_gallery(monkeypatch, hash_ok=False)
     body = client.post("/v1/personas/install", json={"gallery_slug": "sales"}).json()


### PR DESCRIPTION
## Problem

The gallery persona install path uses three encodings for one piece of text, and only two of
them agree.

```python
# coworker/server/app.py
markdown = manifest.get("manifest_markdown", "")
digest = "sha256:" + hashlib.sha256(markdown.encode()).hexdigest()   # UTF-8
...
with tempfile.TemporaryDirectory() as td:
    (Path(td) / f"{slug}.md").write_text(markdown)                   # locale encoding
    summaries = reg.install_from_dir(td)
```

```python
# coworker/personas/manifest.py:261, via registry.install_from_dir -> load_manifest_file
p.read_text(encoding="utf-8")                                        # UTF-8
```

`Path.write_text()` with no `encoding` falls back to `locale.getpreferredencoding()`. On Linux
and macOS that is UTF-8, so all three agree and CI passes. On Windows it is cp1252.

## Impact

Two different failures, depending on which characters the gallery copy contains.

Characters cp1252 cannot represent (CJK, emoji) raise `UnicodeEncodeError` during the write. The
blanket `except Exception` a few lines below turns it into a response the user sees as:

```json
{"ok": false, "error": "'charmap' codec can't encode characters in position 39-40: character maps to <undefined>"}
```

Characters cp1252 *can* represent but UTF-8 encodes differently are worse, because the write
succeeds. An em-dash becomes the single byte `0x97`, a right curly quote becomes `0x92`. The file
lands on disk looking fine, and then `load_manifest_file()` fails reading it back:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x92 in position 17: invalid start byte
```

Persona marketing copy almost always contains em-dashes and curly quotes, so in practice gallery
install is broken on Windows for anything but a pure-ASCII manifest.

`registry._snapshot()` copies the manifest with `shutil.copy2`, a byte copy, so bad bytes also
propagate into the installed snapshot under `installed_dir/<id>/manifest.md`.

## Fix

Pass `encoding="utf-8"` on the write. I also made the `.encode()` above it explicit rather than
relying on its UTF-8 default, since the whole point is that these sites must visibly agree.

## Tests

Added `test_gallery_install_handles_non_ascii_manifest` to `tests/test_cloud_server.py`, reusing
the existing `_stub_gallery` harness. The manifest carries an em-dash, curly quotes, CJK and an
emoji, and the test asserts `name` and `tagline` survive the round trip rather than just checking
the call did not raise. Because it reads those back through `list_all()`, it also covers the
`shutil.copy2` snapshot, not only the initial write.

Before the fix, on Windows:

```
AssertionError: {'ok': False, 'error': "'charmap' codec can't encode characters in position 39-40: character maps to <undefined>"}
```

## Verification

Linux, Python 3.12, matching CI, run in Docker: **890 passed, 1 skipped, 0 failed** (full suite).

Windows 11, Python 3.11.9: the new test goes from failing to passing. Full suite moves from
`9 failed, 880 passed` to `8 failed, 882 passed`.

To be precise about that delta, since it is +2 rather than +1: one is the new test. The other is
`test_ui_refresh_e2e`, which is flaky on Windows and happened to pass on this run. This change did
not fix it, and #210 already addresses that flakiness.

The 8 remaining Windows failures are all pre-existing and unrelated to this change: four in
`test_slack_relay` plus one in `test_github_installs` (deterministic 2s timeouts),
`test_workspace_command_trust_controls_live_engine` (`WinError 32` on a directory rename), and the
two `user-only file` permission tests that #250 covers.

## Note

Found by running the suite on Windows. CI is `ubuntu-latest` only, where the locale is UTF-8, so
this class of defect cannot currently surface upstream.
