### PR TITLE
security: hold back allowlist auto-run for interpreters, package managers and exec-delegating flags

### DIFF
--- a/coworker/permissions.py
+++ b/coworker/permissions.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import shlex
 from dataclasses import dataclass, field
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, Optional
 
 # Shell metacharacters that turn one "allowlisted" command into several. Any of these in a
@@ -24,6 +24,7 @@ _SHELL_OPERATORS = (";", "&", "|", ">", "<", "`", "$(", "(", "\n", "\r")
 def _has_shell_operators(command: str) -> bool:
     return any(op in command for op in _SHELL_OPERATORS)
 
+
 from .risk import (  # re-exported for back-compat (manager.py imports WRITE_TOOLS)
     SHELL_TOOL,
     WRITE_TOOLS,
@@ -32,6 +33,88 @@ from .risk import (  # re-exported for back-compat (manager.py imports WRITE_TOO
     classify,
     is_consequential,
 )
+
+
+
+# An allowlist entry auto-runs a command with NO prompt, matched as an argv prefix. That
+# is only sound while extra arguments cannot add authority. For the programs below they
+# can: the program's own arguments choose what code executes, so an entry that stops
+# before those arguments hands over unbounded authority.
+#
+# Two shapes, both keyed by program so the check never touches unrelated tools:
+#
+# `_RUNNER_ANY_ARG` - interpreters, package managers and exec wrappers where essentially
+# ANY argument names code to run that is not already in the workspace: `python3 -c '...'`
+# is a program the user never saw, `npm install pkg` fetches and runs a package's install
+# scripts, `env CMD` / `xargs CMD` / `ssh host CMD` take the command as an argument.
+# A bare-program entry auto-runs only the zero-argument invocation; to auto-run a specific
+# operation, name it in the entry (`npm test`, `python3 -m pytest`) and arguments may
+# still be appended to that.
+#
+# Deliberately NOT here: project-local task runners (`pytest`, `tox`, `nox`, `make`,
+# `just`) whose default target is the workspace's own code, which the agent can already
+# edit. Their escape is a path pointing outside the workspace (`pytest /tmp/evil_test.py`,
+# `make -f /tmp/evil.mk`) - the same axis as `cat /etc/passwd`, and one the command
+# allowlist cannot express. That belongs to path scoping, not to program matching.
+_RUNNER_ANY_ARG = frozenset(
+    {
+        # language interpreters
+        "python", "python3", "node", "deno", "bun", "ruby", "perl", "php", "Rscript",
+        "awk", "gawk", "osascript",
+        # package managers: install/exec fetch remote code and run its build hooks
+        "npm", "npx", "pnpm", "yarn", "pip", "pip3", "uv", "uvx", "pipx",
+        "cargo", "go", "gem", "bundle", "gradle", "mvn",
+        # shells and exec wrappers (their argument IS the command to run)
+        "sh", "bash", "zsh", "dash", "fish", "env", "sudo", "doas",
+        "nohup", "timeout", "watch", "nice", "xargs",
+        # remote / container execution
+        "ssh", "scp", "docker", "podman", "kubectl",
+    }
+)
+
+# `_RUNNER_ESCAPES` - otherwise-inert tools with a SPECIFIC flag that delegates execution.
+# Only those flags are refused, so ordinary use still auto-runs (`find . -name '*.py'`
+# stays allowed under a bare `find` entry; only the `-exec` family is held back).
+# An entry that names the flag itself opts back in (e.g. `find . -exec`).
+_RUNNER_ESCAPES: dict[str, frozenset[str]] = {
+    "find": frozenset({"-exec", "-execdir", "-ok", "-okdir"}),
+    "git": frozenset({"-c", "--exec-path", "--upload-pack", "--receive-pack"}),
+    "tar": frozenset({"--checkpoint-action", "--to-command", "--use-compress-program"}),
+    "rsync": frozenset({"-e", "--rsh", "--rsync-path"}),
+    "sed": frozenset({"-e", "--expression", "-f", "--file"}),
+    "vim": frozenset({"-c", "--cmd"}),
+    "vi": frozenset({"-c", "--cmd"}),
+    "nvim": frozenset({"-c", "--cmd"}),
+}
+
+
+def _flag_name(token: str) -> str:
+    """`--opt=value` and `-e=x` carry the flag in the part before `=`."""
+    return token.split("=", 1)[0]
+
+
+def _delegates_execution(argv: list[str], prefix: list[str]) -> bool:
+    """True when `argv` extends an allowlist `prefix` in a way that lets the program pick
+    what code runs. Deliberately conservative: an unclear case returns True, which only
+    means "ask the user" - the safe direction for an approval gate.
+    """
+    program = PurePath(argv[0]).name  # tolerate /usr/bin/python3 and .../npm
+    extra = argv[len(prefix) :]
+    if not extra:
+        return False  # exactly the allowlisted invocation, nothing added
+
+    # Any argument can name code, and the entry pinned nothing but the program itself.
+    if program in _RUNNER_ANY_ARG and len(prefix) == 1:
+        return True
+
+    escapes = _RUNNER_ESCAPES.get(program)
+    if escapes:
+        named = {_flag_name(t) for t in prefix}
+        for token in extra:
+            flag = _flag_name(token)
+            if flag in escapes and flag not in named:
+                return True
+    return False
 
 
 class Mode(str, Enum):
@@ -234,5 +317,10 @@ class PermissionEngine:
             except ValueError:
                 continue
             if prefix and argv[: len(prefix)] == prefix:
+                # A prefix match is not enough on its own: for interpreters, package
+                # managers and exec-delegating tools, the arguments AFTER the prefix are
+                # what choose the code to run (see _delegates_execution).
+                if _delegates_execution(argv, prefix):
+                    continue
                 return True
         return False

--- a/coworker/permissions.py
+++ b/coworker/permissions.py
@@ -56,11 +56,17 @@ from .risk import (  # re-exported for back-compat (manager.py imports WRITE_TOO
 # edit. Their escape is a path pointing outside the workspace (`pytest /tmp/evil_test.py`,
 # `make -f /tmp/evil.mk`) - the same axis as `cat /etc/passwd`, and one the command
 # allowlist cannot express. That belongs to path scoping, not to program matching.
+#
+# Names are matched lowercased and without a Windows executable suffix (see
+# `_program_name`), so `python.exe` and `npm.cmd` are the same programs as `python`
+# and `npm`.
 _RUNNER_ANY_ARG = frozenset(
     {
-        # language interpreters
-        "python", "python3", "node", "deno", "bun", "ruby", "perl", "php", "Rscript",
-        "awk", "gawk", "osascript",
+        # language interpreters. `awk`/`sed` are here rather than in the flag table below
+        # because their program text is a POSITIONAL argument (`sed 'e ls'`, `awk
+        # 'BEGIN{system(...)}'`), so no flag is what carries the escape.
+        "python", "python3", "node", "deno", "bun", "ruby", "perl", "php", "rscript",
+        "awk", "gawk", "sed", "osascript",
         # package managers: install/exec fetch remote code and run its build hooks
         "npm", "npx", "pnpm", "yarn", "pip", "pip3", "uv", "uvx", "pipx",
         "cargo", "go", "gem", "bundle", "gradle", "mvn",
@@ -81,11 +87,24 @@ _RUNNER_ESCAPES: dict[str, frozenset[str]] = {
     "git": frozenset({"-c", "--exec-path", "--upload-pack", "--receive-pack"}),
     "tar": frozenset({"--checkpoint-action", "--to-command", "--use-compress-program"}),
     "rsync": frozenset({"-e", "--rsh", "--rsync-path"}),
-    "sed": frozenset({"-e", "--expression", "-f", "--file"}),
     "vim": frozenset({"-c", "--cmd"}),
     "vi": frozenset({"-c", "--cmd"}),
     "nvim": frozenset({"-c", "--cmd"}),
 }
+
+# Windows spells the same programs `python.exe`, `npm.cmd`, `node.exe`.
+_EXE_SUFFIXES = (".exe", ".cmd", ".bat", ".com", ".ps1")
+
+
+def _program_name(argv0: str) -> str:
+    """The program a command invokes, normalised for lookup: directories dropped, case
+    folded, Windows executable suffix removed. Backslashes are treated as separators
+    regardless of host OS so a Windows-style path is not read as one long filename."""
+    name = PurePath(argv0.replace("\\", "/")).name.lower()
+    for suffix in _EXE_SUFFIXES:
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+    return name
 
 
 def _flag_name(token: str) -> str:
@@ -98,7 +117,7 @@ def _delegates_execution(argv: list[str], prefix: list[str]) -> bool:
     what code runs. Deliberately conservative: an unclear case returns True, which only
     means "ask the user" - the safe direction for an approval gate.
     """
-    program = PurePath(argv[0]).name  # tolerate /usr/bin/python3 and .../npm
+    program = _program_name(argv[0])
     extra = argv[len(prefix) :]
     if not extra:
         return False  # exactly the allowlisted invocation, nothing added

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -8,11 +8,18 @@ model = "gpt-5.5"            # default model id (override per session in the UI/
 mode = "interactive"         # plan | interactive | auto | custom
 max_iterations = 12          # max model<->tool iterations per turn before stopping
 
-# Commands auto-allowed without an approval prompt (prefix match).
+# Commands auto-allowed without an approval prompt, matched as an argv prefix (so
+# "git status" also covers "git status -s", but never "git statusfoo" or a bare "git").
+# The built-in default is EMPTY: nothing auto-runs until you list it here.
+#
+# Keep entries to programs that only report. A bare interpreter, package manager or exec
+# wrapper is not a safe entry, because its arguments are what choose the code to run:
+# "python3" would auto-run "python3 anything.py", "npm" would auto-run "npm install
+# <pkg>" (which executes that package's install scripts). Those entries are held back
+# unless they name the operation as well - use "npm test" or "python3 -m pytest".
 allowed_commands = [
-  "ls", "cat", "pwd", "grep", "find",
+  "ls", "pwd", "grep", "find",
   "git status", "git diff", "git log",
-  "python3", "pytest", "node", "npm",
 ]
 
 # In "custom" permission mode, these tools are auto-approved (everything else still

--- a/tests/test_permissions_risk.py
+++ b/tests/test_permissions_risk.py
@@ -208,6 +208,35 @@ def test_runner_check_matches_on_the_program_not_the_path(tmp_path):
     assert not d.allowed and d.needs_user
 
 
+@pytest.mark.parametrize(
+    "entry,command",
+    [
+        ("python.exe", "python.exe C:/tmp/evil.py"),
+        ("python3.exe", "python3.exe evil.py"),
+        ("node.exe", "node.exe evil.js"),
+        ("npm.cmd", "npm.cmd install attacker-pkg"),
+        ("Python3", "Python3 evil.py"),
+        ("PYTHON3", "PYTHON3 evil.py"),
+        (r"C:\\Python\\python.exe", r"C:\\Python\\python.exe evil.py"),
+    ],
+)
+def test_runner_check_survives_windows_spelling(tmp_path, entry, command):
+    # Windows names the same interpreters python.exe / npm.cmd, and paths use backslashes.
+    # Matching on the bare lowercased stem keeps the rule from being spelled around.
+    eng = PermissionEngine(workspace_root=tmp_path, allowed_commands=[entry])
+    d = eng.evaluate("run_shell", {"command": command}, None)
+    assert not d.allowed and d.needs_user, command
+
+
+def test_positional_script_interpreters_are_held_back(tmp_path):
+    # `sed`/`awk` carry their program as a POSITIONAL argument (`sed 'e ls'` shells out on
+    # GNU sed), so there is no flag to key on and they belong with the interpreters.
+    eng = PermissionEngine(workspace_root=tmp_path, allowed_commands=["sed", "awk"])
+    assert eng.evaluate("run_shell", {"command": "sed"}, None).allowed
+    assert eng.evaluate("run_shell", {"command": "sed e_ls README.md"}, None).needs_user
+    assert eng.evaluate("run_shell", {"command": "awk BEGIN_system README.md"}, None).needs_user
+
+
 def test_project_local_task_runners_are_unaffected(tmp_path):
     # `pytest`/`make` run the workspace's own code, which the agent can already edit, so
     # they stay on the ordinary prefix rule. Pointing them outside the workspace is a

--- a/tests/test_permissions_risk.py
+++ b/tests/test_permissions_risk.py
@@ -131,6 +131,92 @@ def test_allowlist_prefix_is_argv_boundary(tmp_path):
     assert eng.evaluate("run_shell", {"command": "lsof"}, None).needs_user
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Interpreters: the argument is a program the user never saw.
+        "python3 /tmp/evil.py",
+        "python3 -c 'import shutil'",
+        "python3 -m http.server",
+        "python3 -m pip install attacker-pkg",
+        "node /tmp/evil.js",
+        "perl /tmp/evil.pl",
+        # Package managers: install/exec fetch remote code and run its hooks.
+        "npm install attacker-pkg",
+        "npm run anything",
+        "npm exec -- attacker-pkg",
+        "pip install attacker-pkg",
+        # Exec wrappers: the argument IS the command to run.
+        "env FOO=1 /tmp/evil.sh",
+        "xargs rm",
+        "sudo rm -rf /",
+        # find's helper-exec family. The classic `-exec ... ;` form is already caught by
+        # operator rejection; `{} +` carries no shell metacharacter at all.
+        "find . -exec touch /tmp/pwned {} +",
+        "find . -execdir /tmp/evil.sh {} +",
+        "find . -ok rm {} +",
+    ],
+)
+def test_bare_allowlist_entry_does_not_auto_run_delegated_execution(tmp_path, command):
+    # A bare program name auto-runs the program, not everything the program can be
+    # pointed at. Every one of these used to auto-run under the allowlist that
+    # docs/config.example.toml recommended.
+    eng = PermissionEngine(
+        workspace_root=tmp_path,
+        allowed_commands=["python3", "node", "perl", "npm", "pip", "env", "xargs", "sudo", "find"],
+    )
+    d = eng.evaluate("run_shell", {"command": command}, None)
+    assert not d.allowed and d.needs_user, command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "find . -name '*.py'",
+        "find . -type f -newer setup.py",
+        "find . -maxdepth 2 -size +1k",
+    ],
+)
+def test_runner_escape_check_leaves_ordinary_use_alone(tmp_path, command):
+    # Only the helper-exec flags are held back; `find` itself stays useful.
+    eng = PermissionEngine(workspace_root=tmp_path, allowed_commands=["find"])
+    assert eng.evaluate("run_shell", {"command": command}, None).allowed, command
+
+
+def test_entry_that_pins_the_operation_still_auto_runs(tmp_path):
+    # Naming the operation in the entry is the opt-in: the user chose that authority, and
+    # further arguments may be appended to it as with any other allowlist entry.
+    eng = PermissionEngine(
+        workspace_root=tmp_path,
+        allowed_commands=["npm test", "python3 -m pytest", "find . -exec"],
+    )
+    assert eng.evaluate("run_shell", {"command": "npm test"}, None).allowed
+    assert eng.evaluate("run_shell", {"command": "npm test --silent"}, None).allowed
+    assert eng.evaluate("run_shell", {"command": "python3 -m pytest -q"}, None).allowed
+    assert eng.evaluate(
+        "run_shell", {"command": "find . -exec grep -l TODO {} +"}, None
+    ).allowed
+    # ...but only that operation, not a sibling the entry never named.
+    assert eng.evaluate("run_shell", {"command": "npm install pkg"}, None).needs_user
+
+
+def test_runner_check_matches_on_the_program_not_the_path(tmp_path):
+    # An absolute path to the same interpreter must not slip past the check.
+    eng = PermissionEngine(workspace_root=tmp_path, allowed_commands=["/usr/bin/python3"])
+    assert eng.evaluate("run_shell", {"command": "/usr/bin/python3"}, None).allowed
+    d = eng.evaluate("run_shell", {"command": "/usr/bin/python3 /tmp/evil.py"}, None)
+    assert not d.allowed and d.needs_user
+
+
+def test_project_local_task_runners_are_unaffected(tmp_path):
+    # `pytest`/`make` run the workspace's own code, which the agent can already edit, so
+    # they stay on the ordinary prefix rule. Pointing them outside the workspace is a
+    # path-scoping concern, not something the command allowlist can express.
+    eng = PermissionEngine(workspace_root=tmp_path, allowed_commands=["pytest", "make"])
+    assert eng.evaluate("run_shell", {"command": "pytest -q"}, None).allowed
+    assert eng.evaluate("run_shell", {"command": "make build"}, None).allowed
+
+
 def test_shell_commands_not_auto_allowed_by_default(tmp_path):
     # There is no generally safe executable: these examples cover code execution,
     # environment disclosure, reads outside the workspace, and helper execution.


### PR DESCRIPTION
Fixes #308.

## Summary

`PermissionEngine._command_allowed` matches an allowlist entry as an argv prefix. That is sound only while extra arguments cannot add authority, and for one class of program they can: the program's own arguments are what choose the code to run. A bare `python3` entry auto-runs `python3 anything.py`; a bare `npm` entry auto-runs `npm install <pkg>`, which executes that package's install scripts.

This holds those back, by program, while leaving ordinary use alone.

## Why this is still reachable

657cf03 (#49) already reasoned exactly this way, in its own commit message:

> Drop language interpreters / package managers (python, python3, node, npm, npx) from `DEFAULT_ALLOWED_COMMANDS` - allowlisting an interpreter allowlists arbitrary code (`python3 -c "..."`), defeating approval gating.

That is the right diagnosis, and 9cc2761 went further and emptied the defaults entirely. But it was applied to the shipped defaults rather than to the mechanism, so it stops holding as soon as such an entry comes back, and two supported paths put it back:

1. **`docs/config.example.toml` has not been changed since the initial import.** It still tells users to copy `"python3", "pytest", "node", "npm"` alongside `cat` and `find` - the exact entries #49 removed for being unsafe.
2. **A trusted workspace can append to `allowed_commands`.** `load_config` merges `<workspace>/.coworker/config.toml` into `cfg.allowed_commands` when `workspace_trusted` is set, so a repository can propose `python3` and a single coarse "trust this workspace" decision turns `python3 anything.py` into a silent auto-run. (Same shape as #213, which is about `.coworker/mcp.json` on the trust boundary.)

## Measurement

Corpus run against `PermissionEngine` with the allowlist `docs/config.example.toml` recommends. Script in the thread on #29 so it can be re-run independently.

| | before | after |
|---|---|---|
| **[A]** delegated execution auto-running | **11/11** | **0/11** |
| **[A']** forms #49's operator rejection already blocks | 2/2 blocked | 2/2 blocked |
| **[B]** read / path scope auto-running | 4/4 | 4/4 *(unchanged, see below)* |
| **[C]** benign commands regressed | 0/9 | 0/9 |

Class A includes `python3 evil.py`, `python3 -c ...`, `python3 -m pip install <pkg>`, `node evil.js`, `npm install <pkg>`, `npm run <script>`, `npm exec`, and `find . -exec touch /tmp/pwned {} +`. That last one matters on its own: the classic `-exec ... ;` form is caught today because `;` is a shell operator, but the `{} +` form carries no shell metacharacter at all.

## The rule

Two shapes, both keyed by program so the check never touches unrelated tools.

**`_RUNNER_ANY_ARG`** - interpreters, package managers and exec wrappers, where essentially any argument names code that is not already in the workspace. A bare-program entry auto-runs only the zero-argument invocation. Naming the operation opts back in, and arguments may still be appended to that:

```toml
allowed_commands = ["npm test", "python3 -m pytest"]   # `npm test --silent` still auto-runs
```

**`_RUNNER_ESCAPES`** - otherwise-inert tools with a specific delegating flag (`find -exec/-execdir/-ok/-okdir`, `git -c/--exec-path`, `tar --checkpoint-action`, `rsync -e`, `sed -e`, `vim -c`). Only that flag is refused, so `find . -name '*.py'` keeps auto-running under a bare `find`, and `find . -exec` as an entry opts back in.

Unclear cases resolve to "ask", which is the safe direction for an approval gate.

## What this deliberately does not fix

`cat /etc/passwd`, `grep -r AKIA /Users` and `pytest /tmp/evil_test.py` still auto-run, and I would rather name that than fold it into the headline number. Those are a **path** question, not a **program** question, and a command allowlist has no way to express which paths an argument may name. Fixing them means scoping path-shaped arguments against the session roots, which is a different mechanism and a separate change.

For the same reason, project-local task runners (`pytest`, `make`, `just`) are left on the ordinary prefix rule: their default target is the workspace's own code, which the agent can already edit, and their escape is a path pointing outside it. This also keeps `test_exec_uses_command_allowlist` and `test_shell_allowlist` passing unmodified.

## Relationship to #281

@Esubaalew found the `find . -exec ... {} +` case independently and fixes it in #281 - same diagnosis, and their PR also spotted that the example config recreates the footgun. The difference is scope: #281 encodes `find(1)`'s argument grammar (a 30-entry `_FIND_UNARY_OPTS` table for primaries that consume the next token) to decide whether `-exec` is a real primary, which closes `find` precisely but does not generalise to `npm install` or `python3 evil.py`, because those escapes are **positional**, not flags. This treats it as one class across programs, and takes the conservative reading on the ambiguous case instead of parsing: if `-exec` appears anywhere the entry did not name it, ask. Over-blocking `find . -name -exec` (a file literally named `-exec`) costs one approval prompt.

Happy to defer to #281 for `find` and rebase this down to the interpreter/package-manager half if the maintainers prefer that split - the two are complementary and I have no attachment to which PR carries which part. Flagging it early rather than after review.

This also overlaps #281 in `docs/config.example.toml`; glad to drop the docs hunk if #281 lands first.

## Test plan

- 30 new cases in `tests/test_permissions_risk.py`, in the existing allowlist section:
  - parametrized: bare-entry interpreters, package managers, exec wrappers and the `find -exec` family are all held back
  - `find . -name`, `-type f -newer`, `-maxdepth` still auto-run under a bare `find`
  - an entry that pins the operation still auto-runs, and still allows appended arguments, but not a sibling operation
  - `/usr/bin/python3` is matched on the program name, not the path
  - `pytest -q` / `make build` unaffected
  - Windows spellings (`python.exe`, `npm.cmd`, `Python3`, `C:\Python\python.exe`) cannot spell around the rule
  - `sed`/`awk` positional script forms are held back
- `pytest tests/test_permissions_risk.py tests/test_tools_permissions.py tests/test_risk_overrides.py tests/test_standing_approvals.py` - 95 passed, no existing test modified
- Full suite: 947 passed. The 6 `tests/test_fake_slack.py` failures and `test_bedrock_provider.py` are pre-existing on `main` (missing `messaging` / `bedrock` extras, #257 and #284) and unrelated.

## Second commit (self-review, before any review time was spent)

Re-reviewing the first commit against Windows and against `sed`'s actual grammar turned up two holes in my own patch, both now fixed and covered:

- `PurePath(argv[0]).name` left the rule spellable-around. Windows names the same interpreters `python.exe` / `node.exe` / `npm.cmd`, and the lookup was case-sensitive, so an entry of `python.exe` or `Python3` prefix-matched and then missed `_RUNNER_ANY_ARG`, restoring the exact auto-run this change exists to prevent. Program resolution now goes through `_program_name` (backslashes as separators regardless of host OS, directories dropped, case folded, executable suffix removed).
- The `sed` entry in `_RUNNER_ESCAPES` was backwards: it keyed on `-e`/`-f`, which blocked the ordinary `sed -e 's/a/b/' file` while still auto-running `sed 'e ls' file` - and the positional script is the form that actually shells out on GNU sed. There is no flag to key on, so `sed` moved to `_RUNNER_ANY_ARG` alongside `awk`, whose program text is positional for the same reason.

Flagging these rather than quietly folding them in, since the first one is a genuine bypass of my own fix on a platform the project ships.
