### PR TITLE
Fix platform-specific approval scope wording

### DIFF
--- a/surfaces/gui/e2e/approval-card.spec.ts
+++ b/surfaces/gui/e2e/approval-card.spec.ts
@@ -1,7 +1,7 @@
 // §35 (UX-018): approval cards speak the transcript's language. Routine workspace writes
 // are a compact ROW (humanized title, inline args-preview, short "Always allow" with the
 // full rule on hover); everything else is a full card — shell titles with the model's
-// description, external actions wear the leaves-this-Mac note. No "PERMISSION REQUIRED"
+// description, external actions wear the leaves-this-computer note. No "PERMISSION REQUIRED"
 // kicker, no raw args dump, no solid-fill buttons.
 import { expect } from "@playwright/test";
 import { test } from "./fixtures";
@@ -34,7 +34,7 @@ test("routine write → compact row: humanized title, inline preview, Allow reso
   await expect(page.getByText(/Done via write_file/)).toBeVisible();
 });
 
-test("run_shell → full card: description title, command preview, stays-on-this-Mac note", async ({
+test("run_shell → full card: description title, command preview, stays-on-this-computer note", async ({
   page,
 }) => {
   await page.goto("/");
@@ -45,7 +45,7 @@ test("run_shell → full card: description title, command preview, stays-on-this
   // The mocked proposal has no description → plain "Run a command" title; the command is
   // the preview; the reason still renders; the scope note replaces the old badge.
   await expect(page.getByText("Run a command").last()).toBeVisible();
-  await expect(page.getByText("stays on this Mac").last()).toBeVisible();
+  await expect(page.getByText("stays on this computer").last()).toBeVisible();
   await expect(page.getByText("The coworker wants to run a command.").first()).toBeVisible();
   await expect(page.getByRole("button", { name: "Always allow this command" }).last()).toBeVisible();
   await expect(page.getByText(/local action/)).toHaveCount(0);

--- a/surfaces/gui/src/components/ApprovalCard.test.tsx
+++ b/surfaces/gui/src/components/ApprovalCard.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { ApprovalCard } from "./ApprovalCard";
+import { ApprovalCard, scopeNote } from "./ApprovalCard";
 import { InboxItemCard } from "./InboxItemCard";
 import type { Item } from "../types";
 import type { InboxItem } from "../api";
@@ -19,6 +19,15 @@ const sendApproval = (extra: Partial<ApprovalItem> = {}): ApprovalItem => ({
 });
 
 afterEach(cleanup);
+
+describe("scopeNote — cross-platform copy", () => {
+  it("describes an overwriting file write without naming the operating system", () => {
+    expect(scopeNote("write_file", { overwrite: true })).toEqual({
+      text: "stays on this computer · overwrites the existing file",
+      external: false,
+    });
+  });
+});
 
 describe("ApprovalCard — standing scoped approvals (§25)", () => {
   it("offers Allow every time only with BOTH a run context and an eligible target", () => {
@@ -110,7 +119,7 @@ describe("ApprovalCard — §35 shapes", () => {
     expect(onApprove).toHaveBeenCalledWith("once");
   });
 
-  it("send_file gets the full external card: destination title, file chip, leaves-the-Mac note", () => {
+  it("send_file gets the full external card: destination title, file chip, leaves-the-computer note", () => {
     render(
       <ApprovalCard
         item={sendApproval({
@@ -121,7 +130,7 @@ describe("ApprovalCard — §35 shapes", () => {
       />,
     );
     expect(screen.getByText(/Send a file to/).textContent).toContain("C9");
-    expect(screen.getByText(/leaves this Mac → Slack/)).toBeTruthy();
+    expect(screen.getByText(/leaves this computer → Slack/)).toBeTruthy();
     expect(screen.getByText(/report\.pdf/)).toBeTruthy();
     expect(screen.getByText(/here you go/)).toBeTruthy();
     expect(screen.getByText("Allow once")).toBeTruthy();
@@ -159,7 +168,7 @@ describe("ApprovalCard — §35 shapes", () => {
     );
     expect(screen.getByText(/Run a command — fetch semiconductor stock data/)).toBeTruthy();
     expect(screen.getByText(/python3 fetch\.py/)).toBeTruthy();
-    expect(screen.getByText(/stays on this Mac/)).toBeTruthy();
+    expect(screen.getByText(/stays on this computer/)).toBeTruthy();
     expect(screen.getByText("Always allow this command")).toBeTruthy();
   });
 });
@@ -213,7 +222,7 @@ describe("InboxItemCard — Allow every time on parked run approvals", () => {
     expect(screen.getByText("fetch_data.py")).toBeTruthy();
     expect(screen.queryByText("Run `send_message`?")).toBeNull();
     expect(screen.getByText(/import json/)).toBeTruthy();
-    expect(screen.getByText(/stays on this Mac/)).toBeTruthy();
+    expect(screen.getByText(/stays on this computer/)).toBeTruthy();
     // §35 labels; resolution vocabulary unchanged (works on every approver path).
     fireEvent.click(screen.getByText("Allow once"));
     expect(onResolve).toHaveBeenCalledWith("i1", "allow");

--- a/surfaces/gui/src/components/ApprovalCard.tsx
+++ b/surfaces/gui/src/components/ApprovalCard.tsx
@@ -27,7 +27,7 @@ const TOOL_VERBS: Record<string, string> = {
 
 // §35: routine workspace writes render as a compact ROW; everything else is a full card.
 const FILE_WRITES = new Set(["write_file", "replace_in_file", "apply_patch", "apply_unified_diff"]);
-// Actions that leave the Mac get the warm border + explicit destination note.
+// Actions that leave the computer get the warm border + explicit destination note.
 const EXTERNAL = new Set(["send_message", "send_file"]);
 
 type ApprovalItem = Extract<Item, { kind: "approval" }>;
@@ -69,10 +69,10 @@ export function scopeNote(
   if (EXTERNAL.has(name)) {
     const platform = String(args?.target ?? "").split(":")[0];
     const names: Record<string, string> = { slack: "Slack", telegram: "Telegram" };
-    return { text: `leaves this Mac → ${names[platform] || platform || "a connected chat"}`, external: true };
+    return { text: `leaves this computer → ${names[platform] || platform || "a connected chat"}`, external: true };
   }
   const overwrite = name === "write_file" && args?.overwrite;
-  return { text: "stays on this Mac" + (overwrite ? " · overwrites the existing file" : ""), external: false };
+  return { text: "stays on this computer" + (overwrite ? " · overwrites the existing file" : ""), external: false };
 }
 
 // The proposed content/command, straight from the tool call's ARGS — the file/action


### PR DESCRIPTION
## Summary

- replace macOS-specific approval scope copy with the existing platform-neutral “this computer” terminology
- apply the wording consistently to local actions and actions that leave the computer
- add direct regression coverage for overwriting file writes and update the rendered-card unit/E2E expectations

Closes #283.

## Screenshots

### Before — Windows shows “stays on this Mac”

![Windows approval dialog with Mac-specific wording](https://github.com/user-attachments/assets/8331a38c-ea53-4fb6-bcf3-a9b11716c9cf)

### After — platform-neutral approval scope

![Approval card showing stays on this computer](https://raw.githubusercontent.com/yaodong-shen/openworker/pr-assets-283/openworker-283-after.png)

## Testing

- `vitest run src/components/ApprovalCard.test.tsx` — 10 passed
- `vitest run` on Node 20.20.2 — 75 passed
- TypeScript compile and Vite production build on Node 20.20.2 — passed
- `playwright test e2e/approval-card.spec.ts` — 3 passed
- full CI-mode Playwright run — 151 passed, 3 passed on retry, exit 0
