### PR TITLE
fix(inbox): a chat reply must not silently refuse a plan/directory prompt

### DIFF
--- a/coworker/connectors/gateway.py
+++ b/coworker/connectors/gateway.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 import logging
 from asyncio import to_thread
 from collections import OrderedDict
-from typing import Callable, Optional
+from inspect import isawaitable
+from typing import Awaitable, Callable, Optional, Union
 from urllib.parse import urlparse
 
 from ..secrets import SecretStore
@@ -30,6 +31,10 @@ logger = logging.getLogger("coworker.connectors")
 
 _RECENT_CAP = 20  # most-recent distinct senders kept for chat-ID auto-capture
 
+# Consumes an inbound message if it resolves an Inbox item. May be sync (tests, simple
+# callers) or async — the manager's resolver awaits a durable resume before answering.
+ReplyResolver = Callable[[MessageEvent], Union[bool, Awaitable[bool]]]
+
 
 class Gateway:
     def __init__(
@@ -38,7 +43,7 @@ class Gateway:
         secrets: Optional[SecretStore] = None,
         settings: Optional[dict[str, ConnectorSettings]] = None,
         handler: Optional[MessageHandler] = None,
-        reply_resolver: Optional[Callable[[MessageEvent], bool]] = None,
+        reply_resolver: Optional[ReplyResolver] = None,
         interaction_handler: Optional[Callable] = None,
         on_unauthorized: Optional[Callable] = None,
     ) -> None:
@@ -62,9 +67,7 @@ class Gateway:
     def set_handler(self, handler: MessageHandler) -> None:
         self._handler = handler
 
-    def set_reply_resolver(
-        self, resolver: Optional[Callable[[MessageEvent], bool]]
-    ) -> None:
+    def set_reply_resolver(self, resolver: Optional[ReplyResolver]) -> None:
         self._reply_resolver = resolver
 
     def register(self, adapter: BasePlatformAdapter) -> None:
@@ -135,7 +138,10 @@ class Gateway:
         # released automatically (InboxStore.resolve fires its waiter).
         if self._reply_resolver is not None:
             try:
-                if self._reply_resolver(event):
+                consumed = self._reply_resolver(event)
+                if isawaitable(consumed):  # the manager's resolver awaits a durable resume
+                    consumed = await consumed
+                if consumed:
                     return
             except Exception:
                 logger.exception("inbox reply resolver failed")

--- a/coworker/inbox_routing.py
+++ b/coworker/inbox_routing.py
@@ -117,14 +117,12 @@ def deliver(item, binding: InboxBinding, sender: Optional[Sender]) -> bool:
     return True
 
 
-def resolve_from_reply(
-    reply: str, resolve: Callable[[str, str], bool]
-) -> Optional[bool]:
-    """Correlate an inbound channel reply to its item (by the embedded id) and resolve it.
+def parse_reply(reply: str) -> Optional[tuple[str, str]]:
+    """``(item_id, resolution)`` for an inbound channel reply, or None if it isn't one.
 
-    Looks for the ``[ow:<id>]`` token (or legacy ``[ocw:…]``) and an allow/deny intent; falls back to treating the whole
-    message as a free-text answer. ``resolve(item_id, resolution)`` is the InboxStore.resolve.
-    Returns the resolve() result, or None if no item id was found."""
+    Looks for the ``[ow:<id>]`` token (or legacy ``[ocw:…]``) and an allow/deny intent; falls
+    back to treating the whole message as a free-text answer. Split out from
+    ``resolve_from_reply`` so an async caller can parse first and then await its resolve."""
     m = _ID_TOKEN.search(reply or "")
     if not m:
         return None
@@ -136,4 +134,17 @@ def resolve_from_reply(
         resolution = "deny"
     else:
         resolution = _ID_TOKEN.sub("", reply).strip()  # free-text answer to a question
-    return resolve(item_id, resolution)
+    return item_id, resolution
+
+
+def resolve_from_reply(
+    reply: str, resolve: Callable[[str, str], bool]
+) -> Optional[bool]:
+    """Correlate an inbound channel reply to its item (by the embedded id) and resolve it.
+
+    ``resolve(item_id, resolution)`` is the InboxStore.resolve. Returns the resolve() result,
+    or None if no item id was found."""
+    parsed = parse_reply(reply)
+    if parsed is None:
+        return None
+    return resolve(*parsed)

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -25,7 +25,7 @@ from ..connections import (
     SessionConnectionStore,
     effective as effective_connections,
 )
-from ..inbox import InboxStore, args_preview
+from ..inbox import KIND_DIRECTORY, KIND_PLAN, InboxStore, args_preview
 from ..inbox_routing import InboxRouting
 from ..personas import PersonaRegistry
 from ..personas.registry import set_registry as set_persona_registry
@@ -2670,33 +2670,39 @@ class SessionManager:
                 pass
 
     # -- inbox replies over messaging connectors --------------------------------
-    def _resolve_inbox_reply(self, event) -> bool:
+    async def _resolve_inbox_reply(self, event) -> bool:
         """Try to handle an inbound Slack/Telegram message as an Inbox reply. Returns True if the
         message carried an `[ow:<id>]` token (so it's consumed here, not routed as a new turn) —
-        resolving the item also releases any agent suspended on it."""
-        from ..inbox_routing import resolve_from_reply
+        resolving the item releases any agent suspended on it, and resumes one whose engine is
+        no longer live. A reply that cannot answer the item (see `_reply_answers`) is still
+        consumed, but leaves the item pending for the app."""
+        from ..inbox_routing import parse_reply
 
-        text = getattr(event, "text", "") or ""
-
-        def _resolve(item_id: str, resolution: str) -> bool:
-            item = self.inbox.get(item_id)
-            if item is None:
-                return False
-            if (
-                getattr(event.source, "platform", "") == "slack"
-                and item.kind in {"approval", "directory", "plan"}
+        parsed = parse_reply(getattr(event, "text", "") or "")
+        if parsed is None:
+            return False
+        item_id, resolution = parsed
+        item = self.inbox.get(item_id)
+        if item is None:
+            return True
+        if (
+            getattr(event.source, "platform", "") == "slack"
+            and item.kind in {"approval", "directory", "plan"}
+        ):
+            actor_id = str(getattr(event.source, "user_id", "") or "")
+            if not self._slack_actor_owns_item(
+                item,
+                actor_id=actor_id,
+                chat_id=getattr(event.source, "chat_id", "") or "",
+                team_id=getattr(event.source, "team_id", None),
             ):
-                actor_id = str(getattr(event.source, "user_id", "") or "")
-                if not self._slack_actor_owns_item(
-                    item,
-                    actor_id=actor_id,
-                    chat_id=getattr(event.source, "chat_id", "") or "",
-                    team_id=getattr(event.source, "team_id", None),
-                ):
-                    return False
-            return self.inbox.resolve(item_id, resolution)
-
-        return resolve_from_reply(text, _resolve) is not None
+                return True
+        if not _reply_answers(item, resolution):
+            return True
+        # Same path as a button click: resolving durably resumes a session whose engine was
+        # evicted (or that outlived a restart) while suspended on this item.
+        await self.resolve_inbox(item_id, resolution)
+        return True
 
     # -- self-wake resumption ---------------------------------------------------
     async def resume_due_wakes(self) -> int:
@@ -3668,6 +3674,23 @@ def _parse_inbox_json(s: str) -> dict[str, Any]:
         return v if isinstance(v, dict) else {}
     except Exception:
         return {}
+
+
+def _reply_answers(item, resolution: str) -> bool:
+    """Whether a chat reply's resolution can actually answer this item.
+
+    Directory and plan prompts carry their answer as a JSON payload (`_parse_inbox_json`),
+    but a chat reply only ever produces the bare intent words `allow` / `deny` or free text.
+    Those parse to `{}`, which both approvers read as a refusal — so replying "approve" to a
+    mirrored plan used to consume the prompt AND tell the agent the user rejected it, with no
+    way to answer it in the app afterwards. Those two kinds are deliberately in-app only
+    (`interactions.buttons_for` gives them no buttons and the mirrored text says "Open the app
+    to respond"), so leave them pending instead. A surface that does send the real JSON
+    payload still resolves them.
+    """
+    if item.kind not in (KIND_DIRECTORY, KIND_PLAN):
+        return True
+    return bool(_parse_inbox_json(resolution))
 
 
 def _epoch() -> float:

--- a/tests/test_inbox_reply_resolution.py
+++ b/tests/test_inbox_reply_resolution.py
@@ -1,0 +1,134 @@
+"""A chat reply must resolve an Inbox item the same way the in-app surfaces do.
+
+Directory and plan prompts carry their answer as a JSON payload, but a chat reply only ever
+produces the bare words `allow` / `deny`. Those used to be stored verbatim, parse to `{}`, and
+read as a refusal — so "approve" consumed the prompt and told the agent it was rejected.
+"""
+
+from __future__ import annotations
+
+from coworker.connectors.base import MessageEvent, SessionSource
+from coworker.providers import ModelCapabilities, ProviderClient
+from coworker.server.manager import (
+    SessionManager,
+    _parse_inbox_json,
+    _reply_answers,
+)
+
+
+class NoTurnsProvider(ProviderClient):
+    def complete(self, *, model, messages, tools=None, **settings):
+        raise AssertionError("no model turns expected")
+
+    def capabilities(self, model):
+        return ModelCapabilities()
+
+
+def _manager(tmp_path) -> SessionManager:
+    return SessionManager(data_dir=tmp_path / "data", provider=NoTurnsProvider())
+
+
+def _reply(item_id: str, text: str = "approve") -> MessageEvent:
+    return MessageEvent(
+        text=f"{text} [ow:{item_id}]",
+        source=SessionSource("telegram", "C1", user_id="U1"),
+    )
+
+
+async def test_plan_reply_is_not_consumed_into_a_silent_rejection(tmp_path):
+    manager = _manager(tmp_path)
+    item = manager.inbox.add_plan("s1", "Approve the plan?", body="step 1")
+
+    assert await manager._resolve_inbox_reply(_reply(item.id)) is True
+
+    # Left pending, so it can still be answered in the app — never stored as a bare "allow"
+    # that `_parse_inbox_json` would hand the plan approver as `{}` (i.e. "rejected").
+    assert manager.inbox.get(item.id).state == "pending"
+    assert not _parse_inbox_json(manager.inbox.get(item.id).resolution or "").get(
+        "approved"
+    )
+    assert manager.inbox.get(item.id).resolution != "allow"
+
+
+async def test_directory_reply_is_not_consumed_into_a_silent_refusal(tmp_path):
+    manager = _manager(tmp_path)
+    item = manager.inbox.add_directory(
+        "s1",
+        "Grant access to a folder?",
+        body="to read the notes",
+        data={"path": "/home/u/notes", "writable": False},
+    )
+
+    assert await manager._resolve_inbox_reply(_reply(item.id)) is True
+    assert manager.inbox.get(item.id).state == "pending"
+    assert manager.inbox.get(item.id).resolution != "allow"
+
+
+async def test_structured_payload_reply_still_resolves(tmp_path):
+    """The JSON payload the in-app surfaces send is still accepted, from any surface."""
+    manager = _manager(tmp_path)
+    item = manager.inbox.add_directory(
+        "s1", "Grant access to a folder?", data={"path": "/home/u/docs"}
+    )
+
+    payload = '{"granted": true}'
+    assert await manager._resolve_inbox_reply(_reply(item.id, payload)) is True
+
+    resolved = manager.inbox.get(item.id)
+    assert resolved.state == "resolved"
+    assert _parse_inbox_json(resolved.resolution).get("granted") is True
+
+
+def test_reply_answers_gate_is_kind_scoped():
+    """The unit behind the fix: only directory/plan demand a structured payload."""
+
+    class _Item:
+        def __init__(self, kind):
+            self.kind = kind
+
+    assert _reply_answers(_Item("approval"), "allow") is True
+    assert _reply_answers(_Item("question"), "us-east-1") is True
+    assert _reply_answers(_Item("notification"), "allow") is True
+
+    assert _reply_answers(_Item("plan"), "allow") is False
+    assert _reply_answers(_Item("plan"), "deny") is False
+    assert _reply_answers(_Item("directory"), "allow") is False
+    assert _reply_answers(_Item("plan"), '{"approved": true}') is True
+    assert _reply_answers(_Item("directory"), '{"granted": true}') is True
+
+
+async def test_approval_and_question_replies_are_unchanged(tmp_path):
+    manager = _manager(tmp_path)
+    approval = manager.inbox.add_approval("s1", "Run `ls`?")
+    question = manager.inbox.add_question("s1", "Which region?")
+
+    assert await manager._resolve_inbox_reply(_reply(approval.id)) is True
+    assert manager.inbox.get(approval.id).resolution == "allow"
+
+    assert await manager._resolve_inbox_reply(_reply(question.id, "us-east-1")) is True
+    assert manager.inbox.get(question.id).resolution == "us-east-1"
+
+
+async def test_non_reply_message_is_not_consumed(tmp_path):
+    manager = _manager(tmp_path)
+    event = MessageEvent(
+        text="just chatting", source=SessionSource("telegram", "C1", user_id="U1")
+    )
+    assert await manager._resolve_inbox_reply(event) is False
+
+
+async def test_reply_durably_resumes_a_session_that_is_not_running(tmp_path):
+    """A reply is a resolution surface like the button — it must rebuild an evicted engine."""
+    manager = _manager(tmp_path)
+    item = manager.inbox.add_approval("s1", "Run `ls`?", tool_call_id="call-1")
+
+    resumed: list[str] = []
+
+    async def _spy(resolved_item) -> None:
+        resumed.append(resolved_item.id)
+
+    manager._durable_resume = _spy  # type: ignore[method-assign]
+
+    assert await manager._resolve_inbox_reply(_reply(item.id)) is True
+    assert manager.inbox.get(item.id).resolution == "allow"
+    assert resumed == [item.id], "the reply path skipped durable resume"

--- a/tests/test_slack_approval_owners.py
+++ b/tests/test_slack_approval_owners.py
@@ -298,7 +298,7 @@ def test_rejected_click_uses_only_slacks_ephemeral_response_url(monkeypatch):
     assert "approval owner" in calls[0][1]["json"]["text"]
 
 
-def test_slack_reply_token_is_owner_only_for_approvals(tmp_path):
+async def test_slack_reply_token_is_owner_only_for_approvals(tmp_path):
     manager = _manager(tmp_path)
     _manual_profile(
         manager,
@@ -311,14 +311,14 @@ def test_slack_reply_token_is_owner_only_for_approvals(tmp_path):
         text=f"approve [ow:{item.id}]",
         source=SessionSource("slack", "C1", user_id="U_MEMBER"),
     )
-    assert manager._resolve_inbox_reply(unauthorized) is True
+    assert await manager._resolve_inbox_reply(unauthorized) is True
     assert manager.inbox.get(item.id).state == "pending"
 
     owner = MessageEvent(
         text=f"approve [ow:{item.id}]",
         source=SessionSource("slack", "C1", user_id="U_OWNER"),
     )
-    assert manager._resolve_inbox_reply(owner) is True
+    assert await manager._resolve_inbox_reply(owner) is True
     assert manager.inbox.get(item.id).resolution == "allow"
 
 


### PR DESCRIPTION
## A chat reply must not silently refuse a plan/directory prompt

Fixes #265

Two defects on one boundary: **resolving an Inbox item over a messaging reply is not
equivalent to resolving it in-app or by button.** No behaviour change for normal use.

### 1 — "approve" is recorded as a rejection, and the prompt is destroyed

`plan` and `directory` prompts carry their answer as a JSON payload (`_parse_inbox_json`),
but a chat reply only ever produces the bare intent word `"allow"` / `"deny"`.
`_resolve_inbox_reply` stored that verbatim, so `_parse_inbox_json("allow")` → `{}` →
`.get("approved")` is `None` → *"the user rejected the plan"*. Same shape for the directory
requester's `.get("granted")`.

The item is also marked resolved, so the in-app card disappears and the user cannot correct it.

**Before / after**, same script (`repro.py`, plan prompt, reply `"approve [ow:…]"`):

```
########## BEFORE (main @ db93d75) ##########
stored resolution : 'allow'
item state        : resolved
plan approver sees: approved=False

BUG: the prompt was consumed and the agent was told the plan was REJECTED.
     It can no longer be answered in the app either:
     re-resolve accepted? False

########## AFTER (this branch) ##########
stored resolution : None
item state        : pending

OK: left pending — still answerable in the app, no silent rejection.
```

**Fix:** `_reply_answers(item, resolution)` — only `directory`/`plan` require a structured
payload; a bare intent/free-text reply leaves them pending. This matches what the product
already intends for those two kinds: `interactions.buttons_for` deliberately gives them no
buttons, and the mirrored message says *"(Open the app to respond.)"*. `approval` and
`question` replies are untouched, and a surface that does send the real JSON payload still
resolves them.

### 2 — the reply path never durably resumes

`resolve_inbox`'s docstring already lists *"channel reply"* as one of its surfaces, but
`_resolve_inbox_reply` called `self.inbox.resolve(...)` directly, so `_durable_resume` never
ran. A live session's waiter still fires, so this only bites the case the Inbox exists for —
an unattended/scheduled run whose engine was evicted or that outlived a restart. It gets
marked resolved and stays parked forever. `_on_interaction` (the button) already goes through
`resolve_inbox`.

```
########## BEFORE ##########          ########## AFTER ##########
resolution stored : 'allow'           resolution stored : 'allow'
durable resume ran: False             durable resume ran: True
```

**Fix:** `_resolve_inbox_reply` is now `async` and awaits `resolve_inbox`. `Gateway` awaits
the resolver only when it returns an awaitable, so the existing sync `reply_resolver`
contract (and `tests/test_gateway_inbox_reply.py`) keeps working unchanged.

### Tests

`tests/test_inbox_reply_resolution.py` (7 new): plan and directory replies stay pending and
are never stored as a bare `"allow"`; the structured-payload path still resolves;
`approval`/`question` replies unchanged; non-reply messages not consumed; a reply durably
resumes a session that isn't running. Plus a kind-scoped unit test of `_reply_answers`.

`tests/test_slack_approval_owners.py::test_slack_reply_token_is_owner_only_for_approvals`
is now `async` and awaits the two calls — assertions unchanged. The Slack approval-owner gate
is unchanged and still runs before any resolution.

Full suite: **896 passed, 1 skipped** (`.venv/bin/pytest tests -q`) — 889 existing + 7 new.
My first baseline run on `main` was 888 passed / 1 skipped / 1 failed, the failure being
`test_ui_refresh_e2e` — flaky and unrelated (already tracked in #210); it passed on re-run.

### Reviewer notes

- **Deliberately chosen "leave pending" over "translate the intent into a payload."**
  Translating would let a chat reply grant a folder or approve a plan, which is a new
  capability — and the mirrored directory message doesn't even show the path being granted
  (it's in `item.data`, not the body), so it would be approving blind. Leaving the item
  pending is the fails-safe reading of the existing design. Happy to switch if you'd rather
  those be answerable from chat.
- **Trade-off:** the replying user now gets no feedback that their reply didn't land — they
  just find the prompt still waiting in the app. That is strictly better than today's silent
  wrong answer, but an ephemeral "open the app to answer this one" (like
  `Gateway.reject_interaction` does for buttons) would be the natural follow-up. Left out to
  keep this diff on one concern.
- The intent parser's substring matching (`"notes"` contains `"no"`) is **out of scope** here
  — that's #160, already covered by open PRs. It does mean the JSON escape hatch is hard to
  reach over chat in practice; the guard is written so it starts working the moment #160
  lands, and it's exercised directly by the unit test.
- No screenshots: this is a backend/messaging path with no UI surface. The before/after
  console transcripts above are the equivalent proof, and both repro scripts are ~50 lines if
  you'd like them attached.
