### PR TITLE
Fix MCP streamable-http import for mcp>=2.0 (fixes #298)

### DIFF
--- a/coworker/mcp/client.py
+++ b/coworker/mcp/client.py
@@ -18,7 +18,13 @@ from typing import Any, Optional
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
+
+try:  # mcp >= 2.0
+    from mcp.client.streamable_http import streamable_http_client
+except ImportError:  # mcp < 2.0
+    from mcp.client.streamable_http import (  # type: ignore[no-redef]
+        streamablehttp_client as streamable_http_client,
+    )
 
 from .config import MCPServerDef
 
@@ -109,7 +115,7 @@ class MCPManager:
                             interactive=interactive,
                         )
                     read, write, *_ = await stack.enter_async_context(
-                        streamablehttp_client(
+                        streamable_http_client(
                             server.url, headers=server.headers or None, auth=auth
                         )
                     )


### PR DESCRIPTION
Fixes #298

## Problem

`mcp` 2.0 renamed `streamablehttp_client` → `streamable_http_client`. Since `pyproject.toml` allows `mcp>=1.1`, a fresh `packaging/setup_dev_env.sh` resolves to `mcp==2.0.0` and the server dies at startup:

```text
ImportError: cannot import name 'streamablehttp_client' from 'mcp.client.streamable_http'
```

Confirmed on the installed 2.0.0: `mcp.client.streamable_http` exports `streamable_http_client`, `create_mcp_http_client`, and `ClientMessageMetadata` — the old name is gone.

## Fix

Import the new name in [coworker/mcp/client.py](coworker/mcp/client.py), falling back to the old one on `mcp<2.0`:

```python
try:  # mcp >= 2.0
    from mcp.client.streamable_http import streamable_http_client
except ImportError:  # mcp < 2.0
    from mcp.client.streamable_http import (  # type: ignore[no-redef]
        streamablehttp_client as streamable_http_client,
    )
```

The call site in `MCPManager` uses the new name. The two symbols are the same async context manager yielding `(read, write, ...)`, so nothing else changes.

I went with a compat shim rather than pinning `mcp>=2.0` so the declared `mcp>=1.1` range keeps working and nobody with an existing 1.x environment has to reinstall. Happy to switch to a hard bump of the constraint instead if you'd prefer to just drop 1.x — just say which you want.

## Verification

`mcp==2.0.0`, Python 3.14: `python -c "from coworker.mcp import client"` imports cleanly, where it raised `ImportError` before.

