### PR TITLE
Add You.com web search provider (keyless, with optional key)

### DIFF
--- a/coworker/config.py
+++ b/coworker/config.py
@@ -37,7 +37,8 @@ class Config:
     auto_allow: list[str] = field(default_factory=list)
     host: str = "127.0.0.1"
     port: int = 8765
-    # Web search provider: "duckduckgo" (keyless default) | "tavily" | "brave" (need a key).
+    # Web search provider: "duckduckgo" (keyless default) | "you" (keyless, optional key)
+    # | "tavily" | "brave" (need a key).
     web_search_provider: str = "duckduckgo"
     # OpenWorker Cloud (sign-in + managed connectors). Config, never constants:
     # dev/staging/BYO-VPC deployments point these at their own instances.

--- a/coworker/web/__init__.py
+++ b/coworker/web/__init__.py
@@ -8,6 +8,7 @@ from .providers import (
     SearchResult,
     TavilyProvider,
     WebSearchProvider,
+    YouProvider,
     build_provider,
     provider_names,
 )
@@ -20,6 +21,7 @@ __all__ = [
     "DuckDuckGoProvider",
     "TavilyProvider",
     "BraveProvider",
+    "YouProvider",
     "build_provider",
     "provider_names",
     "make_web_search_tool",

--- a/coworker/web/providers.py
+++ b/coworker/web/providers.py
@@ -1,12 +1,14 @@
 """Web search providers — a keyless default + pluggable third-party services.
 
-`duckduckgo` works with no API key (our "starting version of our own"). `tavily` and `brave`
-give better results but need a key (configured via the SecretStore / env). All providers
-return a uniform `list[SearchResult]`; the heavy client libs are lazy-imported.
+`duckduckgo` works with no API key (our "starting version of our own"). `you` is also usable
+keyless and takes an optional key to lift the free-tier limits. `tavily` and `brave` give
+better results but need a key (configured via the SecretStore / env). All providers return a
+uniform `list[SearchResult]`; the heavy client libs are lazy-imported.
 """
 
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional
@@ -27,6 +29,9 @@ class SearchResult:
 class WebSearchProvider(ABC):
     name: str = "base"
     requires_key: bool = False
+    # Keyless provider that still uses a key when one is configured (better quota/features).
+    # `build_provider` passes the key through instead of dropping it.
+    accepts_key: bool = False
 
     @abstractmethod
     def search(self, query: str, max_results: int = 5) -> list[SearchResult]: ...
@@ -49,6 +54,53 @@ class DuckDuckGoProvider(WebSearchProvider):
                 snippet=r.get("body", "") or r.get("snippet", ""),
             )
             for r in rows
+        ]
+
+
+class YouProvider(WebSearchProvider):
+    """You.com — keyless out of the box, better with a key.
+
+    Without a key it hits the free agents endpoint (100 searches/day, rate-limited per IP),
+    so it works in a fresh install like `duckduckgo` does. With a key it hits the Search API
+    (`YOU_API_KEY`, or `YDC_API_KEY` — the name You.com's own docs and SDKs use), which lifts
+    the quota. Both return the same `{"results": {"web": [...], "news": [...]}}` shape.
+    """
+
+    name = "you"
+    requires_key = False
+    accepts_key = True
+
+    _KEYLESS_URL = "https://api.you.com/v1/agents/search"
+    _KEYED_URL = "https://ydc-index.io/v1/search"
+    # The free tier has no key, so the User-Agent is how You.com attributes this traffic.
+    _USER_AGENT = "youdotcom-integration/andrewyng-openworker"
+
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        self.api_key = api_key or os.environ.get("YDC_API_KEY") or None
+
+    def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+        import httpx
+
+        headers = {"Accept": "application/json", "User-Agent": self._USER_AGENT}
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+        resp = httpx.get(
+            self._KEYED_URL if self.api_key else self._KEYLESS_URL,
+            headers=headers,
+            params={"query": query, "count": max_results},
+            timeout=_TIMEOUT,
+        )
+        data = resp.json()
+        results = data.get("results", {}) or {}
+        # `count` applies per section; web first, news only fills any remainder.
+        rows = (results.get("web") or []) + (results.get("news") or [])
+        return [
+            SearchResult(
+                title=r.get("title", ""),
+                url=r.get("url", ""),
+                snippet=r.get("description", "") or " ".join(r.get("snippets") or []),
+            )
+            for r in rows[:max_results]
         ]
 
 
@@ -110,6 +162,7 @@ class BraveProvider(WebSearchProvider):
 
 _PROVIDERS = {
     "duckduckgo": DuckDuckGoProvider,
+    "you": YouProvider,
     "tavily": TavilyProvider,
     "brave": BraveProvider,
 }
@@ -120,6 +173,8 @@ def build_provider(name: str, api_key: Optional[str] = None) -> WebSearchProvide
     if cls.requires_key:
         if not api_key:
             raise ValueError(f"web search provider '{name}' needs an API key")
+        return cls(api_key)  # type: ignore[call-arg]
+    if cls.accepts_key:
         return cls(api_key)  # type: ignore[call-arg]
     return cls()  # type: ignore[call-arg]
 

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -20,6 +20,7 @@ from coworker.web.providers import (
     DuckDuckGoProvider,
     TavilyProvider,
     WebSearchProvider,
+    YouProvider,
 )
 
 
@@ -79,6 +80,85 @@ def test_build_provider_third_party_requires_key():
         build_provider("tavily")  # no key
     assert isinstance(build_provider("tavily", "tvly-x"), TavilyProvider)
     assert isinstance(build_provider("brave", "brv-x"), BraveProvider)
+
+
+def test_build_provider_you_is_keyless_with_optional_key(monkeypatch):
+    monkeypatch.delenv("YDC_API_KEY", raising=False)
+    assert "you" in provider_names()
+    keyless = build_provider("you")  # no key needed
+    assert isinstance(keyless, YouProvider) and keyless.api_key is None
+    assert build_provider("you", "ydc-x").api_key == "ydc-x"  # key is passed through
+    monkeypatch.setenv("YDC_API_KEY", "from-env")
+    assert build_provider("you").api_key == "from-env"
+
+
+def _fake_you_get(captured, payload):
+    """Stand-in for httpx.get that records the request and replays a canned response."""
+
+    class Resp:
+        def json(self):
+            return payload
+
+    def get(url, **kw):
+        captured.update(url=url, **kw)
+        return Resp()
+
+    return get
+
+
+def test_you_provider_keyless_request_and_parsing(monkeypatch):
+    import httpx
+
+    monkeypatch.delenv("YDC_API_KEY", raising=False)
+    got = {}
+    monkeypatch.setattr(
+        httpx,
+        "get",
+        _fake_you_get(
+            got,
+            {
+                "results": {
+                    "web": [
+                        {"title": "w", "url": "https://w", "description": "wd"},
+                        {"title": "s", "url": "https://s", "snippets": ["a", "b"]},
+                    ],
+                    "news": [{"title": "n", "url": "https://n", "description": "nd"}],
+                }
+            },
+        ),
+    )
+
+    out = YouProvider().search("openworker", max_results=3)
+    assert got["url"] == YouProvider._KEYLESS_URL  # free tier, no key
+    assert "X-API-Key" not in got["headers"]
+    assert got["headers"]["User-Agent"] == "youdotcom-integration/andrewyng-openworker"
+    assert got["params"] == {"query": "openworker", "count": 3}
+    assert [(r.title, r.url, r.snippet) for r in out] == [
+        ("w", "https://w", "wd"),
+        ("s", "https://s", "a b"),  # falls back to snippets when description is absent
+        ("n", "https://n", "nd"),  # web first, news fills the remainder
+    ]
+
+
+def test_you_provider_with_key_uses_search_api(monkeypatch):
+    import httpx
+
+    got = {}
+    monkeypatch.setattr(httpx, "get", _fake_you_get(got, {"results": {}}))
+
+    assert YouProvider("ydc-123").search("q", max_results=2) == []
+    assert got["url"] == YouProvider._KEYED_URL
+    assert got["headers"]["X-API-Key"] == "ydc-123"
+
+
+def test_you_provider_truncates_to_max_results(monkeypatch):
+    import httpx
+
+    rows = [{"title": f"r{i}", "url": f"https://x/{i}"} for i in range(10)]
+    monkeypatch.setattr(
+        httpx, "get", _fake_you_get({}, {"results": {"web": rows, "news": rows}})
+    )
+    assert len(YouProvider().search("q", max_results=4)) == 4
 
 
 def test_tool_surfaces_missing_key_error(tmp_path):


### PR DESCRIPTION
Closes #261, where I laid out the proposal before writing this.

Adds `you` as a fourth `web_search` provider. Disclosure: I work at You.com.

## Why this one is worth a slot

`providers.py` splits into "keyless default" (DuckDuckGo) and "needs a key" (Tavily, Brave). You.com sits in both columns, which is the whole argument for it:

| | endpoint | setup |
|---|---|---|
| No key | `api.you.com/v1/agents/search` | none — 100 searches/day, per-IP |
| With a key | `ydc-index.io/v1/search` | `YOU_API_KEY`, lifts the quota |

Someone who has never heard of You.com can select it and get results, exactly like `ddgs` today. Someone who has a key gets the higher tier without changing anything else. Same provider, one code path.

**`duckduckgo` remains the default.** This PR only adds an entry to `_PROVIDERS`.

## The one change outside the provider class

Key handling was a single boolean, and `build_provider` discarded the key for any provider with `requires_key = False`:

```python
if cls.requires_key:
    if not api_key:
        raise ValueError(...)
    return cls(api_key)
return cls()          # key dropped here
```

So "keyless, but better with a key" had no way to be expressed — a key configured through the SecretStore or `POST /v1/web-search` would be silently ignored and the user would sit on the free tier without knowing why.

`WebSearchProvider` gains `accepts_key`, defaulting to `False`, and `build_provider` passes the key through when it's set. DuckDuckGo, Tavily and Brave take the identical path they take today; their tests are untouched and still pass.

If you'd rather not touch the ABC, say so and I'll cut it back to keyless-only — it just means BYOK users can't be served.

## Everything else is picked up for free

`SearchResult` keeps its three fields. The manager, the `/v1/web-search` endpoints and the agent registry all read `provider_names()`. `resolve_provider()` already derives `{NAME}_API_KEY`, so `YOU_API_KEY` needs no plumbing (`YDC_API_KEY` is accepted as a fallback — it's the name You.com's own docs and SDKs use). No new dependency: `httpx` is already core, and unlike the DuckDuckGo provider this one needs no extra library.

No GUI change: nothing in `surfaces/` renders a web-search settings panel yet (#51), and the settings endpoint serves `provider_names()` dynamically, so the entry appears on its own.

Requests send `User-Agent: youdotcom-integration/andrewyng-openworker`, to You.com hosts only, so we can attribute the traffic — on the keyless tier there's no key, so it's the only signal available.

## Tests

`tests/test_web_search.py`, extended in place, no network — `httpx.get` is stubbed. Covers the keyless request shape and result parsing, that a key switches host and adds `X-API-Key`, key resolution precedence (`YOU_API_KEY` → `YDC_API_KEY` → keyless), and truncation to `max_results`.

```
$ pytest tests/test_web_search.py -q
13 passed, 1 warning in 0.49s
```

Full suite: 886 passed, 7 failed. The 7 are `test_fake_slack.py` and `test_ui_refresh_e2e.py`, which fail identically on a clean checkout here — the optional `messaging` extra isn't installed.

The README asks for before/after screenshots; this adds a provider rather than fixing broken UI, so here's the equivalent — the tool called live against the free tier with no key set anywhere:

```
$ env -u YDC_API_KEY python -c "..."   # web_search tool, provider='you', no key
{
  "provider": "you",
  "results": [
    {
      "title": "Andrew Ng on X: \"Announcing OpenWorker! An open-source agent that ...",
      "url": "https://x.com/AndrewYNg/status/2080333504446108104",
      "snippet": "Announcing OpenWorker! An open-source agent that doesn't just chat with
                  you, but delivers finished work -- like hand you a polished document,
                  send a slack message, or update a calendar entry. [...]"
    },
    {
      "title": "Andrew Ng Just Released OpenWorker: An Open-Source, Local-First ...",
      "url": "https://www.marktechpost.com/2026/07/23/andrew-ng-just-released-openworker-...",
      "snippet": "Local agent server — Python 3.10+ ... The engine is built on aisuite [...]"
    }
  ]
}
```

The keyed path was smoke-tested the same way against a real key.
