### PR TITLE
Fix Telegram/Slack inbound: bundle the messaging extra, and stop claiming a dead listener is Live (#257)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,13 @@ jobs:
           python -m venv .venv
           if [ "$RUNNER_OS" = "Windows" ]; then VPY=.venv/Scripts/python; else VPY=.venv/bin/python; fi
           "$VPY" -m pip install --upgrade pip
-          "$VPY" -m pip install -e . pyinstaller typer tzdata
+          "$VPY" -m pip install -e ".[messaging]" pyinstaller typer tzdata
           "$VPY" -c "import aisuite, coworker"  # fail fast if either import breaks
+          # The [messaging] extra must be importable HERE, at build time: the PyInstaller
+          # spec collects slack_bolt/telegram only when it can import them, so a build venv
+          # without the extra silently ships a sidecar that can't run the Telegram or
+          # Slack Socket Mode listeners at all.
+          "$VPY" -c "import telegram, slack_bolt"  # fail fast if inbound messaging is missing
 
       - name: npm ci
         working-directory: surfaces/gui

--- a/coworker/connectors/adapters.py
+++ b/coworker/connectors/adapters.py
@@ -101,23 +101,55 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning(
                 "python-telegram-bot not installed — `pip install coworker[messaging]`"
             )
+            self.connect_error = (
+                "python-telegram-bot is not installed — reinstall with the "
+                "messaging extra (`pip install coworker[messaging]`)"
+            )
             return False
 
-        self._app = Application.builder().token(self.token).build()
+        from telegram.error import InvalidToken
 
         async def _on_update(update, _context):
             event = telegram_message_to_event(update.effective_message)
             if event is not None:
                 await self.handle_message(event)
 
-        self._app.add_handler(
-            MessageHandler(filters.TEXT & ~filters.COMMAND, _on_update)
-        )
-        await self._app.initialize()
-        await self._app.start()
-        await self._app.updater.start_polling(drop_pending_updates=True)
+        # Bring the whole listener up under one guard. A failure anywhere here means the bot
+        # receives nothing, and the reason has to reach the user — the Connectors tab shows
+        # this connector as "connected" the moment a token is saved (issue #257).
+        try:
+            self._app = Application.builder().token(self.token).build()
+            self._app.add_handler(
+                MessageHandler(filters.TEXT & ~filters.COMMAND, _on_update)
+            )
+            await self._app.initialize()
+            await self._app.start()
+            await self._app.updater.start_polling(drop_pending_updates=True)
+        except InvalidToken:
+            # Never quote the exception: it repeats the rejected token verbatim.
+            logger.warning("telegram rejected the bot token")
+            self.connect_error = (
+                "Telegram rejected the bot token — re-copy it from @BotFather"
+            )
+            await self._shutdown_quietly()
+            return False
+        except Exception as exc:
+            logger.exception("telegram polling failed to start")
+            self.connect_error = (
+                f"could not start Telegram polling ({type(exc).__name__})"
+            )
+            await self._shutdown_quietly()
+            return False
+
         logger.info("telegram adapter polling")
         return True
+
+    async def _shutdown_quietly(self) -> None:
+        """Tear down a half-started Application so a retry starts from a clean slate."""
+        try:
+            await self.disconnect()  # its `finally` clears _app even when teardown raises
+        except Exception:
+            logger.debug("telegram cleanup after a failed connect", exc_info=True)
 
     async def disconnect(self) -> None:
         if self._app is None:
@@ -189,6 +221,10 @@ class SlackAdapter(BasePlatformAdapter):
             logger.warning(
                 "slack-bolt not installed — `pip install coworker[messaging]`"
             )
+            self.connect_error = (
+                "slack-bolt is not installed — reinstall with the messaging extra "
+                "(`pip install coworker[messaging]`)"
+            )
             return False
 
         # Base-URL override so tests (and the FakeSlack harness) can redirect every Web API
@@ -202,7 +238,11 @@ class SlackAdapter(BasePlatformAdapter):
             auth = await self._app.client.auth_test()
             self._bot_user_id = auth.get("user_id")
         except Exception:
+            # No exception text here either — Slack SDK errors echo the request payload.
             logger.exception("slack auth_test failed")
+            self.connect_error = (
+                "Slack rejected the bot token — reconnect the Slack connector"
+            )
             return False
 
         @self._app.event("message")

--- a/coworker/connectors/base.py
+++ b/coworker/connectors/base.py
@@ -147,6 +147,11 @@ class BasePlatformAdapter(ABC):
     def __init__(self) -> None:
         self._handler: Optional[MessageHandler] = None
         self._interaction_handler: Optional[InteractionHandler] = None
+        # Why the last `connect()` failed, in words a user can act on ("the bot token was
+        # rejected", "the messaging extra isn't installed"). A bare `return False` tells the
+        # gateway the listener is down but not why, and the Connectors tab has to show
+        # *something* — otherwise a dead bot is indistinguishable from a healthy one.
+        self.connect_error: Optional[str] = None
 
     def set_message_handler(self, handler: MessageHandler) -> None:
         self._handler = handler

--- a/coworker/connectors/gateway.py
+++ b/coworker/connectors/gateway.py
@@ -56,6 +56,13 @@ class Gateway:
         # can be PARKED for one-step allow-and-deliver instead of vanishing.
         self._on_unauthorized = on_unauthorized
         self._adapters: dict[str, BasePlatformAdapter] = {}
+        # Which adapters actually came up in `start()`. Registration is NOT liveness: a
+        # platform stays in `_adapters` even when its listener never started (missing
+        # messaging extra, rejected token, network), so anything reporting "connected" has
+        # to read this instead — otherwise a bot that receives nothing still looks live.
+        self._live: set[str] = set()
+        # platform -> why the listener is down (surfaced on the Connectors tab).
+        self._listen_errors: dict[str, str] = {}
         # In-memory recent senders for chat-ID auto-capture (identity only, never persisted).
         self._recent: "OrderedDict[tuple[str, str, str], dict]" = OrderedDict()
 
@@ -167,20 +174,60 @@ class Gateway:
         return [e for e in items if platform is None or e["platform"] == platform]
 
     async def start(self) -> list[str]:
-        """Connect every enabled+registered adapter. Returns the platforms that came up."""
+        """Connect every enabled+registered adapter. Returns the platforms that came up.
+
+        Every failure path records *why* in `_listen_errors` rather than only logging it.
+        A connector whose credentials are saved reads as "connected" everywhere in the UI
+        (that check is credentials-present, by design — it gates the outbound tools), so
+        without this a listener that never started is completely invisible to the user.
+        """
         live: list[str] = []
         for platform, settings in self.settings.items():
             if not settings.enabled:
                 continue
             adapter = self._adapters.get(platform)
             if adapter is None:
+                # Enabled with no adapter: make_adapter() couldn't build one from the saved
+                # profile (e.g. Slack Socket Mode with a bot token but no app token).
+                self._mark_down(
+                    platform, "no listener could be started from the saved settings"
+                )
                 continue
+            adapter.connect_error = None
             try:
                 if await adapter.connect():
                     live.append(platform)
-            except Exception:  # bad token / network — skip, don't break the server
+                    self._live.add(platform)
+                    self._listen_errors.pop(platform, None)
+                else:
+                    self._mark_down(
+                        platform,
+                        adapter.connect_error or "the listener did not start",
+                    )
+            except Exception as exc:  # bad token / network — skip, don't break the server
                 logger.exception("failed to connect %s adapter", platform)
+                # Only the exception TYPE, never its message: this string is served over
+                # REST, and library errors quote the credential they rejected verbatim
+                # (python-telegram-bot's InvalidToken embeds the bot token). Adapters that
+                # want to say more set a curated `connect_error` and return False instead.
+                self._mark_down(
+                    platform,
+                    f"{type(exc).__name__} — see the server log for details",
+                )
         return live
+
+    def _mark_down(self, platform: str, reason: str) -> None:
+        self._live.discard(platform)
+        self._listen_errors[platform] = reason
+        logger.warning("%s listener is not running: %s", platform, reason)
+
+    def is_listening(self, platform: str) -> bool:
+        """True only if this platform's inbound listener actually came up."""
+        return platform in self._live
+
+    def listen_error(self, platform: str) -> Optional[str]:
+        """Why `platform`'s listener isn't running, or None when it is (or was never started)."""
+        return self._listen_errors.get(platform)
 
     async def stop(self) -> None:
         for adapter in self._adapters.values():
@@ -188,6 +235,8 @@ class Gateway:
                 await adapter.disconnect()
             except Exception:
                 logger.exception("error disconnecting %s adapter", adapter.platform)
+        self._live.clear()
+        self._listen_errors.clear()
 
     async def deliver(self, target: str, text: str) -> SendResult:
         """Send via a live adapter (used where the persistent connection is preferred)."""
@@ -223,7 +272,11 @@ class Gateway:
                 {
                     "platform": platform,
                     "enabled": settings.enabled,
-                    "connected": platform in self._adapters,
+                    # Registered ≠ running: `connected` used to be `platform in self._adapters`,
+                    # which was true even when connect() failed.
+                    "registered": platform in self._adapters,
+                    "connected": platform in self._live,
+                    "error": self._listen_errors.get(platform),
                     "allow_all": settings.allow_all,
                     "allowed_users": len(settings.allowed_users),
                 }

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1103,6 +1103,14 @@ class SessionManager:
         for c in connectors:
             if not (c.get("two_way") and c.get("connected")):
                 continue
+            # `connected` above means "credentials are saved" — it gates the outbound tools
+            # and must stay that way. It says nothing about the INBOUND listener, so a bot
+            # whose polling never started still reads as connected while silently receiving
+            # nothing. Report the listener separately (issue #257).
+            c["listening"] = bool(self.gateway and self.gateway.is_listening(c["name"]))
+            c["listen_error"] = (
+                self.gateway.listen_error(c["name"]) if self.gateway else None
+            )
             allowed = set(c.get("allowed_users") or [])
             # Per-workspace allow-lists (managed relay) — a sender is judged against
             # ITS workspace's list; the flat list only governs team-less (socket) events.

--- a/packaging/build_dmg.sh
+++ b/packaging/build_dmg.sh
@@ -12,7 +12,10 @@
 #   - A Python venv at .venv (repo root) with this package installed editable, plus the
 #     build-only deps:
 #       python3 -m venv .venv
-#       .venv/bin/pip install -e . pyinstaller tzdata typer
+#       .venv/bin/pip install -e ".[messaging]" pyinstaller tzdata typer
+#     The [messaging] extra is NOT optional for a release build: openworker-server.spec
+#     bundles slack_bolt/telegram only if it can import them here, so building without it
+#     ships a sidecar whose Telegram / Slack Socket Mode listeners can never start.
 #     `typer` is needed only at BUILD time: PyInstaller walks the `mcp` package and
 #     `mcp.cli` calls sys.exit() at import if typer is absent, which aborts the freeze.
 #     (aisuite installs like any other dependency — git-pinned in pyproject.toml.)

--- a/packaging/build_windows.ps1
+++ b/packaging/build_windows.ps1
@@ -15,7 +15,10 @@
     - A Python venv at platform\.venv with this package installed editable, plus pyinstaller.
       `typer` is needed only at build time: PyInstaller walks the `mcp` package and `mcp.cli`
       calls sys.exit() at import if typer is absent, which aborts the freeze.
-        py -m venv .venv ; .\.venv\Scripts\pip install -e . pyinstaller tzdata typer
+        py -m venv .venv ; .\.venv\Scripts\pip install -e ".[messaging]" pyinstaller tzdata typer
+      The [messaging] extra is NOT optional for a release build: openworker-server.spec
+      bundles slack_bolt/telegram only if it can import them here, so building without it
+      ships a sidecar whose Telegram / Slack Socket Mode listeners can never start.
 
   The result is UNSIGNED — first launch shows a SmartScreen warning ("More info" -> "Run anyway").
   Authenticode signing is a later step.

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -436,7 +436,12 @@ export interface Connector {
   available: boolean;
   fields: ConnectorField[];
   instructions: string[];
+  // `connected` means the credentials are saved — it gates the outbound tools and says
+  // nothing about the inbound listener. These two report the listener itself, so a bot
+  // that receives nothing stops reading as Live (#257). Set for two-way connectors only.
   connected: boolean;
+  listening?: boolean; // the inbound listener actually came up
+  listen_error?: string | null; // why it didn't (only set once a start was attempted)
   account: string | null;
   enabled: boolean;
   brand_color: string; // hex brand color, e.g. "#611f69" (fallback gray "#6b7280")

--- a/surfaces/gui/src/components/connectors/ConnectorsList.test.tsx
+++ b/surfaces/gui/src/components/connectors/ConnectorsList.test.tsx
@@ -1,0 +1,78 @@
+// Listener health in the connected list (#257): a two-way connector whose inbound
+// listener never came up must not read as "Live". `connected` only means the
+// credentials are saved, so the chip has to follow `listen_error` instead.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { ConnectorsList } from "./ConnectorsList";
+import { type Connector } from "../../api";
+
+afterEach(cleanup);
+
+// Only the fields the list actually reads; the rest of Connector is noise here.
+const telegram = (over: Partial<Connector> = {}): Connector =>
+  ({
+    name: "telegram",
+    title: "Telegram",
+    blurb: "Chat with your coworker",
+    auth: "token",
+    two_way: true,
+    channels: true,
+    available: true,
+    connected: true,
+    account: "@testbot",
+    enabled: true,
+    brand_color: "#229ED9",
+    logo: "telegram",
+    fields: [],
+    instructions: [],
+    allowed_users: [],
+    tools: [],
+    managed: false,
+    managed_profile: false,
+    ...over,
+  }) as Connector;
+
+const list = (c: Connector) =>
+  render(
+    <ConnectorsList
+      connectors={[c]}
+      cloud={null}
+      slack={null}
+      onOpen={vi.fn()}
+      onChanged={vi.fn()}
+    />,
+  );
+
+describe("ConnectorsList listener health", () => {
+  it("shows Live when the listener is up", () => {
+    list(telegram({ listening: true }));
+    expect(screen.getByText("● Live")).toBeTruthy();
+    expect(screen.queryByText("● Not receiving")).toBeNull();
+  });
+
+  it("shows Not receiving when the listener failed to start", () => {
+    list(
+      telegram({
+        listening: false,
+        listen_error: "Telegram rejected the bot token — re-copy it from @BotFather",
+      }),
+    );
+    expect(screen.getByText("● Not receiving")).toBeTruthy();
+    expect(screen.queryByText("● Live")).toBeNull();
+  });
+
+  it("puts the reason on the row, so it reads without opening the connector", () => {
+    const reason = "python-telegram-bot is not installed — reinstall with the messaging extra";
+    list(telegram({ listening: false, listen_error: reason }));
+    expect(screen.getByText(reason)).toBeTruthy();
+    expect(screen.queryByText("@testbot")).toBeNull(); // the reason replaces the account line
+  });
+
+  it("stays Live when no listener state is reported at all", () => {
+    // A server with no gateway running reports neither field. Absence is not a failure —
+    // downgrading on it would flag every two-way connector as broken.
+    list(telegram());
+    expect(screen.getByText("● Live")).toBeTruthy();
+    expect(screen.getByText("@testbot")).toBeTruthy();
+  });
+});

--- a/surfaces/gui/src/components/connectors/ConnectorsList.tsx
+++ b/surfaces/gui/src/components/connectors/ConnectorsList.tsx
@@ -61,7 +61,9 @@ export function ConnectorsList({
                 <ConnectorBadge connector={c} size={34} title={c.title} />
                 <span className="min-w-0 flex-1">
                   <span className="font-medium text-[13.5px]">{c.title}</span>
-                  <span className="block text-[12px] text-muted">{statusLine(c)}</span>
+                  <span className="block text-[12px] text-muted truncate" title={statusLine(c)}>
+                    {statusLine(c)}
+                  </span>
                 </span>
                 {healthChip(c, slack)}
                 <span className="text-faint text-[15px] shrink-0">›</span>
@@ -125,6 +127,9 @@ export function ConnectorsList({
 }
 
 function statusLine(c: Connector): string {
+  // The reason rides the subtitle so it's readable without opening the connector — the
+  // reporter's whole problem was that the list looked healthy (#257).
+  if (c.two_way && c.connected && c.listen_error) return c.listen_error;
   if (c.name === "slack" && c.mode === "relay") {
     const n = c.workspaces?.length ?? 0;
     return `${n} workspace${n === 1 ? "" : "s"} · relay`;
@@ -148,7 +153,14 @@ function healthChip(c: Connector, slack: SlackStatus | null) {
       return <span className={CHIP_WARN}>⚠ Token</span>;
     return <span className={CHIP_OK}>● Live</span>;
   }
-  if (c.two_way && c.connected) return <span className={CHIP_OK}>● Live</span>;
+  // Saved credentials used to be enough to claim "Live", so a bot whose polling never
+  // started looked identical to a healthy one (#257). Only downgrade on a recorded
+  // reason: `listen_error` is set once a start was actually attempted and failed, so a
+  // server with no gateway running can't trip a false alarm.
+  if (c.two_way && c.connected) {
+    if (c.listen_error) return <span className={CHIP_OFF}>● Not receiving</span>;
+    return <span className={CHIP_OK}>● Live</span>;
+  }
   return <span className={CHIP_OK}>● Ready</span>;
 }
 

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -165,6 +165,114 @@ async def test_gateway_dispatches_authorized():
     assert not fake.connected
 
 
+# -- listener liveness (issue #257: "live connection" but nothing is received) --------
+def _live_gateway(platform: str = "fake") -> Gateway:
+    return Gateway(
+        settings={platform: ConnectorSettings(platform, enabled=True, allow_all=True)}
+    )
+
+
+class _DeadAdapter(FakeAdapter):
+    """An adapter whose listener never comes up — connect() fails the way the real ones do
+    when the messaging extra is missing or the token is rejected."""
+
+    def __init__(self, *, reason: str | None = None, raises: bool = False) -> None:
+        super().__init__()
+        self._reason = reason
+        self._raises = raises
+
+    async def connect(self) -> bool:
+        if self._raises:
+            raise RuntimeError("boom")
+        self.connect_error = self._reason
+        return False
+
+
+async def test_gateway_status_reports_a_failed_listener_as_down():
+    """Registering an adapter is not the same as its listener running. The status used to
+    read `platform in self._adapters`, so a bot that received nothing still said connected."""
+    gw = _live_gateway()
+    gw.register(_DeadAdapter(reason="python-telegram-bot is not installed"))
+
+    assert await gw.start() == []
+    assert gw.is_listening("fake") is False
+    assert gw.listen_error("fake") == "python-telegram-bot is not installed"
+
+    status = gw.status()[0]
+    assert status["registered"] is True  # it IS registered...
+    assert status["connected"] is False  # ...but nothing is listening
+    assert status["error"] == "python-telegram-bot is not installed"
+
+
+async def test_gateway_records_a_reason_when_connect_gives_none():
+    gw = _live_gateway()
+    gw.register(_DeadAdapter())
+    await gw.start()
+    assert gw.listen_error("fake") == "the listener did not start"
+
+
+async def test_gateway_records_a_raised_connect_error():
+    """A raising connect() must not break the server, but it must not vanish either."""
+    gw = _live_gateway()
+    gw.register(_DeadAdapter(raises=True))
+
+    assert await gw.start() == []
+    assert gw.is_listening("fake") is False
+    assert gw.listen_error("fake") == "RuntimeError — see the server log for details"
+
+
+async def test_gateway_listen_error_never_quotes_the_exception():
+    """This string is served over REST. Library errors quote the credential they rejected
+    (python-telegram-bot's InvalidToken embeds the bot token), so only the type may surface."""
+
+    class _LeakyAdapter(_DeadAdapter):
+        async def connect(self) -> bool:
+            raise RuntimeError("The token `S3CRET-TOKEN` was rejected by the server.")
+
+    gw = _live_gateway()
+    gw.register(_LeakyAdapter())
+    await gw.start()
+
+    assert "S3CRET-TOKEN" not in (gw.listen_error("fake") or "")
+    assert "RuntimeError" in (gw.listen_error("fake") or "")
+
+
+async def test_gateway_flags_an_enabled_platform_with_no_adapter():
+    """make_adapter() returns None for an incomplete profile (e.g. Slack bot token, no app
+    token). The platform is enabled and looks connected, but nothing was ever built."""
+    gw = _live_gateway("slack")
+
+    assert await gw.start() == []
+    assert gw.is_listening("slack") is False
+    assert "no listener" in (gw.listen_error("slack") or "")
+
+
+async def test_gateway_live_listener_has_no_error():
+    gw = _live_gateway()
+    gw.register(FakeAdapter())
+
+    assert await gw.start() == ["fake"]
+    assert gw.is_listening("fake") is True
+    assert gw.listen_error("fake") is None
+    assert gw.status()[0]["connected"] is True
+
+    await gw.stop()
+    assert gw.is_listening("fake") is False  # stopped, so no longer live
+
+
+async def test_gateway_start_clears_a_stale_error_on_recovery():
+    """A connector that failed once and then connects must not keep showing the old reason."""
+    gw = _live_gateway()
+    flaky = _DeadAdapter(reason="Slack rejected the bot token")
+    gw.register(flaky)
+    await gw.start()
+    assert gw.listen_error("fake")
+
+    gw.register(FakeAdapter())  # same platform, now healthy
+    assert await gw.start() == ["fake"]
+    assert gw.listen_error("fake") is None
+
+
 async def test_gateway_deliver_via_adapter():
     gw = Gateway(
         settings={"fake": ConnectorSettings("fake", enabled=True, allow_all=True)}

--- a/tests/test_connectors_allowlist.py
+++ b/tests/test_connectors_allowlist.py
@@ -18,7 +18,8 @@ class ScriptedProvider(ProviderClient):
 
 
 class _Gateway:
-    """Minimal gateway stub exposing the recent-senders surface the manager enriches with."""
+    """Minimal gateway stub exposing the surfaces the manager enriches with: recent senders
+    and listener liveness. Stands in for a gateway whose listeners all came up."""
 
     def __init__(self, recent):
         self._recent = recent
@@ -26,6 +27,12 @@ class _Gateway:
 
     def recent_senders(self, name):
         return [dict(r) for r in self._recent] if name == "slack" else []
+
+    def is_listening(self, name):
+        return True
+
+    def listen_error(self, name):
+        return None
 
 
 def _connected_slack(mgr, allowed=()):

--- a/tests/test_packaging_messaging_extra.py
+++ b/tests/test_packaging_messaging_extra.py
@@ -1,0 +1,79 @@
+"""The [messaging] extra must survive into release builds.
+
+`openworker-server.spec` collects slack_bolt/telegram only when it can IMPORT them, inside a
+`try/except: pass`. So a build venv without the extra produces no error and no bundled
+library — it just ships a sidecar whose Telegram / Slack Socket Mode listeners hit their
+ImportError guard and return False forever (the silent-connector half of #257).
+
+Nothing else catches that: the packaged app is built by a separate workflow, and a missing
+optional import is invisible until a user connects a bot and receives nothing. These pin the
+three files that have to agree.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+SPEC = ROOT / "packaging" / "openworker-server.spec"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+# messaging dependency (as named on PyPI) -> the module the spec has to be able to import.
+MESSAGING_IMPORTS = {
+    "python-telegram-bot": "telegram",
+    "slack-bolt": "slack_bolt",
+}
+
+
+def _messaging_extra() -> list[str]:
+    with open(ROOT / "pyproject.toml", "rb") as fh:
+        pyproject = tomllib.load(fh)
+    return pyproject["project"]["optional-dependencies"]["messaging"]
+
+
+def _sidecar_venv_run() -> str:
+    """The release job step that provisions the .venv the build scripts freeze from."""
+    workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text())
+    for job in workflow["jobs"].values():
+        for step in job.get("steps") or []:
+            if "venv" in (step.get("name") or "").lower():
+                return step.get("run") or ""
+    pytest.fail("no sidecar venv step found in release.yml")
+
+
+def test_messaging_extra_still_declares_the_inbound_listeners():
+    declared = " ".join(_messaging_extra())
+    for dist in MESSAGING_IMPORTS:
+        assert dist in declared, f"{dist} dropped from the [messaging] extra"
+
+
+def test_spec_collects_every_messaging_import():
+    spec = SPEC.read_text()
+    for dist, module in MESSAGING_IMPORTS.items():
+        assert module in spec, (
+            f"{module} ({dist}) is not collected by openworker-server.spec, so it will not "
+            "be bundled even when the build venv has it"
+        )
+
+
+def test_release_build_installs_the_messaging_extra():
+    """Without this the spec's `try: collect_submodules(...) except: pass` silently no-ops."""
+    run = _sidecar_venv_run()
+    assert "[messaging]" in run, (
+        "the release sidecar venv installs the package without the [messaging] extra — "
+        "telegram/slack_bolt would not be importable at freeze time and never get bundled"
+    )
+
+
+def test_release_build_fails_fast_when_messaging_is_missing():
+    """A bundling regression must break the build, not ship a mute connector."""
+    run = _sidecar_venv_run()
+    imports = [m for m in MESSAGING_IMPORTS.values() if m in run]
+    assert imports, (
+        "release.yml never imports the messaging modules after install; add an import check "
+        "so a missing extra fails the build instead of shipping a sidecar that can't listen"
+    )


### PR DESCRIPTION
Fixes #257.

**The root cause turned out to be a packaging bug, found while writing this up.** No release
has ever bundled `python-telegram-bot`, so the Telegram listener cannot start in a downloaded
build — see "The reason no release could ever receive" below. The rest of this PR is what made
that failure invisible for so long.

## The problem

The reporter connected a Telegram bot and saw *"live connection but no further messages received."* That state is reachable, and nothing in the UI can distinguish it from a healthy bot.

A messaging connector reads as **connected** the moment its credentials are saved — `connector_list()` derives that flag from `_profile_connected()`, which only checks that the required fields are present. Nothing anywhere reports whether the **inbound listener** actually came up.

`Gateway.status()` had the same gap from the other side:

```python
"connected": platform in self._adapters,
```

`register()` fills `_adapters` *before* `start()` runs, so a platform stayed `connected: True` even when `connect()` returned `False` or raised. Both failure paths only logged:

```python
try:
    if await adapter.connect():
        live.append(platform)
except Exception:          # bad token / network
    logger.exception(...)  # ...and that's the end of it
```

Reproducing it takes an adapter whose `connect()` returns `False`:

```
start()  -> []            # nothing came up
status() -> [{'platform': 'telegram', 'connected': True, ...}]
```

This is not a corner case. `python-telegram-bot` ships in the optional `[messaging]` extra, so on an install without it `connect()` returns `False` on the import guard — and the connector shows as connected forever while receiving nothing.

## The fix

- **`Gateway`** tracks real liveness (`_live`) and *why* a listener is down (`_listen_errors`), exposed as `is_listening()` / `listen_error()` and cleared on `stop()`. `status()` now separates `registered` from `connected`. Every failure path records a reason, including "enabled but `make_adapter()` built nothing" (e.g. Slack Socket Mode with a bot token but no app token).
- **Adapters** carry a `connect_error` so a bare `False` can explain itself. Telegram and Slack fill it in for the missing-extra and rejected-token cases. Telegram now brings its listener up under one guard and tears down a half-started `Application` before returning, so a retry starts clean.
- **`list_connectors()`** surfaces `listening` and `listen_error` next to the existing `connected`.

`connected` deliberately keeps its current meaning — it gates the outbound connector tools, and a transient listener failure must not disable them. The listener is reported alongside it rather than folded into it, which also gives the Connectors tab something actionable to show ("Telegram rejected the bot token — re-copy it from @BotFather").

## Note on secret handling

My first version recorded `f"{type(exc).__name__}: {exc}"`. The existing `test_connectors_rest` assertion that secrets never leak over REST caught it: python-telegram-bot's `InvalidToken` quotes the rejected token verbatim (`The token `T0K` was rejected by the server.`), and this string is served over REST.

Listener errors now surface the exception **type only**; adapters that want to say more set a curated, secret-free `connect_error`. `test_gateway_listen_error_never_quotes_the_exception` pins this directly rather than relying on the REST test to catch a regression.

## Tests

Seven new tests in `tests/test_connectors.py` covering: a failed listener reported as down, a reason recorded for a `False` return, a raised `connect()`, the secret-leak guard, an enabled platform with no adapter, a live listener having no error and going down on `stop()`, and a stale error being cleared when a connector recovers.

`tests/test_connectors_allowlist.py`'s gateway double gains the two new methods — it documents itself as exposing the surface the manager enriches with, so it follows the interface rather than the manager defending against it with `getattr`.

Full suite: **896 passed, 1 skipped** locally (Python 3.11).

## The UI

The reporter's actual words were *"it just says live connection"* — that chip is `ConnectorsList.tsx`:

```tsx
if (c.two_way && c.connected) return <span className={CHIP_OK}>● Live</span>;
```

It now follows `listen_error`: a listener that didn't start renders `● Not receiving`, and the reason replaces the account on the row's subtitle, so it reads without opening the connector — matching the existing rule in that file that problems surface in the list, never one click deep.

The chip downgrades only on a *recorded reason*, not on `listening !== true`. A server with no gateway running reports neither field, and treating that absence as failure would flag every two-way connector as broken.

Four `ConnectorsList` unit tests cover Live, Not receiving, the reason on the row, and the absent-state case. GUI suite: **72 passed**, `tsc --noEmit` clean.

## The reason no release could ever receive

`.github/workflows/release.yml` provisions the sidecar venv the build freezes from:

```
"$VPY" -m pip install -e . pyinstaller typer tzdata
```

No `[messaging]` extra. And `packaging/openworker-server.spec` collects the messaging
libraries only when it can import them:

```python
for pkg in ("slack_bolt", "telegram"):  # [messaging] extra — optional
    try:
        hiddenimports += collect_submodules(pkg)
    except Exception:
        pass
```

Neither is importable in that venv, the `except: pass` swallows it, and the sidecar ships
without them. So in every downloaded build `TelegramAdapter.connect()` hits its ImportError
guard and returns `False`: the listener never starts, the connector still shows as connected
because the token is saved, and no message ever arrives. Manual Slack Socket Mode has the same
problem; the managed Slack relay does not, since it runs over the cloud websocket rather than
`slack_bolt`.

The release workflow now installs the extra and import-checks it after install, so a bundling
regression fails the build instead of shipping a sidecar that silently can't listen. The
`build_dmg.sh` / `build_windows.ps1` prerequisite headers document the same venv and move with
it. `tests/test_packaging_messaging_extra.py` pins the three files that have to agree — I
verified it fails on the current code and passes with the fix.

## Scope

The two halves are independent and each stands alone: the packaging fix makes a released
Telegram bot able to receive at all, and the liveness work means the next time a listener
fails for any reason — bad token, missing dependency, network — it says so instead of showing
a green chip.

One case this still doesn't cover: the allow-list is deny-by-default, so inbound is dropped
until your user id is added. That path already parks the message and records the sender, so
it leaves evidence; a listener that never started left none. That asymmetry is what this
removes.

## Testing

Python **900 passed, 1 skipped**. GUI unit **72 passed**, `tsc --noEmit` clean. Playwright e2e
**153 passed, 1 pre-existing failure** (`nav-collapse.spec.ts`, a ⌘-key shortcut that also
fails on a clean `main` checkout on Linux).

I have not built a DMG to confirm the bundle end to end — I don't have macOS here, and the
packaging change is not exercised by CI's test job. The three-file consistency test is my
substitute for that, and the import check in the workflow means the next release build proves
it directly.
