### PR TITLE
docs: add CLAUDE.md files for Claude Code guidance (#200)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# OpenWorker Root Context
+
+## Project Architecture
+
+- `coworker/`: Python backend engine and agent tools.
+- `surfaces/gui/`: React + TypeScript frontend running on Tauri 2.
+- `tests/`: Pytest test suite for backend functionality.
+
+## Core Setup Commands
+
+- Full Dev Environment: `bash packaging/setup_dev_env.sh`

--- a/coworker/CLAUDE.md
+++ b/coworker/CLAUDE.md
@@ -1,0 +1,9 @@
+# Coworker Engine (Python Backend)
+
+## Architecture
+Contains agent orchestration logic, tool registries, and FastAPI API routes.
+
+## Guidelines
+- Follow PEP 8 styling with explicit type hints.
+- Use asynchronous functions (`async def`) for I/O operations and API endpoints.
+- Maintain test coverage in `tests/` for new tools and services.

--- a/surfaces/gui/CLAUDE.md
+++ b/surfaces/gui/CLAUDE.md
@@ -1,0 +1,10 @@
+# GUI Surface (React + Tauri)
+
+## Core Commands
+- Install Dependencies: `npm install`
+- Development Server: `npm run dev` or `npm run tauri dev`
+- Type Check & Lint: `npm run typecheck` && `npm run lint`
+
+## Guidelines
+- Write modular functional React components using TypeScript interfaces for props.
+- Keep UI components responsive and maintain design system styles.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,9 @@
+# Test Suite Guidelines
+
+## Running Tests
+- Execute all tests: `pytest`
+- Execute specific test file: `pytest tests/<filename>.py`
+
+## Conventions
+- Use `pytest` fixtures for modular test context and setup.
+- Ensure proper exception testing and mock external network calls.


### PR DESCRIPTION
Closes #200

Added `CLAUDE.md` context files across the requested directories to provide guidance for Claude Code assistant:
- Root directory (`/`)
- Backend engine (`coworker/`)
- Frontend surface (`surfaces/gui/`)
- Test suite (`tests/`)