### PR TITLE
Fix search modal misalignment when opened from collapsed sidebar (#282)

### DIFF
--- a/surfaces/gui/e2e/search-modal.spec.ts
+++ b/surfaces/gui/e2e/search-modal.spec.ts
@@ -1,0 +1,68 @@
+// Search command palette (#282): must stay viewport-centered even when opened from the
+// collapsed/peeked sidebar, whose CSS transform would otherwise become the containing block
+// for a nested `position: fixed` overlay.
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+test("search from expanded sidebar is centered in the viewport", async ({ page }) => {
+  await page.goto("/");
+  await page.locator(".sidebar").getByRole("button", { name: "Search", exact: true }).click();
+
+  const panel = page.getByTestId("search-modal-panel");
+  await expect(panel).toBeVisible();
+  await expect(page.getByPlaceholder("Search chats")).toBeVisible();
+
+  const box = await panel.boundingBox();
+  const viewport = page.viewportSize();
+  expect(box).toBeTruthy();
+  expect(viewport).toBeTruthy();
+  const panelCenter = box!.x + box!.width / 2;
+  const viewportCenter = viewport!.width / 2;
+  expect(Math.abs(panelCenter - viewportCenter)).toBeLessThan(8);
+});
+
+test("search from peeked collapsed sidebar stays viewport-centered", async ({ page }) => {
+  await page.goto("/");
+  const app = page.locator(".app");
+
+  await page.keyboard.press("Meta+b");
+  await expect(app).toHaveClass(/nav-collapsed/);
+
+  // Hover the left-edge zone to peek the floating sidebar, then open Search from it.
+  await page.locator(".nav-hover-zone").hover();
+  await expect(app).toHaveClass(/nav-peek/);
+  await page.locator(".sidebar").getByRole("button", { name: "Search", exact: true }).click();
+
+  const panel = page.getByTestId("search-modal-panel");
+  await expect(panel).toBeVisible();
+
+  // Peek should dismiss so the floating sidebar does not cover the palette.
+  await expect(app).not.toHaveClass(/nav-peek/);
+
+  const box = await panel.boundingBox();
+  const viewport = page.viewportSize();
+  expect(box).toBeTruthy();
+  expect(viewport).toBeTruthy();
+  const panelCenter = box!.x + box!.width / 2;
+  const viewportCenter = viewport!.width / 2;
+  expect(Math.abs(panelCenter - viewportCenter)).toBeLessThan(8);
+});
+
+test("collapsed topbar search is also viewport-centered", async ({ page }) => {
+  await page.goto("/");
+  await page.keyboard.press("Meta+b");
+
+  const cluster = page.getByTestId("topbar-cluster");
+  await cluster.getByRole("button", { name: "Search" }).click();
+
+  const panel = page.getByTestId("search-modal-panel");
+  await expect(panel).toBeVisible();
+
+  const box = await panel.boundingBox();
+  const viewport = page.viewportSize();
+  expect(box).toBeTruthy();
+  expect(viewport).toBeTruthy();
+  const panelCenter = box!.x + box!.width / 2;
+  const viewportCenter = viewport!.width / 2;
+  expect(Math.abs(panelCenter - viewportCenter)).toBeLessThan(8);
+});

--- a/surfaces/gui/e2e/search-modal.spec.ts
+++ b/surfaces/gui/e2e/search-modal.spec.ts
@@ -4,8 +4,14 @@
 import { expect } from "@playwright/test";
 import { test } from "./fixtures";
 
-test("search from expanded sidebar is centered in the viewport", async ({ page }) => {
+async function ready(page: import("@playwright/test").Page) {
   await page.goto("/");
+  await expect(page.locator(".app")).not.toHaveClass(/boot-splash/);
+  await expect(page.locator(".sidebar")).toBeVisible();
+}
+
+test("search from expanded sidebar is centered in the viewport", async ({ page }) => {
+  await ready(page);
   await page.locator(".sidebar").getByRole("button", { name: "Search", exact: true }).click();
 
   const panel = page.getByTestId("search-modal-panel");
@@ -22,10 +28,10 @@ test("search from expanded sidebar is centered in the viewport", async ({ page }
 });
 
 test("search from peeked collapsed sidebar stays viewport-centered", async ({ page }) => {
-  await page.goto("/");
+  await ready(page);
   const app = page.locator(".app");
 
-  await page.keyboard.press("Meta+b");
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
   await expect(app).toHaveClass(/nav-collapsed/);
 
   // Hover the left-edge zone to peek the floating sidebar, then open Search from it.
@@ -49,10 +55,12 @@ test("search from peeked collapsed sidebar stays viewport-centered", async ({ pa
 });
 
 test("collapsed topbar search is also viewport-centered", async ({ page }) => {
-  await page.goto("/");
-  await page.keyboard.press("Meta+b");
+  await ready(page);
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+  await expect(page.locator(".app")).toHaveClass(/nav-collapsed/);
 
   const cluster = page.getByTestId("topbar-cluster");
+  await expect(cluster).toBeVisible();
   await cluster.getByRole("button", { name: "Search" }).click();
 
   const panel = page.getByTestId("search-modal-panel");

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -284,8 +284,10 @@ export function App() {
     window.addEventListener("ocw-open-artifact", show);
     return () => window.removeEventListener("ocw-open-artifact", show);
   }, []);
-  // The command-palette search, openable from the collapsed-sidebar topbar cluster (§22). The
-  // expanded sidebar owns its own instance; this one exists so search never disappears with it.
+  // The command-palette search — single app-level instance for both the expanded sidebar's
+  // Search row and the collapsed-sidebar topbar cluster (§22). Mounting it here (and portaling
+  // to document.body) keeps `position: fixed` viewport-centered even when the collapsed sidebar
+  // applies a CSS transform for peek/slide (#282).
   const [searchOpen, setSearchOpen] = useState(false);
   // A pending composer prefill (text + attachments) pushed from the session start panel.
   const [composerPrefill, setComposerPrefill] = useState<{ text: string; attachments?: Attachment[]; nonce: number }>();
@@ -1285,6 +1287,7 @@ export function App() {
         collapsed={navCollapsed}
         onCollapse={toggleNav}
         onPeekLeave={() => setNavPeek(false)}
+        onOpenSearch={() => setSearchOpen(true)}
       />
       {surface === "scheduled" ? (
         <ScheduledView
@@ -1600,8 +1603,7 @@ export function App() {
       </div>
       )}
 
-      {/* Search from the collapsed-sidebar topbar cluster (the sidebar's own instance is
-          unreachable while it's collapsed). */}
+      {/* Single SearchModal for sidebar Search and the collapsed topbar cluster. */}
       {searchOpen && (
         <SearchModal
           sessions={sessions}

--- a/surfaces/gui/src/components/SearchModal.tsx
+++ b/surfaces/gui/src/components/SearchModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { Persona } from "../api";
 import type { SessionInfo } from "../types";
 import { isProjectScoped, shortPersonaName } from "../personaScope";
@@ -8,6 +9,10 @@ import { baseName } from "../paths";
 // Command-palette search (Codex-style): clicking Search opens this overlay over the whole app
 // rather than filtering the sidebar in place (which made the grouped list collapse). It searches
 // ALL sessions, split into Pinned + Recent, filters as you type, and supports ↑/↓ + Enter + ⌘1–9.
+//
+// Portaled to document.body so `position: fixed` is always viewport-relative. The collapsed
+// sidebar uses `transform` for peek/slide (#282), which would otherwise become the containing
+// block for any fixed descendant mounted inside `.sidebar`.
 
 const byRecent = (a: SessionInfo, b: SessionInfo) =>
   (b.updated_at || "").localeCompare(a.updated_at || "");
@@ -109,10 +114,14 @@ export function SearchModal({
     );
   };
 
-  return (
-    <div className="fixed inset-0 z-50" onKeyDown={onKey}>
+  // z-[70] sits above the collapsed sidebar peek (z-60) so the palette is never covered.
+  return createPortal(
+    <div className="fixed inset-0 z-[70]" data-testid="search-modal" onKeyDown={onKey}>
       <div className="absolute inset-0 bg-black/30 backdrop-blur-[1px]" onClick={onClose} />
-      <div className="absolute left-1/2 top-[14vh] -translate-x-1/2 w-[640px] max-w-[92vw] rounded-xl2 border border-line bg-panel shadow-2xl overflow-hidden">
+      <div
+        data-testid="search-modal-panel"
+        className="absolute left-1/2 top-[14vh] -translate-x-1/2 w-[640px] max-w-[92vw] rounded-xl2 border border-line bg-panel shadow-2xl overflow-hidden"
+      >
         <div className="px-4 pt-3.5 pb-2.5 border-b border-line flex items-center gap-2.5">
           <Icon name="search" size={16} className="text-faint shrink-0" />
           <input
@@ -151,6 +160,7 @@ export function SearchModal({
           )}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/surfaces/gui/src/components/Sidebar.tsx
+++ b/surfaces/gui/src/components/Sidebar.tsx
@@ -24,7 +24,6 @@ import { isProjectScoped, shortPersonaName } from "../personaScope";
 import { ConnectorIcon } from "../connectors/ConnectorIcon";
 import { Icon, type IconName } from "./Icon";
 import { PersonaGlyph, personaGlyph } from "./personaIcon";
-import { SearchModal } from "./SearchModal";
 import { baseName } from "../paths";
 import { showPersonas } from "../flags";
 
@@ -146,6 +145,9 @@ interface Props {
   collapsed?: boolean;
   onCollapse?: () => void;
   onPeekLeave?: () => void;
+  // Opens the app-level SearchModal. Kept out of this tree so the collapsed sidebar's
+  // `transform` cannot become the containing block for `position: fixed` (#282).
+  onOpenSearch?: () => void;
 }
 
 // Compact age for project session rows: "now" / "5m" / "6h" / "3d" / "2w" / "4mo" / "2y".
@@ -171,7 +173,6 @@ const compactAge = (iso?: string | null): string => {
 // Sessions shown per group before "Show more" comes from Settings (sessions_peek, default 5).
 
 export function Sidebar(props: Props) {
-  const [searchModalOpen, setSearchModalOpen] = useState(false);
   const [appMenuOpen, setAppMenuOpen] = useState(false);
   // The account row (§26): cloud sign-in status drives the avatar/name/dot; refreshed on
   // focus and whenever the menu opens (sign-in completes out-of-band in the browser).
@@ -1014,11 +1015,16 @@ export function Sidebar(props: Props) {
       />
 
       {/* Search: a borderless nav-style entry (not a boxed input) that opens the command-palette
-          SearchModal over the whole app. Matches the bottom-nav rows to reduce the boxy look. */}
+          SearchModal over the whole app. Matches the bottom-nav rows to reduce the boxy look.
+          Opens via App so the palette is never mounted under the transformed collapsed sidebar. */}
       <div className="px-2.5 mt-1">
         <button
           className="w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-[13px] text-left text-muted hover:bg-paper hover:text-ink"
-          onClick={() => setSearchModalOpen(true)}
+          onClick={() => {
+            // Dismiss a hover-peek first so the floating sidebar doesn't sit above the palette.
+            props.onPeekLeave?.();
+            props.onOpenSearch?.();
+          }}
         >
           <Icon name="search" size={15} className="shrink-0" /> Search
         </button>
@@ -1270,17 +1276,6 @@ export function Sidebar(props: Props) {
         </div>
       </div>
 
-      {searchModalOpen && (
-        <SearchModal
-          sessions={props.sessions}
-          personas={personas ?? undefined}
-          onSelect={(id, ws, ag) => {
-            setSearchModalOpen(false);
-            props.onSelectSession(id, ws, ag);
-          }}
-          onClose={() => setSearchModalOpen(false)}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes [#282](https://github.com/andrewyng/openworker/issues/282): the Search command palette opened off-center when launched from the collapsed (peeked) sidebar.

**Root cause:** `SearchModal` was mounted inside `.sidebar`. Collapsed-nav CSS applies `transform` to the sidebar for slide/peek, which makes that element the containing block for nested `position: fixed`. The palette then centered relative to the 264px sidebar instead of the viewport.

**Fix:**
- Use a single app-level `SearchModal` (sidebar Search calls `onOpenSearch`)
- Portal the modal to `document.body` so fixed positioning is always viewport-relative
- Raise z-index above the peeked sidebar (`z-60`) and dismiss peek when opening Search
- Add Playwright coverage that asserts horizontal centering from expanded sidebar, peeked collapsed sidebar, and the collapsed topbar cluster

## Visual proof

Before (modal mounted under transformed `.sidebar`, **Δ ~508px** off-center):

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/3bb78cf0-51d6-44bd-b5cb-f31f1528fbce" />

After (portaled + app-level mount, **Δ 0px**):

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/133db09a-cf72-405c-b961-d88f3e227280" />

Demo recording:

https://github.com/user-attachments/assets/a5313343-f71c-4f5d-b3a4-fafd78299dd1


## Test plan

- [x] `npx tsc --noEmit` in `surfaces/gui`
- [x] Playwright: `e2e/search-modal.spec.ts` (3 passed)
- [x] Visual demo: before/after screenshots + video recording
- [x] Manually: collapse sidebar → hover peek → click Search → palette centered in the window
- [x] Manually: expanded sidebar Search and collapsed topbar Search still open correctly
