### PR TITLE
setup_dev_env.sh: install the bedrock extra so a fresh env passes the test suite

### DIFF
--- a/packaging/setup_dev_env.sh
+++ b/packaging/setup_dev_env.sh
@@ -15,7 +15,9 @@ python3 -m venv "$VENV"
 # aisuite comes in as a regular dependency (git-pinned in pyproject.toml until
 # the next PyPI release).
 "$VENV/bin/pip" install --quiet --upgrade pip
-"$VENV/bin/pip" install --quiet -e "$ROOT[messaging,dev]"
+# Keep the extras in step with CI (.github/workflows/ci.yml) — the bedrock test
+# suite imports boto3 directly, so skipping that extra leaves a fresh env red.
+"$VENV/bin/pip" install --quiet -e "$ROOT[messaging,dev,bedrock]"
 
 "$VENV/bin/python" -c 'import aisuite, coworker' # fail loudly if the wiring broke
 echo "Ready: $VENV"


### PR DESCRIPTION
## What

`packaging/setup_dev_env.sh` installs `.[messaging,dev]`, but CI installs `.[messaging,dev,bedrock]`. The bedrock test suite imports boto3 directly, so a dev env built by the bootstrap script fails 7 tests (`tests/test_bedrock_provider.py`) out of the box.

One-line fix: add `bedrock` to the script's extras so the local env matches CI.

Closes #284

## Before

Fresh env from `packaging/setup_dev_env.sh`, then `.venv/bin/pytest tests -q`:

![7 failed on a fresh env](https://raw.githubusercontent.com/xiaonancui/openworker/assets/pr-assets/before_7_failed.png)

## After

Same tree, env rebuilt with the fixed script (verified end-to-end: deleted `.venv`, re-ran the script, re-ran the suite):

![930 passed](https://raw.githubusercontent.com/xiaonancui/openworker/assets/pr-assets/after_930_passed.png)