### PR TITLE
Add configurable composer Enter behavior

### DIFF
--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -1354,6 +1354,12 @@ def create_app(manager: SessionManager) -> FastAPI:
         b = body or {}
         return manager.set_surfaces(chat=b.get("chat"), code=b.get("code"))
 
+    @app.post("/v1/settings/composer-enter-behavior")
+    def settings_set_composer_enter_behavior(body: dict) -> dict[str, Any]:
+        return manager.set_composer_enter_behavior(
+            str((body or {}).get("composer_enter_behavior", ""))
+        )
+
     @app.post("/v1/settings/scratch-base")
     def settings_set_scratch_base(body: dict) -> dict[str, Any]:
         return manager.set_scratch_base(str((body or {}).get("path", "")))

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1773,6 +1773,7 @@ class SessionManager:
             "onboarded": bool(self._prefs.get("onboarded")),
             "experimental_connectors": experimental_enabled(self.secrets),
             "surfaces": self._surfaces(),
+            "composer_enter_behavior": self.composer_enter_behavior(),
             "nav_layout": self._nav_layout(),
             "sessions_peek": self.sessions_peek(),
             "scratch_base": self._prefs.get("scratch_base")
@@ -1802,6 +1803,23 @@ class SessionManager:
             self._prefs["show_code"] = bool(code)
         self._save_prefs()
         return {"ok": True, "surfaces": self._surfaces()}
+
+    def composer_enter_behavior(self) -> str:
+        """Composer Enter-key preference: ``"send"`` (default) or ``"newline"``."""
+        return (
+            "newline"
+            if self._prefs.get("composer_enter_behavior") == "newline"
+            else "send"
+        )
+
+    def set_composer_enter_behavior(self, behavior: str) -> dict[str, Any]:
+        """Set + persist the composer's Enter-key behavior. Unknown values fall back to
+        ``"send"``.
+        """
+        value = "newline" if (behavior or "").strip() == "newline" else "send"
+        self._prefs["composer_enter_behavior"] = value
+        self._save_prefs()
+        return {"ok": True, "composer_enter_behavior": value}
 
     def _nav_layout(self) -> str:
         """Sidebar layout: ``"flat"`` (default) or ``"grouped"`` (by persona). Persisted in

--- a/surfaces/gui/e2e/composer.spec.ts
+++ b/surfaces/gui/e2e/composer.spec.ts
@@ -96,3 +96,22 @@ test("composer: PDF over the page threshold is rejected with a notice", async ({
   });
   await expect(page.locator(".attach-chip")).toContainText("small.pdf");
 });
+
+test("composer: Enter-key behavior follows the user preference", async ({ page }) => {
+  await page.goto("/");
+  await page.getByText("Draft the launch note").first().click();
+
+  const box = page.getByPlaceholder(/Ask the coworker/);
+
+  await box.fill("send this now");
+  await box.press("Enter");
+  await expect(box).toHaveValue("");
+
+  await page.getByTestId("account-row").click();
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  const [req] = await Promise.all([
+    page.waitForRequest((r) => r.url().endsWith("/v1/settings/composer-enter-behavior") && r.method() === "POST"),
+    page.getByTestId("composer-enter-behavior").getByRole("button", { name: "Newline on Enter" }).click(),
+  ]);
+  expect(req.postDataJSON()).toEqual({ composer_enter_behavior: "newline" });
+});

--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -32,6 +32,7 @@ const SETTINGS = {
   onboarded: true,
   experimental_connectors: false,
   surfaces: { cowork: true, chat: false, code: true },
+  composer_enter_behavior: "send",
   nav_layout: "grouped",
   scratch_base: "~/OpenWorker",
   secrets_path: "/Users/test/.config/coworker/secrets.json",
@@ -539,6 +540,13 @@ export async function mockApi(page: import("@playwright/test").Page) {
   // Providers — mutable so save (POST) flips `configured` and stamps key_set_at, matching the
   // backend's set_provider. verify (POST) never mutates: it's a live read-only credential check.
   const providers: any[] = PROVIDERS.map((p) => ({ ...p }));
+  // Settings — PER-TEST copy so preference-editing specs (like composer Enter behavior and
+  // PDF token-savings thresholds) never leak mutated values into sibling tests.
+  const settings = {
+    ...SETTINGS,
+    surfaces: { ...SETTINGS.surfaces },
+    model_labels: { ...SETTINGS.model_labels },
+  };
   // Automations — mutable so Run now appends a run, enable/disable toggles, and delete removes.
   const automations: any[] = [{ ...AUTOMATION }, { ...AUTOMATION_CLEAN }];
   // MCP servers (empty by default; the granola OAuth quick-add test populates it).
@@ -809,14 +817,21 @@ export async function mockApi(page: import("@playwright/test").Page) {
     }
 
     if (p.endsWith("/v1/health")) return json(HEALTH);
-    if (p.endsWith("/v1/settings")) return json(SETTINGS);
-    if (p.endsWith("/v1/settings/pdf") && m === "POST") {
-      Object.assign(SETTINGS, req.postDataJSON());
+    if (p.endsWith("/v1/settings")) return json(settings);
+    if (p.endsWith("/v1/settings/composer-enter-behavior") && m === "POST") {
+      Object.assign(settings, req.postDataJSON());
       return json({
         ok: true,
-        pdf_fallback: SETTINGS.pdf_fallback,
-        pdf_max_pages: SETTINGS.pdf_max_pages,
-        pdf_max_mb: SETTINGS.pdf_max_mb,
+        composer_enter_behavior: settings.composer_enter_behavior,
+      });
+    }
+    if (p.endsWith("/v1/settings/pdf") && m === "POST") {
+      Object.assign(settings, req.postDataJSON());
+      return json({
+        ok: true,
+        pdf_fallback: settings.pdf_fallback,
+        pdf_max_pages: settings.pdf_max_pages,
+        pdf_max_mb: settings.pdf_max_mb,
       });
     }
     if (p.endsWith("/v1/attachments/inspect-pdf") && m === "POST") {

--- a/surfaces/gui/e2e/settings.spec.ts
+++ b/surfaces/gui/e2e/settings.spec.ts
@@ -119,3 +119,21 @@ test("Settings: Token savings card edits PDF fallback and thresholds", async ({ 
   ]);
   expect(req2.postDataJSON()).toEqual({ pdf_max_pages: 30 });
 });
+
+test("Settings: Composer card edits Enter key behavior", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("account-row").click();
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+
+  const card = page.getByTestId("composer-card");
+  await expect(card).toBeVisible();
+  const seg = page.getByTestId("composer-enter-behavior");
+  await expect(seg.getByRole("button", { name: "Send on Enter" })).toHaveClass(/active/);
+
+  const [req] = await Promise.all([
+    page.waitForRequest((r) => r.url().endsWith("/v1/settings/composer-enter-behavior") && r.method() === "POST"),
+    seg.getByRole("button", { name: "Newline on Enter" }).click(),
+  ]);
+  expect(req.postDataJSON()).toEqual({ composer_enter_behavior: "newline" });
+  await expect(seg.getByRole("button", { name: "Newline on Enter" })).toHaveClass(/active/);
+});

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -21,6 +21,7 @@ import {
   setSessionFlags,
   setUnattended,
   Session,
+  type ComposerEnterBehavior,
   type InboxItem,
   type MessageSource,
   type Persona,
@@ -154,6 +155,7 @@ export function App() {
   const [models, setModels] = useState<string[]>([]);
   const [modelLabels, setModelLabels] = useState<Record<string, string>>({});
   const [surfaces, setSurfaces] = useState<SurfaceVisibility>({ cowork: true, chat: false, code: false });
+  const [composerEnterBehavior, setComposerEnterBehavior] = useState<ComposerEnterBehavior>("send");
   const [mode, setMode] = useState("interactive");
   const [connected, setConnected] = useState(false);
   const [running, setRunning] = useState(false);
@@ -484,6 +486,9 @@ export function App() {
         setModels(s.models || []);
         setModelLabels(s.model_labels || {});
         setModelReady(s.model_ready);
+        setComposerEnterBehavior(
+          s.composer_enter_behavior === "newline" ? "newline" : "send",
+        );
         if (s.surfaces) setSurfaces(s.surfaces);
       })
       .catch(() => {});
@@ -1523,6 +1528,7 @@ export function App() {
               modelLabels={modelLabels}
               running={running}
               connected={connected}
+              enterBehavior={composerEnterBehavior}
               modelReady={modelReady}
               onConnectModel={openModelSetup}
               onConfigureVoiceInput={() => openSettings("voice")}

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -681,6 +681,7 @@ export interface ModelSettings {
   source: "env" | "store" | null;
   onboarded: boolean;
   surfaces: SurfaceVisibility;
+  composer_enter_behavior?: "send" | "newline";
   scratch_base: string;
   secrets_path: string;  // OS-native on-disk location the server reports (not hardcoded)
   // Sidebar layout preference (§7): "flat" = the persona accordions / today's list; "grouped" =
@@ -702,6 +703,20 @@ export interface PdfSettings {
   pdf_fallback: "text" | "images";
   pdf_max_pages: number;
   pdf_max_mb: number;
+}
+
+export type ComposerEnterBehavior = "send" | "newline";
+
+/** Persist whether Enter sends or inserts a newline in the composer. */
+export async function setComposerEnterBehavior(
+  composer_enter_behavior: ComposerEnterBehavior,
+): Promise<{ ok: boolean; composer_enter_behavior?: ComposerEnterBehavior; error?: string }> {
+  const res = await fetch(`${httpBase()}/v1/settings/composer-enter-behavior`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ composer_enter_behavior }),
+  });
+  return res.json();
 }
 
 /** Persist the Token-savings PDF settings (fallback mode + attach thresholds). */

--- a/surfaces/gui/src/components/Composer.test.tsx
+++ b/surfaces/gui/src/components/Composer.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Composer } from "./Composer";
+
+const props = (extra: Partial<Parameters<typeof Composer>[0]> = {}) => ({
+  mode: "interactive",
+  model: "gpt-5.6-sol",
+  running: false,
+  connected: true,
+  onSend: vi.fn(),
+  onInterrupt: vi.fn(),
+  onModeChange: vi.fn(),
+  onModelChange: vi.fn(),
+  ...extra,
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("Composer Enter behavior", () => {
+  it("defaults to send on Enter and newline on Shift+Enter", () => {
+    const onSend = vi.fn();
+    render(<Composer {...props({ onSend })} />);
+
+    const box = screen.getByPlaceholderText(/Ask the coworker/) as HTMLTextAreaElement;
+    fireEvent.change(box, { target: { value: "hello" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("hello", []);
+
+    fireEvent.change(box, { target: { value: "line" } });
+    fireEvent.keyDown(box, { key: "Enter", shiftKey: true });
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports newline on Enter and send on Shift+Enter", () => {
+    const onSend = vi.fn();
+    render(<Composer {...props({ onSend, enterBehavior: "newline" })} />);
+
+    const box = screen.getByPlaceholderText(/Ask the coworker/) as HTMLTextAreaElement;
+    fireEvent.change(box, { target: { value: "hello" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(box, { key: "Enter", shiftKey: true });
+    expect(onSend).toHaveBeenCalledWith("hello", []);
+  });
+
+  it("does not send while IME composition is active", () => {
+    const onSend = vi.fn();
+    render(<Composer {...props({ onSend })} />);
+
+    const box = screen.getByPlaceholderText(/Ask the coworker/) as HTMLTextAreaElement;
+    fireEvent.change(box, { target: { value: "hello" } });
+    fireEvent.keyDown(box, { key: "Enter", keyCode: 229, nativeEvent: { isComposing: true } });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import type { ComposerEnterBehavior } from "../api";
 import type { Attachment } from "../types";
 import { isPdfFile, readFile } from "../attach";
 import { getSettings, inspectPdf } from "../api";
@@ -53,6 +54,7 @@ interface Props {
   // interactive-then-disabled control.
   running: boolean;
   connected: boolean;
+  enterBehavior?: ComposerEnterBehavior;
   // False when the default model's provider has no key — the composer shows a "connect a model"
   // banner and routes sends to setup (preserving the draft) instead of dropping them.
   modelReady?: boolean;
@@ -268,7 +270,9 @@ export function Composer(props: Props) {
   };
 
   const onKey = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
+    const sendKey = props.enterBehavior === "newline" ? e.shiftKey : !e.shiftKey;
+    if (e.key === "Enter" && sendKey) {
       e.preventDefault();
       submit();
     }

--- a/surfaces/gui/src/components/SettingsView.tsx
+++ b/surfaces/gui/src/components/SettingsView.tsx
@@ -2,11 +2,13 @@ import { useEffect, useState } from "react";
 import {
   getSettings,
   getTrustedWorkspaces,
+  setComposerEnterBehavior,
   setOnboarded,
   setPdfSettings,
   setScratchBase,
   setSessionsPeek,
   setWorkspaceTrusted,
+  type ComposerEnterBehavior,
   type ModelSettings,
   type PdfSettings,
   type WorkspaceCommandTrust,
@@ -423,6 +425,8 @@ function AppearanceSection() {
         <div className={FIELD_HELP}>Auto follows your Mac&rsquo;s appearance.</div>
       </div>
 
+      <ComposerCard />
+
       <SidebarCard />
 
       <FilesCard />
@@ -517,6 +521,46 @@ function TrustedWorkspacesCard() {
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function ComposerCard() {
+  const [behavior, setBehavior] = useState<ComposerEnterBehavior | null>(null);
+
+  useEffect(() => {
+    getSettings()
+      .then((s) => setBehavior(s.composer_enter_behavior === "newline" ? "newline" : "send"))
+      .catch(() => setBehavior("send"));
+  }, []);
+
+  const save = async (next: ComposerEnterBehavior) => {
+    setBehavior(next);
+    await setComposerEnterBehavior(next);
+  };
+
+  if (behavior === null) return null;
+  return (
+    <div className={CARD + " p-4 mb-4"} data-testid="composer-card">
+      <div className={FIELD_LABEL}>Composer</div>
+      <div className={FIELD_HELP}>
+        Choose whether pressing Enter sends your message or inserts a new line.
+      </div>
+
+      <div
+        className="seg mt-2.5"
+        role="radiogroup"
+        aria-label="Composer Enter behavior"
+        data-testid="composer-enter-behavior"
+      >
+        <button className={behavior === "send" ? "active" : ""} onClick={() => save("send")}>
+          Send on Enter
+        </button>
+        <button className={behavior === "newline" ? "active" : ""} onClick={() => save("newline")}>
+          Newline on Enter
+        </button>
+      </div>
+      <div className={FIELD_HELP}>Shift+Enter does the opposite of the selected mode.</div>
     </div>
   );
 }

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -130,6 +130,41 @@ def test_nav_layout_setting_roundtrips(tmp_path, monkeypatch):
     assert reborn.get_settings()["nav_layout"] == "grouped"
 
 
+def test_composer_enter_behavior_setting_roundtrips(tmp_path, monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from coworker.server.app import create_app
+    from coworker.server.manager import SessionManager
+
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    data_dir = tmp_path / "data"
+    client = TestClient(create_app(SessionManager(data_dir=data_dir)))
+
+    assert client.get("/v1/settings").json()["composer_enter_behavior"] == "send"
+
+    resp = client.post(
+        "/v1/settings/composer-enter-behavior",
+        json={"composer_enter_behavior": "newline"},
+    ).json()
+    assert resp == {"ok": True, "composer_enter_behavior": "newline"}
+    assert client.get("/v1/settings").json()["composer_enter_behavior"] == "newline"
+
+    assert (
+        client.post(
+            "/v1/settings/composer-enter-behavior",
+            json={"composer_enter_behavior": "bogus"},
+        ).json()["composer_enter_behavior"]
+        == "send"
+    )
+
+    client.post(
+        "/v1/settings/composer-enter-behavior",
+        json={"composer_enter_behavior": "newline"},
+    )
+    reborn = SessionManager(data_dir=data_dir)
+    assert reborn.get_settings()["composer_enter_behavior"] == "newline"
+
+
 def test_scratch_base_setting_persists_and_drives_provisioning(tmp_path, monkeypatch):
     from fastapi.testclient import TestClient
 


### PR DESCRIPTION
## Summary
- add a persisted composer preference for Enter key behavior
- add a Settings toggle for "Send on Enter(default)" vs "Newline on Enter" 
- update composer handling and tests, including IME-safe Enter handling
## Testing
- .venv/bin/pytest tests/test_settings.py
- npx vitest run src/components/Composer.test.tsx src/components/Composer.voice.test.tsx
- npm run build
- npm run e2e -- --grep "Composer card edits Enter key behavior|Enter-key behavior follows the user preference"