### PR TITLE
fix(gui): open external links in system browser (fixes #270)

### DIFF
--- a/surfaces/gui/src-tauri/Cargo.lock
+++ b/surfaces/gui/src-tauri/Cargo.lock
@@ -1937,6 +1937,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,6 +2684,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "open"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +2711,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
+ "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "uuid",
@@ -4073,6 +4104,28 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows 0.61.3",
+ "zbus",
 ]
 
 [[package]]

--- a/surfaces/gui/src-tauri/Cargo.toml
+++ b/surfaces/gui/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }

--- a/surfaces/gui/src-tauri/capabilities/default.json
+++ b/surfaces/gui/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:window:allow-set-focus",
     "core:window:allow-unminimize",
     "dialog:default",
-    "autostart:default"
+    "autostart:default",
+    "opener:default"
   ]
 }

--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -598,6 +598,7 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
             None,
@@ -699,6 +700,28 @@ pub fn run() {
                     // worked, DMGs didn't. main.tsx guards against drops outside the
                     // composer navigating the page.
                     .disable_drag_drop_handler()
+                    // External links must open in the system browser, never navigate the SPA
+                    // away. This catches full-page navigations the SPA can't intercept —
+                    // notably the webview's context-menu "Open Link" (issue #270), which was
+                    // silently dropped before. Left-clicks are handled in the SPA (openExternal),
+                    // so anything landing here that isn't the app itself goes to the OS.
+                    .on_navigation(|url| {
+                        let scheme = url.scheme();
+                        let host = url.host_str().unwrap_or("");
+                        // The SPA itself: tauri:// (macOS/Linux prod), http://tauri.localhost
+                        // (Windows prod), the Vite devUrl in dev builds. Any other localhost
+                        // URL (e.g. a preview server the agent started) is still external.
+                        let is_dev_spa = cfg!(debug_assertions)
+                            && host == "localhost"
+                            && url.port() == Some(1420);
+                        if scheme == "tauri" || host == "tauri.localhost" || is_dev_spa {
+                            return true;
+                        }
+                        if matches!(scheme, "http" | "https" | "mailto") {
+                            let _ = tauri_plugin_opener::open_url(url.as_str(), None::<&str>);
+                        }
+                        false
+                    })
                     .initialization_script(&inject);
             #[cfg(target_os = "macos")]
             {

--- a/surfaces/gui/src/components/Markdown.test.tsx
+++ b/surfaces/gui/src/components/Markdown.test.tsx
@@ -30,6 +30,18 @@ describe("Markdown artifact links", () => {
     expect(a.getAttribute("href")).toBe("https://example.com");
   });
 
+  // Issue #270: the desktop webview silently drops target="_blank", so clicks must be routed
+  // through openExternal (window.open here — no __TAURI__ in jsdom) instead of default nav.
+  it("clicking an ordinary link opens it via openExternal, not default navigation", () => {
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    const { container } = render(<Markdown text="see [the docs](https://example.com/x)" />);
+    const a = container.querySelector("a")!;
+    const prevented = !fireEvent.click(a); // fireEvent returns false when defaultPrevented
+    expect(prevented).toBe(true);
+    expect(open).toHaveBeenCalledWith("https://example.com/x", "_blank", "noopener,noreferrer");
+    open.mockRestore();
+  });
+
   it("chip title falls back to the filename when the link text is empty", () => {
     vi.spyOn(window, "dispatchEvent");
     render(<Markdown text="[](artifact:out/report.pdf)" />);

--- a/surfaces/gui/src/components/Markdown.tsx
+++ b/surfaces/gui/src/components/Markdown.tsx
@@ -1,6 +1,7 @@
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Icon } from "./Icon";
+import { openExternal } from "../tauri";
 
 // §34 (UX-016): the agent ends a deliverable turn with plain markdown —
 // [Title](artifact:relative/path) — and the renderer turns it into a chip that opens the
@@ -50,7 +51,21 @@ export function Markdown({ text }: { text: string }) {
               return <ArtifactChip path={href.slice("artifact:".length)} title={title} />;
             }
             return (
-              <a href={href} {...props} target="_blank" rel="noreferrer">
+              <a
+                href={href}
+                {...props}
+                target="_blank"
+                rel="noreferrer"
+                // The desktop webview silently drops target="_blank" (issue #270) — route the
+                // click through the opener plugin instead; in the browser this is window.open.
+                // main.tsx's capture-phase guard handles it first in the desktop shell (and
+                // preventDefaults), so skip when already handled to avoid opening twice.
+                onClick={(e) => {
+                  if (!href || e.defaultPrevented) return;
+                  e.preventDefault();
+                  openExternal(href);
+                }}
+              >
                 {children}
               </a>
             );

--- a/surfaces/gui/src/main.tsx
+++ b/surfaces/gui/src/main.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
 import { initTheme } from "./theme";
-import { platformOS } from "./tauri";
+import { isTauri, openExternal, platformOS } from "./tauri";
 import "./tailwind.css";
 import "./styles.css";
 
@@ -16,6 +16,26 @@ document.documentElement.dataset.platform = platformOS();
 // native drag-drop interception so HTML5 drag events reach the DOM at all — see lib.rs.)
 window.addEventListener("dragover", (e) => e.preventDefault());
 window.addEventListener("drop", (e) => e.preventDefault());
+
+// Desktop shell: any web link that slips past a component-level handler (connector cards,
+// dangerouslySetInnerHTML, future surfaces) must open in the system browser — the webview
+// silently drops target="_blank" popups, which read as "clicking does nothing" (issue #270).
+// Capture phase so it still runs when a component stopPropagation()s in bubble phase.
+if (isTauri()) {
+  window.addEventListener(
+    "click",
+    (e) => {
+      if (e.defaultPrevented || e.button !== 0) return;
+      const anchor = (e.target as HTMLElement | null)?.closest?.("a[href]");
+      if (!(anchor instanceof HTMLAnchorElement)) return;
+      const href = anchor.href;
+      if (!/^https?:/i.test(href)) return; // in-app routes, artifact:, mailto: — not ours
+      e.preventDefault();
+      openExternal(href);
+    },
+    true,
+  );
+}
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/surfaces/gui/src/tauri.ts
+++ b/surfaces/gui/src/tauri.ts
@@ -127,7 +127,7 @@ export const installUpdate = () => invokeStrict<void>("install_update");
 
 /** Best-effort open a URL in the user's browser. Uses the Tauri opener plugin if present, else
  * `window.open`. The caller should also render the raw URL so it stays copyable if both no-op
- * (the desktop webview has no opener plugin wired yet). */
+ * (in the browser build a popup blocker can still swallow window.open). */
 export function openExternal(url: string): void {
   const opener = (globalThis as any).__TAURI__?.opener;
   if (opener?.openUrl) {


### PR DESCRIPTION
Fixes #270 — links reported by OpenWorker could not be opened by left-click or right-click "Open Link"; nothing happened and no permission dialog appeared (v0.1.6, macOS).

## Root cause

- The desktop shell never wired up an opener: `tauri-plugin-opener` was not a dependency, not registered in `lib.rs`, and no `opener` permission existed in `capabilities/default.json`. `src/tauri.ts` even noted it: *"the desktop webview has no opener plugin wired yet"*.
- `openExternal()` therefore fell back to `window.open()`, and markdown links rely on `<a target="_blank">` — both are **silently dropped** by the Tauri v2 webview (no popup, no error), which matches the "nothing happens" report.
- Right-click "Open Link" issues a native full-page navigation; with no `on_navigation` handler it was dropped as well.

## Fix

**Rust shell (`surfaces/gui/src-tauri/`)**
- Add `tauri-plugin-opener = "2"`, register `tauri_plugin_opener::init()`, and grant `opener:default`.
- Add an `on_navigation` handler on the main window: the SPA's own origins (`tauri://`, `http://tauri.localhost`, the Vite devUrl in dev builds) stay in-app; any other `http/https/mailto` navigation is handed to the system browser via `open_url` and blocked in the webview — this fixes right-click "Open Link".

**Frontend (`surfaces/gui/src/`)**
- `Markdown.tsx`: external links now `preventDefault()` and go through `openExternal(href)` — this fixes left-click. Browser builds keep the same behavior via `window.open`.
- `main.tsx`: capture-phase click fallback (desktop only) so links rendered outside `Markdown` (connector cards, future surfaces) also open externally.
- `tauri.ts`: updated the now-stale comment.

## Behavior before / after

| Action (desktop app) | Before | After |
|---|---|---|
| Left-click a web link | silently ignored | opens in system browser |
| Right-click → Open Link | silently ignored | opens in system browser |
| Browser (dev) build | opens new tab | unchanged |
| `artifact:` chips | opens artifact viewer | unchanged |

Note on the screenshot guideline: the broken state renders identically to the fixed state (the bug is that clicking produces no visible response at all), so a static screenshot cannot show the difference. Happy to attach a short screen recording if that helps review.

## Tests

- `npx tsc --noEmit` — clean
- `npx vitest run` — 69/69 passing, including a new `Markdown.test.tsx` case asserting link clicks are prevented and routed through `openExternal`
- `cargo check` — clean
