### PR TITLE
[codex] Secure workspace trust persistence on Windows

### DIFF
--- a/coworker/workspace_trust.py
+++ b/coworker/workspace_trust.py
@@ -9,11 +9,10 @@ accepted until the user revokes trust.
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Optional
 
-from .secrets import state_dir
+from .secrets import state_dir, write_private_text
 
 
 class WorkspaceTrustStore:
@@ -51,12 +50,8 @@ class WorkspaceTrustStore:
             values.add(canonical)
         else:
             values.discard(canonical)
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self.path.with_name(f".{self.path.name}.{os.getpid()}.tmp")
-        tmp.write_text(
+        write_private_text(
+            self.path,
             json.dumps({"trusted_workspaces": sorted(values)}, indent=2) + "\n",
-            encoding="utf-8",
         )
-        os.chmod(tmp, 0o600)
-        tmp.replace(self.path)
         return canonical

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+import stat
+import subprocess
+import sys
 
 from coworker.config import load_config
 
@@ -77,7 +81,16 @@ def test_workspace_trust_is_canonical_and_user_owned(tmp_path):
     assert canonical == str(real.resolve())
     assert store.is_trusted(real)
     assert store.list() == [str(real.resolve())]
-    assert (store.path.stat().st_mode & 0o777) == 0o600
+    if sys.platform == "win32":
+        out = subprocess.run(
+            ["icacls", str(store.path)], capture_output=True, text=True
+        ).stdout
+        user = os.environ.get("USERNAME", "")
+        assert user and user in out
+        assert "NT AUTHORITY\\SYSTEM" not in out
+        assert "BUILTIN\\Administrators" not in out
+    else:
+        assert stat.S_IMODE(os.stat(store.path).st_mode) == 0o600
 
     store.set_trusted(real, False)
     assert not store.is_trusted(alias)


### PR DESCRIPTION
## What changed
- Route `WorkspaceTrustStore` writes through the existing cross-platform private-file helper.
- Verify Windows ACLs rather than POSIX mode bits in the workspace-trust test.

## Why
The trust store controls whether a workspace's command allowances take effect. Its direct `chmod(0600)` call is ineffective on Windows, so the resulting file could retain inherited broad ACLs and the existing test failed there.

## Validation
- `uv run pytest tests/test_config.py tests/test_secrets.py tests/test_permissions_risk.py -q` (45 passed)
- `npm test -- --run` (81 passed)