### PR TITLE
Fix Schedule.human() weekday: _DOW must be Sunday-indexed

### DIFF
--- a/coworker/automation/models.py
+++ b/coworker/automation/models.py
@@ -10,7 +10,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-_DOW = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+_DOW = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
 
 def _now() -> float:

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -34,7 +34,7 @@ def _task(**kw) -> ScheduledTask:
 # -- model / schedule ----------------------------------------------------------
 def test_schedule_human():
     assert Schedule("cron", cron="10 19 * * *").human() == "Every day at ~7:10 PM"
-    assert "Monday" in Schedule("cron", cron="0 9 * * 0").human()
+    assert "Sunday" in Schedule("cron", cron="0 9 * * 0").human()
     assert Schedule("cron", cron="0 9 5 * *").human() == "Monthly on day 5 at ~9:00 AM"
     assert Schedule("once", fire_at="2026-07-01T09:00:00").human().startswith("Once at")
 


### PR DESCRIPTION
Cron day-of-week is 0=Sunday, but _DOW started with Monday, shifting every weekly automation label by one day. Reorder _DOW and update the test assertion.

Closes #18.