### PR TITLE
Fix inbox routing allow/deny substring matching

### DIFF
--- a/coworker/automation/models.py
+++ b/coworker/automation/models.py
@@ -10,7 +10,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-_DOW = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+_DOW = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
 
 def _now() -> float:

--- a/coworker/inbox_routing.py
+++ b/coworker/inbox_routing.py
@@ -130,9 +130,9 @@ def resolve_from_reply(
         return None
     item_id = m.group(1)
     lowered = reply.lower()
-    if any(w in lowered for w in ("approve", "allow", "yes", "👍", "✅")):
+    if re.search(r"\b(?:approve|allow(?:ed)?|yes)\b", lowered) or "👍" in lowered or "✅" in lowered:
         resolution = "allow"
-    elif any(w in lowered for w in ("deny", "reject", "no", "👎", "❌")):
+    elif re.search(r"\b(?:deny|denied|reject|rejected|no)\b", lowered) or "👎" in lowered or "❌" in lowered:
         resolution = "deny"
     else:
         resolution = _ID_TOKEN.sub("", reply).strip()  # free-text answer to a question

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -34,7 +34,7 @@ def _task(**kw) -> ScheduledTask:
 # -- model / schedule ----------------------------------------------------------
 def test_schedule_human():
     assert Schedule("cron", cron="10 19 * * *").human() == "Every day at ~7:10 PM"
-    assert "Monday" in Schedule("cron", cron="0 9 * * 0").human()
+    assert "Sunday" in Schedule("cron", cron="0 9 * * 0").human()
     assert Schedule("cron", cron="0 9 5 * *").human() == "Monthly on day 5 at ~9:00 AM"
     assert Schedule("once", fire_at="2026-07-01T09:00:00").human().startswith("Once at")
 

--- a/tests/test_inbox_routing.py
+++ b/tests/test_inbox_routing.py
@@ -88,3 +88,26 @@ def test_inbound_legacy_ocw_token_still_resolves(tmp_path):
     item = store.add_approval("s1", "Deploy?", inbox="ops")
     assert resolve_from_reply(f"deny [ocw:{item.id}]", store.resolve) is True
     assert store.get(item.id).resolution == "deny"
+
+
+def test_disallow_does_not_match_allow(tmp_path):
+    """'disallow' contains 'allow' but must NOT approve — the old substring
+    match approved it; word-boundary regex catches it correctly."""
+    store = InboxStore(tmp_path / "inbox.json")
+    q = store.add_question("s1", "Free text?")
+    assert resolve_from_reply(f"disallow [ow:{q.id}]", store.resolve) is True
+    assert store.get(q.id).resolution == "disallow"
+
+
+def test_no_word_boundary_avoids_false_denies(tmp_path):
+    """'note', 'know', 'innovation' contain 'no' but must NOT trigger deny —
+    only standalone 'no' as a word should."""
+    store = InboxStore(tmp_path / "inbox.json")
+    q = store.add_question("s1", "Any input?")
+    # embed the REAL item id so the store can resolve it
+    assert resolve_from_reply(f"note this [ow:{q.id}]", store.resolve) is True
+    assert store.get(q.id).resolution == "note this"
+    # actual standalone 'no' still denies
+    item = store.add_approval("s2", "Deploy?", inbox="ops")
+    assert resolve_from_reply(f"no [ow:{item.id}]", store.resolve) is True
+    assert store.get(item.id).resolution == "deny"


### PR DESCRIPTION
replace plain `in` substring checks with \b word-boundary regex so that \"disallow\" does not match \"allow\" and \"note\"/\"know\" do not match \"no\".

Closes #160.