### PR TITLE
Add Novita AI provider

### DIFF
--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -11,7 +11,8 @@ Today: `openai` (the default, with an optional custom endpoint that covers Azure
 `AnthropicProvider`), `gemini` (native Google GenAI API via `GeminiProvider`), `bedrock`
 (models in the user's own AWS account — Claude natively, everything else via Converse),
 `vertex` (the user's own GCP project — Gemini and Claude natively, open-weight via the
-MaaS endpoint), and `ollama` (local, OpenAI-compatible `/v1`).
+MaaS endpoint), `novita` (OpenAI-compatible Novita Cloud), and `ollama` (local,
+OpenAI-compatible `/v1`).
 """
 
 from __future__ import annotations
@@ -184,10 +185,11 @@ def _build_ollama(profile: dict[str, Any], secrets: Any) -> ProviderClient:
 
 def _openai_compat(vendor: str, default_base_url: str, env_key: Optional[str] = None):
     """Builder factory for vendors reached through their OpenAI-compatible API (Z AI, DeepSeek,
-    Kimi, MiniMax, Qwen, xAI, Mistral). The key is resolved from the vendor's OWN profile (or its
-    env var) — deliberately NOT from the OpenAI env/SecretStore fallback, so a configured OpenAI
-    key is never silently sent to a different vendor's endpoint. Missing key ⇒ fail fast with a
-    vendor-named error (these are only built on demand, when one of their models is selected).
+    Kimi, MiniMax, Qwen, xAI, Mistral, Novita). The key is resolved from the vendor's OWN
+    profile (or its env var) — deliberately NOT from the OpenAI env/SecretStore fallback, so a
+    configured OpenAI key is never silently sent to a different vendor's endpoint. Missing key ⇒
+    fail fast with a vendor-named error (these are only built on demand, when one of their models
+    is selected).
     """
 
     def build(profile: dict[str, Any], secrets: Any) -> ProviderClient:
@@ -209,7 +211,7 @@ def _compat(
     title: str,
     *,
     base_url: str,
-    recommended_model: str,
+    recommended_model: Optional[str] = None,
     env_key: str,
     endpoint_help: str = "",
 ) -> ProviderDescriptor:
@@ -518,6 +520,13 @@ DESCRIPTORS: list[ProviderDescriptor] = [
         recommended_model="muse-spark-1.1",
         env_key="META_API_KEY",
         endpoint_help="Prefilled with the Meta Model API endpoint (public preview, US-only as of 2026-07).",
+    ),
+    _compat(
+        "novita",
+        "Novita AI",
+        base_url="https://api.novita.ai/openai/v1",
+        env_key="NOVITA_API_KEY",
+        endpoint_help="Prefilled with Novita's OpenAI-compatible endpoint; keep it unless you use a regional or proxy variant.",
     ),
     # Resellers: many labs' models behind one key, using THEIR model namespaces (the curated
     # ids + display labels live in providers/matrix.py). TODO: add Groq here (+ its matrix

--- a/surfaces/gui/src/providers/ProviderSetup.tsx
+++ b/surfaces/gui/src/providers/ProviderSetup.tsx
@@ -29,6 +29,7 @@ export const KEY_HELP: Record<string, { url: string; label: string }> = {
   kimi: { url: "https://platform.moonshot.ai/console/api-keys", label: "platform.moonshot.ai" },
   deepseek: { url: "https://platform.deepseek.com/api_keys", label: "platform.deepseek.com" },
   mistral: { url: "https://console.mistral.ai/api-keys", label: "console.mistral.ai" },
+  novita: { url: "https://novita.ai/", label: "novita.ai" },
   qwen: { url: "https://modelstudio.console.alibabacloud.com", label: "alibabacloud.com" },
   minimax: { url: "https://platform.minimax.io", label: "platform.minimax.io" },
   xai: { url: "https://console.x.ai", label: "console.x.ai" },

--- a/surfaces/gui/src/providers/logos.ts
+++ b/surfaces/gui/src/providers/logos.ts
@@ -48,6 +48,7 @@ export const PROVIDER_ORDER = [
   "openai",
   "gemini",
   "meta",
+  "novita",
   "ollama",
   "bedrock",
   "vertex",

--- a/tests/test_provider_router.py
+++ b/tests/test_provider_router.py
@@ -71,6 +71,20 @@ def test_build_ollama_client_uses_base_url(monkeypatch):
     assert captured["api_key"] == "ollama"  # placeholder, Ollama ignores it
 
 
+def test_build_novita_client_uses_base_url(monkeypatch):
+    captured: dict = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("openai.OpenAI", FakeOpenAI)
+    client = build_provider_client("novita", {"api_key": "sk-nov"}, secrets=None)
+    client._ensure_client()  # type: ignore[attr-defined]
+    assert captured["base_url"] == "https://api.novita.ai/openai/v1"
+    assert captured["api_key"] == "sk-nov"
+
+
 # -- router routing -------------------------------------------------------------
 class _Recorder(ProviderClient):
     def __init__(self, name: str):

--- a/tests/test_provider_verify.py
+++ b/tests/test_provider_verify.py
@@ -59,6 +59,14 @@ def test_verify_openai_custom_endpoint(monkeypatch):
     assert cap["url"] == "https://gw.example/openai/v1/models"
 
 
+def test_verify_novita_uses_openai_compatible_endpoint(monkeypatch):
+    cap: dict = {}
+    _patch_get(monkeypatch, status=200, capture=cap)
+    assert verify_provider_key("novita", api_key="sk-nov") == {"ok": True}
+    assert cap["url"] == "https://api.novita.ai/openai/v1/models"
+    assert cap["headers"]["Authorization"] == "Bearer sk-nov"
+
+
 def test_verify_bad_key_is_invalid(monkeypatch):
     _patch_get(monkeypatch, status=401)
     assert verify_provider_key("openai", api_key="sk-bad") == {


### PR DESCRIPTION
Adds Novita as an OpenAI-compatible provider.

- Registers Novita with the OpenAI-compatible base URL and NOVITA_API_KEY
- Surfaces Novita in the GUI provider setup and provider ordering
- Adds tests for client construction and key verification

Verification:
- pytest -q tests/test_provider_router.py::test_build_novita_client_uses_base_url tests/test_provider_verify.py::test_verify_novita_uses_openai_compatible_endpoint