### PR TITLE
Web: add Linkup as a web_search provider

### DIFF
--- a/coworker/config.py
+++ b/coworker/config.py
@@ -37,7 +37,8 @@ class Config:
     auto_allow: list[str] = field(default_factory=list)
     host: str = "127.0.0.1"
     port: int = 8765
-    # Web search provider: "duckduckgo" (keyless default) | "tavily" | "brave" (need a key).
+    # Web search provider: "duckduckgo" (keyless default) | "tavily" | "brave" | "linkup"
+    # (need a key).
     web_search_provider: str = "duckduckgo"
     # OpenWorker Cloud (sign-in + managed connectors). Config, never constants:
     # dev/staging/BYO-VPC deployments point these at their own instances.

--- a/coworker/web/__init__.py
+++ b/coworker/web/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .providers import (
     BraveProvider,
     DuckDuckGoProvider,
+    LinkupProvider,
     SearchResult,
     TavilyProvider,
     WebSearchProvider,
@@ -20,6 +21,7 @@ __all__ = [
     "DuckDuckGoProvider",
     "TavilyProvider",
     "BraveProvider",
+    "LinkupProvider",
     "build_provider",
     "provider_names",
     "make_web_search_tool",

--- a/coworker/web/providers.py
+++ b/coworker/web/providers.py
@@ -1,8 +1,8 @@
 """Web search providers — a keyless default + pluggable third-party services.
 
-`duckduckgo` works with no API key (our "starting version of our own"). `tavily` and `brave`
-give better results but need a key (configured via the SecretStore / env). All providers
-return a uniform `list[SearchResult]`; the heavy client libs are lazy-imported.
+`duckduckgo` works with no API key (our "starting version of our own"). `tavily`, `brave`, and
+`linkup` give better results but need a key (configured via the SecretStore / env). All
+providers return a uniform `list[SearchResult]`; the heavy client libs are lazy-imported.
 """
 
 from __future__ import annotations
@@ -108,10 +108,45 @@ class BraveProvider(WebSearchProvider):
         ]
 
 
+class LinkupProvider(WebSearchProvider):
+    name = "linkup"
+    requires_key = True
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+        import httpx
+
+        resp = httpx.post(
+            "https://api.linkup.so/v1/search",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            json={
+                "q": query,
+                # "fast" is the low-latency tier, the right fit for snippet lookup;
+                # the heavier tiers add passes aimed at multi-step research.
+                "depth": "fast",
+                "outputType": "searchResults",
+                "maxResults": max_results,
+            },
+            timeout=_TIMEOUT,
+        )
+        data = resp.json()
+        return [
+            SearchResult(
+                title=r.get("name", ""),
+                url=r.get("url", ""),
+                snippet=r.get("content", ""),
+            )
+            for r in data.get("results", [])
+        ]
+
+
 _PROVIDERS = {
     "duckduckgo": DuckDuckGoProvider,
     "tavily": TavilyProvider,
     "brave": BraveProvider,
+    "linkup": LinkupProvider,
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "mcp>=1.1",  # MCP client (stdio + streamable-http); we use our own async layer on it
     "httpx>=0.27",  # sync outbound senders for messaging connectors (send_message tool)
     "websockets>=13",  # managed Slack relay client transport (relay_client.py)
-    "ddgs>=9",  # keyless default web-search provider (DuckDuckGo); Tavily/Brave use httpx
+    "ddgs>=9",  # keyless default web-search provider (DuckDuckGo); Tavily/Brave/Linkup use httpx
     "croniter>=2",  # cron next-fire math for the automation scheduler
     # PDF attachments for models without native PDF support (pdf_support.py):
     # pypdf = pure-python text extraction; pypdfium2 = page rasterization (BSD pdfium,

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -1,7 +1,7 @@
 """Tests for web search — provider abstraction, the tool, and config resolution.
 
 No network: a FakeProvider is injected; third-party key handling and the REST config path
-are exercised without hitting DuckDuckGo/Tavily/Brave.
+are exercised without hitting DuckDuckGo/Tavily/Brave/Linkup.
 """
 
 from __future__ import annotations
@@ -18,6 +18,7 @@ from coworker.web import (
 from coworker.web.providers import (
     BraveProvider,
     DuckDuckGoProvider,
+    LinkupProvider,
     TavilyProvider,
     WebSearchProvider,
 )
@@ -77,8 +78,52 @@ def test_build_provider_default_is_keyless_duckduckgo():
 def test_build_provider_third_party_requires_key():
     with pytest.raises(ValueError):
         build_provider("tavily")  # no key
+    with pytest.raises(ValueError):
+        build_provider("linkup")  # no key
     assert isinstance(build_provider("tavily", "tvly-x"), TavilyProvider)
     assert isinstance(build_provider("brave", "brv-x"), BraveProvider)
+    assert isinstance(build_provider("linkup", "lp-x"), LinkupProvider)
+    assert "linkup" in provider_names()
+
+
+def test_linkup_maps_response_to_search_results(monkeypatch):
+    """Linkup names its fields `name`/`content`; check the mapping and the request shape."""
+    import httpx
+
+    sent: dict = {}
+
+    def fake_post(url, **kwargs):
+        sent["url"] = url
+        sent.update(kwargs)
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "type": "text",
+                        "name": "Result one",
+                        "url": "https://example.com/1",
+                        "content": "snippet one",
+                        "favicon": "https://example.com/favicon.ico",
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    results = LinkupProvider("lp-x").search("anthropic", max_results=3)
+
+    assert [(r.title, r.url, r.snippet) for r in results] == [
+        ("Result one", "https://example.com/1", "snippet one")
+    ]
+    assert sent["url"] == "https://api.linkup.so/v1/search"
+    assert sent["headers"]["Authorization"] == "Bearer lp-x"
+    assert sent["json"] == {
+        "q": "anthropic",
+        "depth": "fast",
+        "outputType": "searchResults",
+        "maxResults": 3,
+    }
 
 
 def test_tool_surfaces_missing_key_error(tmp_path):


### PR DESCRIPTION
## Summary

Disclosure up front: I work with Linkup.

Adds `linkup` alongside `duckduckgo` (keyless default), `tavily` and `brave`. It's a provider class plus one `_PROVIDERS` entry — no new abstractions — so it picks up `GET/POST /v1/web-search`, the `web_search_provider` config key, the `web_search:default` SecretStore profile and `LINKUP_API_KEY` resolution from the existing registry wiring.

**No behavior changes.** The keyless DuckDuckGo default is untouched.

## Configuration

```toml
# global or workspace config.toml
web_search_provider = "linkup"
```

Key via `LINKUP_API_KEY`, the SecretStore profile, or `POST /v1/web-search`.

## Notes on the implementation

Linkup names its result fields `name` and `content`, so the mapping to `SearchResult` differs from Tavily's; result count is `maxResults`.

`outputType` is `searchResults` — the raw sources — since `sourcedAnswer` returns synthesized prose and `structured` needs a caller-supplied schema, neither of which fits the title/url/snippet contract.

`depth` is `fast`. Across keyword, factual and news queries the `fast` and `standard` tiers returned identical result sets, with `fast` consistently 22–30% quicker (e.g. 1.57s vs 2.25s). They diverge only on instruction-style queries, where `standard` will scrape a URL handed to it in the prompt — a capability `web_fetch` already covers here, so there's no reason to pay the latency on every search. It's also the tier the benchmarks below measure.

The provider keeps to the uniform `SearchResult` contract and adds no agent-facing surface area: no new tools, no changes to the `web_search` schema, nothing for other providers to absorb.

## Benchmarks

Linkup publishes accuracy evaluations for its search endpoints, and the harness is open source, so these are reproducible rather than assertions. On Verified SimpleQA — OpenAI's fact-seeking suite, scored by F1 across sub-second search APIs — Linkup's fast tier, the one this provider uses, leads at 92%, ahead of Perplexity Sonar (87%), Gemini 3 Flash (85%), Serper (83%), Tavily (79%) and Exa (63%). On SealQA-0, Linkup's research tier ranks first at 61%. Vertical evaluations on GTM, legal and finance workflows show the same ordering. The harness is public if anyone wants to re-run it against the providers already wired up here.

Methodology and full results: https://www.linkup.so/benchmarks

## Testing

`pytest tests -q` → **931 passed, 1 skipped**.

`tests/test_web_search.py` gains coverage for the key requirement and for the exact request body, auth header and response mapping. No network — the Linkup call is stubbed.

Unrelated, in case it's useful: on a clean install `mcp>=1.1` now resolves to mcp 2.0, which removed `streamablehttp_client`, so `coworker/mcp/client.py` raises on import and the pytest job fails before it can collect. I pinned `mcp<2` locally to run the suite. Happy to send that as its own PR.
