### PR TITLE
fix: block find -exec auto-run via shell allowlist

### DIFF
--- a/coworker/permissions.py
+++ b/coworker/permissions.py
@@ -20,9 +20,28 @@ from typing import Any, Optional
 # (`` ` `` `$(`), process substitution / grouping (`(`), and newlines.
 _SHELL_OPERATORS = (";", "&", "|", ">", "<", "`", "$(", "(", "\n", "\r")
 
+# find(1) flags that run an arbitrary helper. Shell-operator rejection already blocks the
+# classic `… -exec … ;` form (`;` is an operator), but `… -exec … {} +` has no shell
+# metacharacters — so a bare allowlisted `find` would otherwise auto-run helpers.
+_FIND_HELPER_FLAGS = frozenset({"-exec", "-execdir", "-ok", "-okdir"})
+
 
 def _has_shell_operators(command: str) -> bool:
     return any(op in command for op in _SHELL_OPERATORS)
+
+
+def _unauthorized_find_helper(argv: list[str], prefix: list[str]) -> bool:
+    """True when argv uses find helper-exec flags the allowlist entry did not itself name.
+
+    Allowlisting `find` means inspection (`find . -name '*.py'`). Auto-running
+    `find . -exec … {} +` requires the entry to include that flag (e.g. `find . -exec`).
+    """
+    prog = Path(argv[0]).name.lower()
+    if prog not in {"find", "gfind"}:
+        return False
+    used = {t for t in argv if t in _FIND_HELPER_FLAGS}
+    authorized = {t for t in prefix if t in _FIND_HELPER_FLAGS}
+    return bool(used - authorized)
 
 from .risk import (  # re-exported for back-compat (manager.py imports WRITE_TOOLS)
     SHELL_TOOL,
@@ -219,7 +238,8 @@ class PermissionEngine:
         # carrying shell operators (chaining/redirection/substitution) up front, then match
         # the parsed argv against each entry — the entry's own tokens must be an exact
         # prefix of the command's tokens (so `git status` matches `git status -s` but never
-        # `git statusfoo` or a bare `git`).
+        # `git statusfoo` or a bare `git`). Also reject program-native helper execution
+        # that the entry did not authorize (find -exec / -execdir / -ok / -okdir).
         if _has_shell_operators(command):
             return False
         try:
@@ -233,6 +253,9 @@ class PermissionEngine:
                 prefix = shlex.split(allowed)
             except ValueError:
                 continue
-            if prefix and argv[: len(prefix)] == prefix:
-                return True
+            if not prefix or argv[: len(prefix)] != prefix:
+                continue
+            if _unauthorized_find_helper(argv, prefix):
+                continue
+            return True
         return False

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -3,17 +3,25 @@
 #   <your-project>/.coworker/config.toml    (per-workspace, overrides global)
 #
 # All keys are optional; unset keys fall back to built-in defaults.
+# Note: allowed_commands and auto_allow are global-only — a repo's
+# .coworker/config.toml cannot grant them (untrusted checkout).
 
 model = "gpt-5.5"            # default model id (override per session in the UI/CLI)
 mode = "interactive"         # plan | interactive | auto | custom
 max_iterations = 12          # max model<->tool iterations per turn before stopping
 
-# Commands auto-allowed without an approval prompt (prefix match).
-allowed_commands = [
-  "ls", "cat", "pwd", "grep", "find",
-  "git status", "git diff", "git log",
-  "python3", "pytest", "node", "npm",
-]
+# Commands auto-allowed without an approval prompt (exact argv-prefix match; shell
+# operators rejected). Built-in default is empty: there is no generally safe
+# executable — even "read-only" tools can read secrets outside the workspace or
+# run helpers. Prefer narrow prefixes over bare binaries.
+#
+# Safe-ish inspection examples:
+#   allowed_commands = ["git status", "git diff", "git log", "ls", "pwd"]
+#
+# Do NOT bare-allowlist interpreters or package managers (python3, node, npm) —
+# that auto-approves arbitrary code. Bare `find` allows name searches but not
+# `-exec`/`-execdir`/`-ok`/`-okdir` unless your entry itself names that flag.
+allowed_commands = []
 
 # In "custom" permission mode, these tools are auto-approved (everything else still
 # asks). e.g. auto-accept file edits but keep asking before running shell commands.

--- a/tests/test_permissions_risk.py
+++ b/tests/test_permissions_risk.py
@@ -149,3 +149,45 @@ def test_shell_commands_not_auto_allowed_by_default(tmp_path):
     ):
         d = eng.evaluate("run_shell", {"command": cmd}, None)
         assert not d.allowed and d.needs_user, cmd
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "find . -exec touch /tmp/pwned {} +",
+        "find /tmp -execdir sh -c 'id' {} +",
+        "find . -ok rm {} +",
+        "find . -okdir echo {} +",
+        "/usr/bin/find . -exec cat {} +",
+    ],
+)
+def test_allowlisted_find_rejects_helper_execution(tmp_path, command):
+    # Bare `find` is inspection-only. The `{} +` form has no shell metacharacters, so
+    # operator rejection alone is not enough — helper flags must be denied unless the
+    # allowlist entry itself names them.
+    eng = PermissionEngine(workspace_root=tmp_path, allowed_commands=["find"])
+    d = eng.evaluate("run_shell", {"command": command}, None)
+    assert not d.allowed and d.needs_user, command
+
+
+def test_allowlisted_find_still_allows_inspection(tmp_path):
+    eng = PermissionEngine(workspace_root=tmp_path, allowed_commands=["find"])
+    assert eng.evaluate(
+        "run_shell", {"command": "find . -name '*.py'"}, None
+    ).allowed
+    assert eng.evaluate("run_shell", {"command": "find . -type f"}, None).allowed
+
+
+def test_find_helper_allowed_only_when_entry_names_flag(tmp_path):
+    # Opting into helper execution requires naming the flag in the allowlist entry.
+    eng = PermissionEngine(
+        workspace_root=tmp_path, allowed_commands=["find . -exec"]
+    )
+    assert eng.evaluate(
+        "run_shell", {"command": "find . -exec touch /tmp/x {} +"}, None
+    ).allowed
+    # A different helper flag is still not covered by `-exec`.
+    d = eng.evaluate(
+        "run_shell", {"command": "find . -execdir touch /tmp/x {} +"}, None
+    )
+    assert not d.allowed and d.needs_user


### PR DESCRIPTION
## Summary
- Harden `PermissionEngine._command_allowed` so a bare allowlisted `find` no longer auto-approves helper execution (`-exec` / `-execdir` / `-ok` / `-okdir`), including the `{} +` form that bypasses shell-operator rejection.
- Users who intentionally want that authority can still opt in with a prefix that names the flag (e.g. `find . -exec`).
- Align `docs/config.example.toml` with empty defaults and warn against bare interpreters / unsafe binaries.

## Context
Defaults were already emptied because of `find -exec` (see `coworker/config.py`), but:
1. Operator rejection only catches `… -exec … ;` (`;` is a shell operator), not `… -exec … {} +`.
2. The example config still recommended `find` / `python3` / `node`, which recreated the footgun for anyone copying it.

Verified before fix: `allowed_commands=["find"]` → `find . -exec touch /tmp/pwned {} +` returned `allowed=True`.

## Test plan
- [x] `pytest tests/test_permissions_risk.py tests/test_tools_permissions.py` (50 passed)
- [ ] Confirm allowlisted `find . -name '*.py'` still auto-runs
- [ ] Confirm allowlisted `find` + `find . -exec … {} +` now asks for approval
- [ ] Confirm `allowed_commands = ["find . -exec"]` still auto-allows matching `-exec` commands