### PR TITLE
Bound provider context and retain large tool outputs

### DIFF
--- a/coworker/agent.py
+++ b/coworker/agent.py
@@ -122,6 +122,7 @@ def build_engine(
     extra_tools: Optional[list[Any]] = None,
     secrets: Optional[SecretStore] = None,
     task_store: Optional[Any] = None,
+    automation_deleter: Optional[Any] = None,
     wake_store: Optional[Any] = None,
     session_id: Optional[str] = None,
     audit_sink: Optional[Any] = None,
@@ -133,6 +134,9 @@ def build_engine(
     channel_buffer: Optional[Any] = None,
     routing_targets: Optional[list[str]] = None,
     connector_filter: Optional[set[str]] = None,
+    tool_output_store: Optional[Any] = None,
+    context_windows: Optional[dict[str, int]] = None,
+    context_budget: Optional[Any] = None,
 ) -> TurnEngine:
     ws = Path(workspace).expanduser().resolve() if workspace else None
     if agent.needs_workspace and ws is None:
@@ -150,6 +154,30 @@ def build_engine(
 
     workspace_trusted = bool(ws and WorkspaceTrustStore().is_trusted(ws))
     config = load_config(ws, workspace_trusted=workspace_trusted)
+
+    # Every engine needs a session-isolated output store so oversized tool
+    # results remain recoverable without being replayed into model context.
+    # The manager supplies its data-rooted store; direct callers get durable
+    # storage when they name a session and a self-cleaning temporary store
+    # otherwise.
+    ephemeral_output_dir = None
+    if tool_output_store is None:
+        import tempfile
+        import uuid
+
+        from .tool_outputs import SessionToolOutputStore
+
+        if session_id:
+            tool_output_store = SessionToolOutputStore(state_dir(), session_id)
+        else:
+            ephemeral_output_dir = tempfile.TemporaryDirectory(
+                prefix="ow-tool-outputs-"
+            )
+            tool_output_store = SessionToolOutputStore(
+                ephemeral_output_dir.name,
+                uuid.uuid4().hex,
+            )
+
     executor = (
         LocalExecutor(cwd=ws) if (agent.needs_workspace and ws is not None) else None
     )
@@ -221,6 +249,8 @@ def build_engine(
                 provider=provider,
                 model=model,
                 model_settings=model_settings,
+                context_windows=context_windows,
+                context_budget=context_budget,
             )
         )
     # Scheduling: knowledge surfaces with a workspace can set up scheduled tasks (origin = this
@@ -233,7 +263,12 @@ def build_engine(
             "agent": agent.name,
         }
         registry.register_all(
-            scheduling_tools(task_store, origin=origin, default_workspace=str(ws))
+            scheduling_tools(
+                task_store,
+                origin=origin,
+                default_workspace=str(ws),
+                delete_task=automation_deleter,
+            )
         )
     # Self-wake: knowledge surfaces can suspend + schedule their own resumption (timer /
     # on-completion / on-event). The scheduler tick resumes due wakes.
@@ -283,6 +318,11 @@ def build_engine(
     # plan mode via set_mode, and the registry is fixed at build); the engine rejects the
     # call whenever the session isn't actually in plan mode.
     registry.register(propose_plan_tool())
+    # Internal retrieval is registered last. A user, connector, MCP, memory, or
+    # skill tool may not shadow this session-scoped capability.
+    from .tool_outputs import read_tool_output_tool
+
+    registry.register(read_tool_output_tool(tool_output_store), replace=False)
 
     # Per-turn ephemeral context, appended to the latest user message since mid-thread system
     # messages aren't reliable across providers. Two producers: the plan-mode reminder (mode can
@@ -325,6 +365,9 @@ def build_engine(
         directory_requester=directory_requester,
         plan_approver=plan_approver,
         question_asker=question_asker,
+        tool_output_store=tool_output_store,
+        context_windows=context_windows,
+        context_budget=context_budget,
     )
     engine.executor = executor  # type: ignore[attr-defined]
     engine.todo = todo  # type: ignore[attr-defined]
@@ -336,6 +379,8 @@ def build_engine(
         "workspace": str(ws) if ws else "",
     }
     engine.skill_loader = skill_loader  # type: ignore[attr-defined]
+    if ephemeral_output_dir is not None:
+        engine._ephemeral_output_dir = ephemeral_output_dir
     return engine
 
 

--- a/coworker/automation/store.py
+++ b/coworker/automation/store.py
@@ -66,6 +66,10 @@ class TaskStore:
     def __init__(self, path: str | Path) -> None:
         self.path = str(path)
         self._lock = threading.RLock()
+        # A task object loaded before deletion can still be held by the scheduler,
+        # an agent tool, or a standing-approval callback. Keep same-process
+        # tombstones so their later save/add_run cannot recreate deleted rows.
+        self._deleted_task_ids: set[str] = set()
         self._conn = sqlite3.connect(self.path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._init()
@@ -90,10 +94,12 @@ class TaskStore:
             self._conn.commit()
 
     # -- tasks ------------------------------------------------------------------
-    def save(self, task: ScheduledTask) -> ScheduledTask:
+    def save(self, task: ScheduledTask) -> Optional[ScheduledTask]:
         task.updated_at = _epoch_now()
         task.next_run = compute_next_run(task) if task.enabled else None
         with self._lock:
+            if task.id in self._deleted_task_ids:
+                return None
             self._conn.execute(
                 "INSERT OR REPLACE INTO scheduled_tasks (id, enabled, next_run, data) VALUES (?, ?, ?, ?)",
                 (
@@ -127,7 +133,10 @@ class TaskStore:
             )
             self._conn.execute("DELETE FROM task_runs WHERE task_id=?", (task_id,))
             self._conn.commit()
-            return cur.rowcount > 0
+            deleted = cur.rowcount > 0
+            if deleted:
+                self._deleted_task_ids.add(task_id)
+            return deleted
 
     def due(self, *, now: Optional[float] = None) -> list[ScheduledTask]:
         now = now if now is not None else _epoch_now()
@@ -139,8 +148,10 @@ class TaskStore:
         return [ScheduledTask.from_dict(json.loads(r["data"])) for r in rows]
 
     # -- runs -------------------------------------------------------------------
-    def add_run(self, run: TaskRun) -> TaskRun:
+    def add_run(self, run: TaskRun) -> Optional[TaskRun]:
         with self._lock:
+            if run.task_id in self._deleted_task_ids:
+                return None
             self._conn.execute(
                 "INSERT OR REPLACE INTO task_runs (run_id, task_id, started_at, data) VALUES (?, ?, ?, ?)",
                 (run.run_id, run.task_id, run.started_at, json.dumps(run.to_dict())),
@@ -163,12 +174,19 @@ class TaskStore:
         run = self.find_run(session_id[len("__run__") :])
         return self.get(run.task_id) if run else None
 
-    def runs(self, task_id: str, *, limit: int = 50) -> list[TaskRun]:
+    def runs(self, task_id: str, *, limit: Optional[int] = 50) -> list[TaskRun]:
         with self._lock:
-            rows = self._conn.execute(
-                "SELECT data FROM task_runs WHERE task_id=? ORDER BY started_at DESC LIMIT ?",
-                (task_id, limit),
-            ).fetchall()
+            if limit is None:
+                rows = self._conn.execute(
+                    "SELECT data FROM task_runs WHERE task_id=? ORDER BY started_at DESC",
+                    (task_id,),
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    "SELECT data FROM task_runs WHERE task_id=? "
+                    "ORDER BY started_at DESC LIMIT ?",
+                    (task_id, limit),
+                ).fetchall()
         return [TaskRun.from_dict(json.loads(r["data"])) for r in rows]
 
     def close(self) -> None:

--- a/coworker/automation/tools.py
+++ b/coworker/automation/tools.py
@@ -153,6 +153,7 @@ def scheduling_tools(
     *,
     origin: dict[str, Any],
     default_workspace: str,
+    delete_task: Optional[Callable[[str], bool]] = None,
 ) -> list[Callable[..., Any]]:
     def create_scheduled_task(
         title, instructions, cron=None, fire_at=None, timezone="local", permissions=None
@@ -219,11 +220,15 @@ def scheduling_tools(
             task.instructions = instructions
         if title is not None:
             task.title = title
-        store.save(task)
+        if store.save(task) is None:
+            return {"error": f"no such task: {id}"}
         return {"ok": True, "task": task.public()}
 
     def delete_scheduled_task(id):
-        return {"ok": store.delete(id), "id": id}
+        return {
+            "ok": delete_task(id) if delete_task is not None else store.delete(id),
+            "id": id,
+        }
 
     return [
         _gated(create_scheduled_task, _CREATE_SCHEMA, approval=True),

--- a/coworker/context.py
+++ b/coworker/context.py
@@ -1,0 +1,778 @@
+"""Provider-facing context projection and request-budget accounting.
+
+The durable transcript is canonical application state.  This module creates a
+separate, bounded copy for provider calls; callers must continue to persist the
+original transcript.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import hashlib
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Collection, Mapping, Optional, Sequence
+
+
+_OMISSION_MARKER = {
+    "role": "system",
+    "content": "[Earlier conversation omitted to stay within the model context budget.]",
+}
+_DISPLAY_SIDECARS = frozenset(
+    {"source", "_display", "_steering", "ts", "reasoning", "usage"}
+)
+_GATEWAY_MAX_REQUEST_BYTES = 2 * 1_024 * 1_024
+_GATEWAY_WIRE_HEADROOM_BYTES = 64 * 1_024
+_IMAGE_ATTACHMENT_TOKEN_ESTIMATE = 16_000
+_PDF_ATTACHMENT_TOKEN_ESTIMATE = 50_000
+
+
+class ContextBudgetExceeded(ValueError):
+    """Raised when protected context cannot fit inside the hard request limits."""
+
+
+@dataclass(frozen=True)
+class _MessageGroup:
+    indexed_messages: tuple[tuple[int, dict[str, Any]], ...]
+    protected: bool = False
+    valid: bool = True
+
+
+@dataclass(frozen=True)
+class ContextBudget:
+    """Soft trimming targets and optional transport request limits.
+
+    Direct providers do not share one request-byte ceiling, so the default only
+    applies message and model-token budgets. Hosted gateways opt into the explicit
+    byte policy via :meth:`gateway`.
+    """
+
+    soft_message_limit: int = 220
+    hard_message_limit: int = 256
+    soft_request_bytes: Optional[int] = None
+    hard_request_bytes: Optional[int] = None
+    soft_token_limit: Optional[int] = None
+    hard_token_limit: Optional[int] = None
+    bytes_per_token: float = 4.0
+    token_target_ratio: float = 0.85
+    reserved_output_tokens: int = 20_000
+    historical_file_write_tools: frozenset[str] = frozenset(
+        {"write_file", "create_file"}
+    )
+    historical_file_replace_tools: frozenset[str] = frozenset({"replace_in_file"})
+    historical_tool_argument_redaction_bytes: int = 8 * 1_024
+
+    def __post_init__(self) -> None:
+        _validate_limits(
+            "message",
+            self.soft_message_limit,
+            self.hard_message_limit,
+        )
+        if self.soft_request_bytes is not None or self.hard_request_bytes is not None:
+            if self.soft_request_bytes is None or self.hard_request_bytes is None:
+                raise ValueError(
+                    "soft_request_bytes and hard_request_bytes must be configured together"
+                )
+            _validate_limits(
+                "request byte",
+                self.soft_request_bytes,
+                self.hard_request_bytes,
+            )
+        if self.soft_token_limit is not None or self.hard_token_limit is not None:
+            if self.soft_token_limit is None or self.hard_token_limit is None:
+                raise ValueError(
+                    "soft_token_limit and hard_token_limit must be configured together"
+                )
+            _validate_limits(
+                "token",
+                self.soft_token_limit,
+                self.hard_token_limit,
+            )
+        if self.bytes_per_token <= 0:
+            raise ValueError("bytes_per_token must be greater than zero")
+        if not 0 < self.token_target_ratio <= 1:
+            raise ValueError(
+                "token_target_ratio must be greater than zero and at most one"
+            )
+        if self.reserved_output_tokens < 0:
+            raise ValueError("reserved_output_tokens cannot be negative")
+        if self.historical_tool_argument_redaction_bytes < 0:
+            raise ValueError(
+                "historical_tool_argument_redaction_bytes cannot be negative"
+            )
+
+    @classmethod
+    def gateway(cls, **overrides: Any) -> "ContextBudget":
+        """Budget for a 2 MiB JSON gateway, reserving transport-adapter headroom."""
+
+        values = {
+            "soft_request_bytes": 1_536 * 1_024,
+            "hard_request_bytes": (
+                _GATEWAY_MAX_REQUEST_BYTES - _GATEWAY_WIRE_HEADROOM_BYTES
+            ),
+        }
+        values.update(overrides)
+        return cls(**values)
+
+    def token_limits(
+        self,
+        model_context_window: Optional[int],
+    ) -> tuple[Optional[int], Optional[int]]:
+        """Return the active soft target and hard token ceiling for a model."""
+
+        if model_context_window is not None and model_context_window <= 0:
+            raise ValueError("model_context_window must be greater than zero")
+        hard_limit = self.hard_token_limit
+        if model_context_window is not None:
+            hard_limit = (
+                model_context_window
+                if hard_limit is None
+                else min(hard_limit, model_context_window)
+            )
+
+        soft_limit = self.soft_token_limit
+        if soft_limit is None and model_context_window is not None:
+            soft_limit = min(
+                int(model_context_window * self.token_target_ratio),
+                model_context_window - self.reserved_output_tokens,
+            )
+            if soft_limit <= 0:
+                raise ValueError(
+                    "model_context_window must exceed reserved_output_tokens"
+                )
+        if soft_limit is not None and hard_limit is not None:
+            soft_limit = min(soft_limit, hard_limit)
+        return soft_limit, hard_limit
+
+
+@dataclass(frozen=True)
+class ContextProjection:
+    """A measured provider request projection built from a durable transcript."""
+
+    messages: list[dict[str, Any]]
+    message_count: int
+    request_bytes: int
+    estimated_tokens: int
+    soft_token_limit: Optional[int] = None
+    hard_token_limit: Optional[int] = None
+    omitted_message_count: int = 0
+    omitted_group_count: int = 0
+    redacted_tool_argument_bytes: int = 0
+
+    @classmethod
+    def build(
+        cls,
+        messages: Sequence[Mapping[str, Any]],
+        *,
+        budget: ContextBudget,
+        model: str,
+        model_context_window: Optional[int] = None,
+        tools: Optional[Sequence[Mapping[str, Any]]] = None,
+        settings: Optional[Mapping[str, Any]] = None,
+        replay_sidecar_keys: Collection[str] = (),
+    ) -> "ContextProjection":
+        """Copy, trim, and measure messages for one provider request."""
+
+        active_sidecars = frozenset(replay_sidecar_keys)
+        steering_indices = {
+            index
+            for index, message in enumerate(messages)
+            if message.get("_steering") is True
+        }
+        indexed = [
+            (index, _normalize_message(message, active_sidecars))
+            for index, message in enumerate(messages)
+            if message.get("role") != "notice"
+        ]
+        latest_user_index = next(
+            (
+                index
+                for index, message in reversed(indexed)
+                if message.get("role") == "user"
+            ),
+            None,
+        )
+        leading_system_indices: set[int] = set()
+        for index, message in indexed:
+            if message.get("role") != "system":
+                break
+            leading_system_indices.add(index)
+        steered_turn_indices, exact_tool_call_indices = (
+            _steered_current_turn_indices(
+                indexed,
+                steering_indices=steering_indices,
+            )
+        )
+        trailing_tool_result_index = (
+            indexed[-1][0] if indexed and indexed[-1][1].get("role") == "tool" else None
+        )
+        candidate_groups = _atomic_groups(
+            indexed,
+            protected_indices=leading_system_indices
+            | steered_turn_indices
+            | {
+                index
+                for index in (latest_user_index, trailing_tool_result_index)
+                if index is not None
+            },
+        )
+        groups = _coalesce_historical_user_turns(
+            [group for group in candidate_groups if group.valid],
+            latest_user_index=latest_user_index,
+        )
+        omitted_messages = sum(
+            len(group.indexed_messages) for group in candidate_groups if not group.valid
+        )
+        omitted_groups = sum(not group.valid for group in candidate_groups)
+        valid_indexed = [
+            indexed_message
+            for group in groups
+            for indexed_message in group.indexed_messages
+        ]
+        redacted_tool_argument_bytes = _project_completed_file_tool_arguments(
+            valid_indexed,
+            write_tool_names=budget.historical_file_write_tools,
+            replace_tool_names=budget.historical_file_replace_tools,
+            threshold_bytes=budget.historical_tool_argument_redaction_bytes,
+            exact_tool_call_indices=exact_tool_call_indices,
+        )
+        soft_token_limit, hard_token_limit = budget.token_limits(model_context_window)
+
+        while True:
+            projected = [
+                message for group in groups for _, message in group.indexed_messages
+            ]
+            if omitted_groups:
+                projected.insert(
+                    _leading_system_count(projected),
+                    dict(_OMISSION_MARKER),
+                )
+            request_bytes, estimated_tokens = _measure(
+                projected,
+                budget=budget,
+                model=model,
+                tools=tools,
+                settings=settings,
+            )
+            if not _over_soft_budget(
+                message_count=len(projected),
+                request_bytes=request_bytes,
+                estimated_tokens=estimated_tokens,
+                budget=budget,
+                soft_token_limit=soft_token_limit,
+            ):
+                break
+            removable = next(
+                (
+                    position
+                    for position, group in enumerate(groups)
+                    if not group.protected
+                ),
+                None,
+            )
+            if removable is None:
+                break
+            removed = groups.pop(removable)
+            omitted_messages += len(removed.indexed_messages)
+            omitted_groups += 1
+
+        if _over_hard_budget(
+            message_count=len(projected),
+            request_bytes=request_bytes,
+            estimated_tokens=estimated_tokens,
+            budget=budget,
+            hard_token_limit=hard_token_limit,
+        ):
+            raise ContextBudgetExceeded(
+                "protected context exceeds the configured hard request limits"
+            )
+
+        return cls(
+            messages=projected,
+            message_count=len(projected),
+            request_bytes=request_bytes,
+            estimated_tokens=estimated_tokens,
+            soft_token_limit=soft_token_limit,
+            hard_token_limit=hard_token_limit,
+            omitted_message_count=omitted_messages,
+            omitted_group_count=omitted_groups,
+            redacted_tool_argument_bytes=redacted_tool_argument_bytes,
+        )
+
+
+def _validate_limits(kind: str, soft: int, hard: int) -> None:
+    if soft <= 0 or hard <= 0:
+        raise ValueError(f"{kind} limits must be greater than zero")
+    if soft > hard:
+        raise ValueError(f"soft {kind} limit cannot exceed hard limit")
+
+
+def _normalize_message(
+    message: Mapping[str, Any],
+    replay_sidecar_keys: frozenset[str],
+) -> dict[str, Any]:
+    return {
+        key: deepcopy(value)
+        for key, value in message.items()
+        if key not in _DISPLAY_SIDECARS
+        and (not key.startswith("_") or key in replay_sidecar_keys)
+    }
+
+
+def _project_completed_file_tool_arguments(
+    indexed_messages: Sequence[tuple[int, dict[str, Any]]],
+    *,
+    write_tool_names: frozenset[str],
+    replace_tool_names: frozenset[str],
+    threshold_bytes: int,
+    exact_tool_call_indices: frozenset[int] = frozenset(),
+) -> int:
+    redacted_bytes = 0
+    for position, (message_index, message) in enumerate(indexed_messages):
+        if message.get("role") != "assistant":
+            continue
+        # Native Anthropic/Gemini history carries signed replay state. Rewriting
+        # the associated function-call arguments invalidates that provider-owned
+        # turn, so keep signed exchanges exact.
+        if (
+            message_index in exact_tool_call_indices
+            or "_anthropic" in message
+            or "_gemini" in message
+        ):
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        call_ids = {
+            call.get("id")
+            for call in tool_calls
+            if isinstance(call, Mapping) and call.get("id")
+        }
+        result_ids: set[str] = set()
+        cursor = position + 1
+        while cursor < len(indexed_messages):
+            _, result = indexed_messages[cursor]
+            if (
+                result.get("role") != "tool"
+                or result.get("tool_call_id") not in call_ids
+            ):
+                break
+            result_ids.add(result["tool_call_id"])
+            cursor += 1
+        # The just-completed exchange must remain exact for its immediate
+        # tool-result follow-up sampling call.
+        if cursor == len(indexed_messages):
+            continue
+        for call in tool_calls:
+            if not isinstance(call, dict) or call.get("id") not in result_ids:
+                continue
+            function = call.get("function")
+            if not isinstance(function, dict):
+                continue
+            tool_name = function.get("name")
+            if tool_name in write_tool_names:
+                content_keys = ("content",)
+            elif tool_name in replace_tool_names:
+                content_keys = ("old", "new")
+            else:
+                continue
+            raw_arguments = function.get("arguments")
+            if isinstance(raw_arguments, str):
+                try:
+                    arguments = json.loads(raw_arguments)
+                except (TypeError, ValueError):
+                    continue
+            elif isinstance(raw_arguments, Mapping):
+                arguments = dict(raw_arguments)
+            else:
+                continue
+            if not isinstance(arguments, dict):
+                continue
+            contents = {
+                key: arguments[key]
+                for key in content_keys
+                if isinstance(arguments.get(key), str)
+            }
+            encoded_contents = {
+                key: content.encode("utf-8") for key, content in contents.items()
+            }
+            content_size = sum(len(content) for content in encoded_contents.values())
+            if content_size <= threshold_bytes:
+                continue
+
+            for key, content_bytes in encoded_contents.items():
+                arguments.pop(key)
+                arguments[f"{key}_bytes"] = len(content_bytes)
+                arguments[f"{key}_sha256"] = hashlib.sha256(content_bytes).hexdigest()
+            arguments["context_note"] = (
+                "Full file edit text was omitted from historical context; "
+                "use read_file on the saved path if needed."
+            )
+            function["arguments"] = (
+                json.dumps(
+                    arguments,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
+                if isinstance(raw_arguments, str)
+                else arguments
+            )
+            redacted_bytes += content_size
+    return redacted_bytes
+
+
+def _steered_current_turn_indices(
+    indexed_messages: Sequence[tuple[int, dict[str, Any]]],
+    *,
+    steering_indices: set[int],
+) -> tuple[set[int], frozenset[int]]:
+    """Protect an active tool exchange when queued steering follows its results.
+
+    Steering is persisted as one or more user messages immediately after a completed
+    tool-result run.  That means the literal tail is no longer a tool result, but the
+    next provider call is still the immediate follow-up for that exchange.  Preserve
+    the active turn's user inputs and latest exchange, and keep its signed/write
+    arguments exact.
+    """
+
+    suffix_start = len(indexed_messages)
+    while (
+        suffix_start > 0
+        and indexed_messages[suffix_start - 1][1].get("role") == "user"
+        and indexed_messages[suffix_start - 1][0] in steering_indices
+    ):
+        suffix_start -= 1
+    if suffix_start == len(indexed_messages) or suffix_start == 0:
+        return set(), frozenset()
+
+    result_start = suffix_start
+    while (
+        result_start > 0
+        and indexed_messages[result_start - 1][1].get("role") == "tool"
+    ):
+        result_start -= 1
+    assistant_position = result_start - 1
+    if assistant_position < 0:
+        return set(), frozenset()
+
+    assistant_index, assistant = indexed_messages[assistant_position]
+    tool_calls = (
+        assistant.get("tool_calls")
+        if assistant.get("role") == "assistant"
+        else None
+    )
+    if not isinstance(tool_calls, list) or not tool_calls:
+        return set(), frozenset()
+
+    call_id_list = [
+        call.get("id")
+        for call in tool_calls
+        if isinstance(call, Mapping) and call.get("id")
+    ]
+    call_ids = set(call_id_list)
+    result_ids = [
+        message.get("tool_call_id")
+        for _, message in indexed_messages[result_start:suffix_start]
+    ]
+    if not (
+        len(call_id_list) == len(tool_calls)
+        and len(call_ids) == len(call_id_list)
+        and len(result_ids) == len(call_id_list)
+        and set(result_ids) == call_ids
+    ):
+        return set(), frozenset()
+
+    # The active turn starts after the last completed assistant answer. Preserve all
+    # user inputs in it (the original prompt plus any earlier steering), while the
+    # latest valid tool exchange is protected atomically below.
+    turn_boundary = -1
+    for position in range(assistant_position - 1, -1, -1):
+        message = indexed_messages[position][1]
+        prior_calls = (
+            message.get("tool_calls")
+            if message.get("role") == "assistant"
+            else None
+        )
+        if message.get("role") == "assistant" and not prior_calls:
+            turn_boundary = position
+            break
+
+    protected = {
+        index
+        for index, message in indexed_messages[
+            turn_boundary + 1 : assistant_position
+        ]
+        if message.get("role") == "user"
+    }
+    protected.update(
+        index
+        for index, _ in indexed_messages[assistant_position:suffix_start]
+    )
+    protected.update(index for index, _ in indexed_messages[suffix_start:])
+    return protected, frozenset({assistant_index})
+
+
+def _leading_system_count(messages: Sequence[Mapping[str, Any]]) -> int:
+    count = 0
+    for message in messages:
+        if message.get("role") != "system":
+            break
+        count += 1
+    return count
+
+
+def _atomic_groups(
+    indexed_messages: Sequence[tuple[int, dict[str, Any]]],
+    *,
+    protected_indices: set[int],
+) -> list[_MessageGroup]:
+    groups: list[_MessageGroup] = []
+    position = 0
+    while position < len(indexed_messages):
+        index, message = indexed_messages[position]
+        grouped = [(index, message)]
+        valid = True
+        tool_calls = (
+            message.get("tool_calls") if message.get("role") == "assistant" else None
+        )
+        if isinstance(tool_calls, list) and tool_calls:
+            call_id_list = [
+                call.get("id")
+                for call in tool_calls
+                if isinstance(call, Mapping) and call.get("id")
+            ]
+            call_ids = set(call_id_list)
+            result_ids: list[str] = []
+            cursor = position + 1
+            while cursor < len(indexed_messages):
+                result_index, result = indexed_messages[cursor]
+                if result.get("role") != "tool":
+                    break
+                grouped.append((result_index, result))
+                result_ids.append(result.get("tool_call_id"))
+                cursor += 1
+            valid = (
+                len(call_id_list) == len(tool_calls)
+                and len(call_ids) == len(call_id_list)
+                and len(result_ids) == len(call_id_list)
+                and set(result_ids) == call_ids
+            )
+            position = cursor
+        else:
+            valid = message.get("role") != "tool"
+            position += 1
+
+        groups.append(
+            _MessageGroup(
+                indexed_messages=tuple(grouped),
+                protected=any(
+                    item_index in protected_indices for item_index, _ in grouped
+                ),
+                valid=valid,
+            )
+        )
+    return groups
+
+
+def _coalesce_historical_user_turns(
+    groups: Sequence[_MessageGroup],
+    *,
+    latest_user_index: Optional[int],
+) -> list[_MessageGroup]:
+    """Keep an old user prompt and every response to it in one removable unit.
+
+    The active turn is intentionally left as smaller API-round groups: its latest user
+    message and trailing tool exchange are protected independently, while old intermediate
+    tool rounds may still be shed if one unusually long turn approaches a hard limit.
+    """
+
+    coalesced: list[_MessageGroup] = []
+    position = 0
+    while position < len(groups):
+        group = groups[position]
+        user_indices = [
+            index
+            for index, message in group.indexed_messages
+            if message.get("role") == "user"
+        ]
+        if not user_indices or latest_user_index in user_indices:
+            coalesced.append(group)
+            position += 1
+            continue
+
+        combined = list(group.indexed_messages)
+        protected = group.protected
+        position += 1
+        while position < len(groups):
+            following = groups[position]
+            if any(
+                message.get("role") == "user"
+                for _, message in following.indexed_messages
+            ):
+                break
+            combined.extend(following.indexed_messages)
+            protected = protected or following.protected
+            position += 1
+        coalesced.append(
+            _MessageGroup(
+                indexed_messages=tuple(combined),
+                protected=protected,
+            )
+        )
+    return coalesced
+
+
+def _over_soft_budget(
+    *,
+    message_count: int,
+    request_bytes: int,
+    estimated_tokens: int,
+    budget: ContextBudget,
+    soft_token_limit: Optional[int],
+) -> bool:
+    return (
+        message_count > budget.soft_message_limit
+        or (
+            budget.soft_request_bytes is not None
+            and request_bytes > budget.soft_request_bytes
+        )
+        or (soft_token_limit is not None and estimated_tokens > soft_token_limit)
+    )
+
+
+def _over_hard_budget(
+    *,
+    message_count: int,
+    request_bytes: int,
+    estimated_tokens: int,
+    budget: ContextBudget,
+    hard_token_limit: Optional[int],
+) -> bool:
+    return (
+        message_count > budget.hard_message_limit
+        or (
+            budget.hard_request_bytes is not None
+            and request_bytes > budget.hard_request_bytes
+        )
+        or (hard_token_limit is not None and estimated_tokens > hard_token_limit)
+    )
+
+
+def _request_payload(
+    *,
+    messages: Sequence[Mapping[str, Any]],
+    model: str,
+    tools: Optional[Sequence[Mapping[str, Any]]],
+    settings: Optional[Mapping[str, Any]],
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"model": model, "messages": list(messages)}
+    if tools is not None:
+        payload["tools"] = list(tools)
+    for key, value in (settings or {}).items():
+        if key not in {"model", "messages", "tools"}:
+            payload[key] = value
+    return payload
+
+
+def _measure(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    budget: ContextBudget,
+    model: str,
+    tools: Optional[Sequence[Mapping[str, Any]]],
+    settings: Optional[Mapping[str, Any]],
+) -> tuple[int, int]:
+    payload = _request_payload(
+        messages=messages,
+        model=model,
+        tools=tools,
+        settings=settings,
+    )
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    request_bytes = len(encoded)
+    token_payload, attachment_tokens = _token_projection(payload)
+    token_bytes = len(
+        json.dumps(
+            token_payload,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    )
+    return (
+        request_bytes,
+        math.ceil(token_bytes / budget.bytes_per_token) + attachment_tokens,
+    )
+
+
+def _token_projection(value: Any) -> tuple[Any, int]:
+    """Replace inline binary transport data before estimating language tokens.
+
+    Image/PDF base64 bytes count toward an HTTP body but providers meter those
+    modalities independently from text. Treating every four base64 bytes as a
+    language token falsely rejects otherwise-supported direct-provider uploads.
+    The fixed allowances are deliberately generous heuristics; actual usage from
+    the provider remains authoritative.
+    """
+
+    if isinstance(value, Mapping):
+        projected = dict(value)
+        kind = value.get("type")
+        attachment_tokens = 0
+
+        if kind in {"image_url", "input_image"}:
+            image = value.get("image_url")
+            if isinstance(image, Mapping):
+                url = image.get("url")
+                if _is_inline_binary(url):
+                    projected["image_url"] = {
+                        **image,
+                        "url": "[inline image attachment]",
+                    }
+                    attachment_tokens += _IMAGE_ATTACHMENT_TOKEN_ESTIMATE
+            elif _is_inline_binary(image):
+                projected["image_url"] = "[inline image attachment]"
+                attachment_tokens += _IMAGE_ATTACHMENT_TOKEN_ESTIMATE
+
+        if kind in {"file", "input_file"}:
+            file_value = value.get("file")
+            if isinstance(file_value, Mapping):
+                file_data = file_value.get("file_data")
+                if _is_inline_binary(file_data):
+                    projected["file"] = {
+                        **file_value,
+                        "file_data": "[inline PDF attachment]",
+                    }
+                    attachment_tokens += _PDF_ATTACHMENT_TOKEN_ESTIMATE
+            else:
+                file_data = value.get("file_data")
+                if _is_inline_binary(file_data):
+                    projected["file_data"] = "[inline PDF attachment]"
+                    attachment_tokens += _PDF_ATTACHMENT_TOKEN_ESTIMATE
+
+        for key, child in tuple(projected.items()):
+            child_projection, child_tokens = _token_projection(child)
+            projected[key] = child_projection
+            attachment_tokens += child_tokens
+        return projected, attachment_tokens
+
+    if isinstance(value, (list, tuple)):
+        projected_items = []
+        attachment_tokens = 0
+        for child in value:
+            child_projection, child_tokens = _token_projection(child)
+            projected_items.append(child_projection)
+            attachment_tokens += child_tokens
+        return projected_items, attachment_tokens
+
+    return value, 0
+
+
+def _is_inline_binary(value: Any) -> bool:
+    return isinstance(value, str) and (value.startswith("data:") or len(value) > 1_024)

--- a/coworker/conversations.py
+++ b/coworker/conversations.py
@@ -247,6 +247,16 @@ class ConversationStore:
             origin_label=row["origin_label"],
         )
 
+    def exists(self, session_id: str) -> bool:
+        """Check for a session row without loading and parsing its transcript."""
+
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT 1 FROM sessions WHERE session_id = ? LIMIT 1",
+                (session_id,),
+            ).fetchone()
+        return row is not None
+
     def set_extra_roots(self, session_id: str, extra_roots: list[dict]) -> None:
         """Persist just the session's added folders, independent of its message log — used when
         the user adds/removes a folder (which may happen with no active engine)."""

--- a/coworker/engine.py
+++ b/coworker/engine.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -24,6 +25,8 @@ from .permissions import Mode, PermissionEngine
 from .providers import AssistantTurn, ProviderClient, ToolCall
 from .providers.errors import friendly_model_error
 from .tools import ToolRegistry
+
+logger = logging.getLogger("coworker.engine")
 
 
 class ApprovalOutcome(str, Enum):
@@ -73,6 +76,9 @@ class TurnEngine:
         question_asker: Optional[
             Callable[[dict[str, Any]], "Awaitable[dict[str, Any]]"]
         ] = None,
+        tool_output_store: Any = None,
+        context_windows: Optional[dict[str, int]] = None,
+        context_budget: Any = None,
         # Called (thread-safe, best-effort) when the user stops the turn — e.g. the
         # executor's kill for a running shell command.
         interrupt_hooks: Optional[list[Callable[[], None]]] = None,
@@ -103,6 +109,23 @@ class TurnEngine:
         # (answerable inline in a live session or from the Inbox when unattended). None on surfaces
         # that can't ask (the tool then no-ops).
         self.question_asker = question_asker
+        self.tool_output_store = tool_output_store
+        self._tool_projector = None
+        self._ephemeral_output_dir = None
+        if tool_output_store is not None:
+            from .tool_outputs import ToolResultProjector
+
+            self._tool_projector = ToolResultProjector(tool_output_store)
+        from .providers.matrix import model_context_windows
+
+        self.context_windows = {
+            **model_context_windows(),
+            **(context_windows or {}),
+        }
+        from .context import ContextBudget
+
+        self.context_budget = context_budget or ContextBudget()
+        self.last_context_projection = None
         self.audit_context: dict[str, Any] = {}
         if instructions and not (
             self.messages and self.messages[0].get("role") == "system"
@@ -395,7 +418,7 @@ class TurnEngine:
         tools = self.registry.schemas() or None
         model, messages, settings = (
             self.model,
-            self._outbound_messages(),
+            self._outbound_messages(tools=tools),
             self.model_settings,
         )
         provider = self.provider
@@ -651,7 +674,31 @@ class TurnEngine:
         if isinstance(result, dict) and "_display" in result:
             display = result.get("_display") or None
             result = {k: v for k, v in result.items() if k != "_display"}
-        message = _tool_result_message(tool_call, result)
+        projected: Any = result
+        stored = None
+        try:
+            if self._tool_projector is not None:
+                outcome = self._tool_projector.project(
+                    tool_call.id,
+                    tool_call.name,
+                    result,
+                )
+                projected, stored = outcome.model_value, outcome.stored
+        except Exception:
+            original_chars: Optional[int] = (
+                len(result) if isinstance(result, str) else None
+            )
+            projected = {
+                "error": "tool output could not be retained",
+                "recoverable": False,
+                **(
+                    {"original_chars": original_chars}
+                    if original_chars is not None
+                    else {}
+                ),
+            }
+            status = "error"
+        message = _tool_result_message(tool_call, projected)
         if display:
             message["_display"] = display
         self.messages.append(message)
@@ -670,12 +717,30 @@ class TurnEngine:
                 status="hidden",
                 reason=" · ".join(parts) + " by privacy filters",
             )
+        spill_meta = (
+            {
+                "output_ref": stored.ref,
+                "original_chars": stored.chars,
+                "original_bytes": stored.bytes,
+                "truncated": True,
+                "content_complete": stored.content_complete,
+            }
+            if stored is not None
+            else {}
+        )
         self._audit(
             tool_call,
             stage="finished",
             status=status,
-            result=result,
-            result_preview=_preview(result),
+            # The audit log follows the same bounded disclosure policy as the model feed.
+            result_preview=_preview(projected),
+            projected_chars=len(_serialize_result(projected)),
+            resource=(
+                str(result["url"])
+                if isinstance(result, dict) and result.get("url")
+                else ""
+            ),
+            **spill_meta,
         )
         rule = self._standing_notes.pop(tool_call.id, "")
         return Event(
@@ -683,7 +748,8 @@ class TurnEngine:
             {
                 "name": tool_call.name,
                 "status": status,
-                "result_preview": _preview(result),
+                "result_preview": _preview(projected),
+                **spill_meta,
                 **({"display": display} if display else {}),
                 **({"standing_rule": rule} if rule else {}),
             },
@@ -870,6 +936,10 @@ class TurnEngine:
             message: dict[str, Any] = {
                 "role": "user",
                 "content": text,
+                # Internal durable marker: context projection uses it to distinguish
+                # in-turn steering from a later standalone user turn when it follows
+                # tool results. Unknown underscore sidecars never reach providers.
+                "_steering": True,
                 "ts": time.time(),
             }
             if source is not None:
@@ -877,15 +947,20 @@ class TurnEngine:
             self.messages.append(message)
         self._steering = []
 
-    def _outbound_messages(self) -> list[dict[str, Any]]:
+    def _outbound_messages(
+        self,
+        *,
+        tools: Optional[list[dict[str, Any]]] = None,
+    ) -> list[dict[str, Any]]:
         """`self.messages` prepared for the provider. The SOLE provider feed (see `_astream`).
 
         Every message is stripped of the display-only sidecars — `source`, `_display`, and
         `ts` — (providers reject unknown keys), unconditionally — whether or not a
         `<system-context>` block is added. When a context
         provider yields a non-empty string, an ephemeral `<system-context>` block is appended to the
-        last user message. Never mutates `self.messages`, so neither the strip nor the block is
-        persisted/replayed.
+        last user message. The resulting copy is then projected inside the provider's
+        message, byte, and token budgets. Never mutates `self.messages`, so neither the
+        strip, the block, argument redactions, nor history omissions are persisted.
         """
         # Strip the display-only sidecars — `source` (connector cards), `_display`
         # (e.g. filter-hidden counts), `ts` (append-time timestamps), `reasoning`
@@ -966,23 +1041,56 @@ class TurnEngine:
         context = (
             self.context_provider() if self.context_provider is not None else ""
         ) or ""
-        if not context:
-            return out
-        block = f"\n\n<system-context>\n{context}\n</system-context>"
-        for i in range(len(out) - 1, -1, -1):
-            if out[i].get("role") != "user":
-                continue
-            msg = dict(out[i])
-            content = msg.get("content")
-            if isinstance(content, str):
-                msg["content"] = content + block
-            elif isinstance(content, list):  # content-parts (text + images)
-                msg["content"] = [*content, {"type": "text", "text": block}]
-            else:
-                msg["content"] = block
-            out[i] = msg
-            break
-        return out
+        if context:
+            block = f"\n\n<system-context>\n{context}\n</system-context>"
+            for i in range(len(out) - 1, -1, -1):
+                if out[i].get("role") != "user":
+                    continue
+                msg = dict(out[i])
+                content = msg.get("content")
+                if isinstance(content, str):
+                    msg["content"] = content + block
+                elif isinstance(content, list):  # content-parts (text + images)
+                    msg["content"] = [*content, {"type": "text", "text": block}]
+                else:
+                    msg["content"] = block
+                out[i] = msg
+                break
+
+        from .context import ContextProjection
+
+        replay_sidecar_keys = getattr(self.provider, "replay_sidecar_keys", None)
+        projection = ContextProjection.build(
+            out,
+            budget=self.context_budget,
+            model=self.model,
+            model_context_window=self.context_windows.get(self.model),
+            tools=tools,
+            settings=self.model_settings,
+            replay_sidecar_keys=(
+                replay_sidecar_keys(self.model)
+                if callable(replay_sidecar_keys)
+                else frozenset()
+            ),
+        )
+        self.last_context_projection = projection
+        if (
+            projection.omitted_message_count
+            or projection.redacted_tool_argument_bytes
+        ):
+            logger.info(
+                "bounded provider context model=%s messages=%d request_bytes=%d "
+                "estimated_tokens=%d omitted_messages=%d omitted_groups=%d "
+                "redacted_tool_argument_bytes=%d",
+                self.model,
+                projection.message_count,
+                projection.request_bytes,
+                projection.estimated_tokens,
+                projection.omitted_message_count,
+                projection.omitted_group_count,
+                projection.redacted_tool_argument_bytes,
+            )
+        return projection.messages
 
 
 def _assistant_message(turn: AssistantTurn, model: Optional[str] = None) -> dict[str, Any]:
@@ -1017,13 +1125,17 @@ def _assistant_message(turn: AssistantTurn, model: Optional[str] = None) -> dict
 
 
 def _tool_result_message(tool_call: ToolCall, result: Any) -> dict[str, Any]:
-    content = result if isinstance(result, str) else json.dumps(result, default=str)
+    content = _serialize_result(result)
     return {
         "role": "tool",
         "tool_call_id": tool_call.id,
         "content": content,
         "ts": time.time(),
     }
+
+
+def _serialize_result(result: Any) -> str:
+    return result if isinstance(result, str) else json.dumps(result, default=str)
 
 
 def _tool_error_message(tool_call: ToolCall, reason: str) -> dict[str, Any]:

--- a/coworker/providers/anthropic_provider.py
+++ b/coworker/providers/anthropic_provider.py
@@ -520,6 +520,10 @@ class AnthropicProvider(ProviderClient):
     def capabilities(self, model: str) -> ModelCapabilities:
         return capabilities_for(model)
 
+    def replay_sidecar_keys(self, model: str) -> frozenset[str]:
+        # Signed thinking blocks must be replayed verbatim with their tool-use turn.
+        return frozenset({"_anthropic"})
+
     def stream(
         self,
         *,

--- a/coworker/providers/base.py
+++ b/coworker/providers/base.py
@@ -120,6 +120,15 @@ class ProviderClient(ABC):
     def capabilities(self, model: str) -> ModelCapabilities:
         """Return capability flags for the given model."""
 
+    def replay_sidecar_keys(self, model: str) -> frozenset[str]:
+        """Provider-private message keys that must survive history replay.
+
+        Unknown and foreign underscore-prefixed keys are excluded from provider-facing
+        context before it is budgeted. Providers that persist signed replay state opt in
+        only their own keys here.
+        """
+        return frozenset()
+
     def stream(
         self,
         *,

--- a/coworker/providers/bedrock_provider.py
+++ b/coworker/providers/bedrock_provider.py
@@ -577,3 +577,7 @@ class BedrockProvider(ProviderClient):
     def capabilities(self, model: str) -> ModelCapabilities:
         qualified = model if model.startswith("bedrock:") else f"bedrock:{model}"
         return capabilities_for(qualified)
+
+    def replay_sidecar_keys(self, model: str) -> frozenset[str]:
+        family, rest = self._split(model)
+        return self._family_client(family).replay_sidecar_keys(rest)

--- a/coworker/providers/gemini_provider.py
+++ b/coworker/providers/gemini_provider.py
@@ -489,6 +489,10 @@ class GeminiProvider(ProviderClient):
     def capabilities(self, model: str) -> ModelCapabilities:
         return capabilities_for(model)
 
+    def replay_sidecar_keys(self, model: str) -> frozenset[str]:
+        # Gemini validates thought signatures when prior function calls are replayed.
+        return frozenset({"_gemini"})
+
     def stream(
         self,
         *,

--- a/coworker/providers/openai_provider.py
+++ b/coworker/providers/openai_provider.py
@@ -202,6 +202,13 @@ class OpenAIProvider(ProviderClient):
     def capabilities(self, model: str) -> ModelCapabilities:
         return capabilities_for(model)
 
+    def replay_sidecar_keys(self, model: str) -> frozenset[str]:
+        # Direct DeepSeek V4 Chat Completions replay reasoning state between tool
+        # calls via the `_openai` sidecar. GPT and other compat models do not.
+        if model.lower().startswith("deepseek-v4"):
+            return frozenset({"_openai"})
+        return frozenset()
+
     def stream(
         self,
         *,

--- a/coworker/providers/router.py
+++ b/coworker/providers/router.py
@@ -116,3 +116,6 @@ class ProviderRouter(ProviderClient):
 
     def capabilities(self, model: str):
         return capabilities_for(model)
+
+    def replay_sidecar_keys(self, model: str) -> frozenset[str]:
+        return self._client_for(model).replay_sidecar_keys(self._bare(model))

--- a/coworker/providers/vertex_provider.py
+++ b/coworker/providers/vertex_provider.py
@@ -236,3 +236,7 @@ class VertexProvider(ProviderClient):
     def capabilities(self, model: str) -> ModelCapabilities:
         qualified = model if model.startswith("vertex:") else f"vertex:{model}"
         return capabilities_for(qualified)
+
+    def replay_sidecar_keys(self, model: str) -> frozenset[str]:
+        family, rest = self._split(model)
+        return self._family_client(family).replay_sidecar_keys(rest)

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -18,7 +18,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Optional
 
-from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
@@ -165,6 +165,7 @@ from .manager import SessionManager
 def create_app(manager: SessionManager) -> FastAPI:
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
+        manager.collect_tool_output_orphans()
         try:
             live = (
                 await manager.start_gateway()
@@ -592,6 +593,38 @@ def create_app(manager: SessionManager) -> FastAPI:
     @app.get("/v1/sessions/{session_id}/messages")
     def session_messages(session_id: str) -> dict[str, Any]:
         return {"messages": manager.session_messages(session_id)}
+
+    @app.get("/v1/sessions/{session_id}/tool-outputs/{output_ref}")
+    def tool_output(
+        session_id: str,
+        output_ref: str,
+        offset_bytes: int = 0,
+        limit_bytes: int = 4_000,
+    ) -> dict[str, Any]:
+        from ..tool_outputs import ToolOutputStoreError, is_valid_output_ref
+
+        if not is_valid_output_ref(output_ref):
+            raise HTTPException(status_code=400, detail="invalid output reference")
+        if not manager.session_exists(session_id):
+            raise HTTPException(status_code=404, detail="session not found")
+        try:
+            store = manager.tool_output_store(session_id, create=False)
+        except FileNotFoundError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail="tool output not found",
+            ) from exc
+        try:
+            return store.read(output_ref, offset_bytes, limit_bytes)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except KeyError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail="tool output not found",
+            ) from exc
+        except ToolOutputStoreError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     @app.patch("/v1/sessions/{session_id}")
     def session_patch(session_id: str, body: dict) -> dict[str, Any]:
@@ -1724,11 +1757,15 @@ def create_app(manager: SessionManager) -> FastAPI:
                     if event.type.value in _CHECKPOINTS:
                         manager.save(session_id, engine)
             finally:
-                manager.mark_idle(session_id)
-                manager.save(session_id, engine)
-                await manager.broadcast_session(
-                    session_id, {"type": "turn_done", "data": {}}
-                )
+                try:
+                    manager.save(session_id, engine)
+                finally:
+                    try:
+                        manager.mark_idle(session_id)
+                    finally:
+                        await manager.broadcast_session(
+                            session_id, {"type": "turn_done", "data": {}}
+                        )
 
         # This socket is now a live view of the session; background turns (channel delivery,
         # self-wake, durable resume) broadcast here too, not just locally driven run_turns.

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -14,6 +14,7 @@ import os
 import re
 import shutil
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -140,6 +141,15 @@ class SessionManager:
         self._running_sessions: set[str] = (
             set()
         )  # sessions with an in-flight turn (busy)
+        # Explicit deletion is terminal for this manager lifetime. A stale in-flight
+        # turn may still reach its finally/checkpoint save after delete_session returns;
+        # tombstones prevent that callback from resurrecting the conversation.
+        self._deleted_sessions: set[str] = set()
+        self._deleted_automation_tasks: set[str] = set()
+        self._session_lifecycle_lock = threading.RLock()
+        # Reuse stores so successful digest verification is cached across HTTP pages
+        # and concurrent writers share one session quota lock.
+        self._tool_output_stores: dict[str, Any] = {}
         # Sessions with an auto-title LLM call in flight (FB-010) — one call at a time.
         self._autotitle_inflight: set[str] = set()
         self._autotitle_tasks: set[asyncio.Task] = set()
@@ -371,6 +381,35 @@ class SessionManager:
         plan_approver: Optional[Any] = None,
         question_asker: Optional[Any] = None,
     ) -> Optional[TurnEngine]:
+        # Building publishes several coupled resources (engine, output store, and
+        # possibly a scratch directory). Keep deletion from interleaving halfway
+        # through that publication.
+        with self._session_lifecycle_lock:
+            return self._get_engine_locked(
+                session_id,
+                workspace=workspace,
+                agent=agent,
+                approver=approver,
+                extra_tools=extra_tools,
+                directory_requester=directory_requester,
+                plan_approver=plan_approver,
+                question_asker=question_asker,
+            )
+
+    def _get_engine_locked(
+        self,
+        session_id: str,
+        *,
+        workspace: Optional[str] = None,
+        agent: str = "code",
+        approver: Optional[Approver] = None,
+        extra_tools: Optional[list[Any]] = None,
+        directory_requester: Optional[Any] = None,
+        plan_approver: Optional[Any] = None,
+        question_asker: Optional[Any] = None,
+    ) -> Optional[TurnEngine]:
+        if session_id in self._deleted_sessions:
+            return None
         engine = self._engines.get(session_id)
         if engine is not None:
             if approver is not None:
@@ -427,6 +466,9 @@ class SessionManager:
             extra_tools=extra_tools,
             secrets=self.secrets,
             task_store=self.task_store,
+            automation_deleter=lambda task_id: bool(
+                self.delete_automation(task_id).get("ok")
+            ),
             wake_store=self.wakes,
             session_id=session_id,
             audit_sink=self.audit_store.append,
@@ -446,6 +488,7 @@ class SessionManager:
             routing_targets=self._routing_targets(session_id, agent),
             # Per-session connection hierarchy: expose only effective-enabled connectors' tools.
             connector_filter=self.effective_connectors(session_id, agent_name),
+            tool_output_store=self.tool_output_store(session_id),
         )
         # An automation run rebuilt here (manual "Run now" over WS, durable resume) still
         # carries its task's standing allowances — the rules live on the task record.
@@ -849,7 +892,8 @@ class SessionManager:
         engine = self.get_engine(item.session_id)
         if engine is None or not hasattr(engine, "resume"):
             return
-        self.mark_running(item.session_id)
+        if not self.try_mark_running(item.session_id):
+            return
         try:
             async for _event in engine.resume():
                 pass
@@ -2490,7 +2534,8 @@ class SessionManager:
         target = standing_rule_candidate(tool_name, arguments or {}, metadata)
         if not target or not task.add_rule(tool_name, target):
             return False
-        self.task_store.save(task)
+        if self.task_store.save(task) is None:
+            return False
         engine = self._engines.get(session_id)
         if engine is not None:
             engine.permissions.task_rules.setdefault(tool_name, set()).add(target)
@@ -2513,8 +2558,6 @@ class SessionManager:
         """Map an approval resolution (from any surface) to an ApprovalOutcome, handling
         the task-persistent "always_task" vocabulary alongside the session-scoped ones.
         """
-        from ..engine import ApprovalOutcome
-
         if resolution == "always_task":
             self.mint_task_rule(
                 session_id,
@@ -2534,7 +2577,6 @@ class SessionManager:
         return ApprovalOutcome.DENY
 
     def _scheduled_approver(self, task, session_id: str):
-        from ..engine import ApprovalOutcome
         from ..permissions import WRITE_TOOLS
 
         name_allowed = task.name_allowed_tools()
@@ -2594,6 +2636,7 @@ class SessionManager:
             # Scheduled runs respect the same per-session connection hierarchy as live sessions:
             # expose only the persona's effective-enabled connectors' tools (§4.3).
             connector_filter=self.effective_connectors(session_id, task.agent),
+            tool_output_store=self.tool_output_store(session_id),
         )
         self._seed_task_permissions(engine, task)
         return engine
@@ -2723,24 +2766,36 @@ class SessionManager:
         return resumed
 
     def mark_running(self, session_id: str) -> None:
-        self._running_sessions.add(session_id)
+        with self._session_lifecycle_lock:
+            if session_id not in self._deleted_sessions:
+                self._running_sessions.add(session_id)
 
     def try_mark_running(self, session_id: str) -> bool:
         """Atomically claim an idle session for one turn on the server event loop."""
-        if session_id in self._running_sessions:
-            return False
-        self._running_sessions.add(session_id)
-        return True
+        with self._session_lifecycle_lock:
+            if (
+                session_id in self._running_sessions
+                or session_id in self._deleted_sessions
+            ):
+                return False
+            self._running_sessions.add(session_id)
+            return True
 
     def mark_idle(self, session_id: str) -> None:
-        self._running_sessions.discard(session_id)
+        with self._session_lifecycle_lock:
+            self._running_sessions.discard(session_id)
+            deleted = session_id in self._deleted_sessions
+        if deleted:
+            self._delete_tool_outputs(session_id)
+            return
         # Every turn path (WS, background delivery, durable resume) marks idle when it
         # finishes — the one shared post-turn moment, so auto-titling hooks in here and
         # can never add latency to the response itself.
         self._maybe_autotitle(session_id)
 
     def is_running(self, session_id: str) -> bool:
-        return session_id in self._running_sessions
+        with self._session_lifecycle_lock:
+            return session_id in self._running_sessions
 
     async def _resume_wake(self, wake) -> None:
         await self.deliver_to_session(wake.session_id, self._wake_message(wake))
@@ -2980,7 +3035,16 @@ class SessionManager:
         run = TaskRun(
             task_id=task.id, trigger=trigger
         )  # __post_init__ sets run.session_id
-        self.task_store.add_run(run)  # mark "running"
+        with self._session_lifecycle_lock:
+            if (
+                task.id in self._deleted_automation_tasks
+                or self.task_store.get(task.id) is None
+            ):
+                run.status = "error"
+                run.error = "automation was deleted"
+                run.finished_at = _epoch()
+                return run
+            self.task_store.add_run(run)  # mark "running"
         # UX-026: tell every open app window a SCHEDULED run just started (the 5s
         # top-right toast). Manual runs never come through here — the user is
         # already watching those live.
@@ -3000,10 +3064,17 @@ class SessionManager:
         # Each run is a real, persisted conversation thread: it runs the instructions under its
         # own session id, then saves the transcript. The user can reopen that session and ask a
         # follow-up — the scheduled agent is no longer fire-and-forget.
-        engine = self._build_task_engine(task, session_id=run.session_id)
-        # Register the live engine up-front: a parked approval persists the session
-        # mid-run (durable suspend), and resolving from the Inbox must find this engine.
-        self._engines[run.session_id] = engine
+        with self._session_lifecycle_lock:
+            if task.id in self._deleted_automation_tasks:
+                run.status = "error"
+                run.error = "automation was deleted"
+                run.finished_at = _epoch()
+                return run
+            engine = self._build_task_engine(task, session_id=run.session_id)
+            # Register the live engine up-front: a parked approval persists the session
+            # mid-run (durable suspend), and resolving from the Inbox must find this engine.
+            self._engines[run.session_id] = engine
+            self._running_sessions.add(run.session_id)
         # The first turn is the task itself. The framing matters: instructions often restate the
         # schedule ("every day at 5:32pm…"), so make explicit that the schedule already fired and
         # the job now is to execute, not to (re)schedule.
@@ -3029,10 +3100,13 @@ class SessionManager:
             # follow-up; record the run (now carrying its session_id).
             try:
                 self.save(run.session_id, engine)
-                self._engines[run.session_id] = engine
             except Exception:
                 pass
-            self.task_store.add_run(run)
+            self.mark_idle(run.session_id)
+            with self._session_lifecycle_lock:
+                if task.id not in self._deleted_automation_tasks:
+                    self._engines[run.session_id] = engine
+                    self.task_store.add_run(run)
         return run
 
     async def _notify_task_done(self, task, run: TaskRun) -> None:
@@ -3088,12 +3162,18 @@ class SessionManager:
         return {"tasks": tasks}
 
     def mark_automation_seen(self, task_id: str) -> dict[str, Any]:
-        task = self.task_store.get(task_id)
-        if task is None:
-            return {"ok": False, "error": "not found"}
-        task.seen_runs_at = time.time()
-        self.task_store.save(task)
-        return {"ok": True}
+        with self._session_lifecycle_lock:
+            task = (
+                None
+                if task_id in self._deleted_automation_tasks
+                else self.task_store.get(task_id)
+            )
+            if task is None:
+                return {"ok": False, "error": "not found"}
+            task.seen_runs_at = time.time()
+            if self.task_store.save(task) is None:
+                return {"ok": False, "error": "not found"}
+            return {"ok": True}
 
     def get_automation(self, task_id: str) -> dict[str, Any]:
         task = self.task_store.get(task_id)
@@ -3155,102 +3235,141 @@ class SessionManager:
     def update_automation(
         self, task_id: str, changes: dict[str, Any]
     ) -> dict[str, Any]:
-        task = self.task_store.get(task_id)
-        if task is None:
-            return {"ok": False, "error": "not found"}
-        if "enabled" in changes:
-            task.enabled = bool(changes["enabled"])
-        if changes.get("instructions") is not None:
-            task.instructions = changes["instructions"]
-        if changes.get("title") is not None:
-            task.title = changes["title"]
-        if changes.get("cron") is not None:
-            from croniter import croniter
+        with self._session_lifecycle_lock:
+            task = (
+                None
+                if task_id in self._deleted_automation_tasks
+                else self.task_store.get(task_id)
+            )
+            if task is None:
+                return {"ok": False, "error": "not found"}
+            if "enabled" in changes:
+                task.enabled = bool(changes["enabled"])
+            if changes.get("instructions") is not None:
+                task.instructions = changes["instructions"]
+            if changes.get("title") is not None:
+                task.title = changes["title"]
+            if changes.get("cron") is not None:
+                from croniter import croniter
 
-            if not croniter.is_valid(changes["cron"]):
-                return {"ok": False, "error": "invalid cron"}
-            task.schedule.cron, task.schedule.kind = changes["cron"], "cron"
-        if changes.get("revoke"):
-            # Revocation from the task detail page ("Allowed without asking … · Revoke").
-            # Human-only, like minting; the agent-facing update tool has no such field.
-            task.revoke_rule(str(changes["revoke"]))
-        self.task_store.save(task)
-        if changes.get("revoke"):
-            # A live run engine may still hold the revoked rule — reseed from the record.
-            for sid, engine in self._engines.items():
-                owner = self.task_store.task_for_run_session(sid)
-                if owner is not None and owner.id == task.id:
-                    engine.permissions.task_rules = task.standing_rules()
-        return {"ok": True, "task": task.public()}
+                if not croniter.is_valid(changes["cron"]):
+                    return {"ok": False, "error": "invalid cron"}
+                task.schedule.cron, task.schedule.kind = changes["cron"], "cron"
+            if changes.get("revoke"):
+                # Revocation from the task detail page ("Allowed without asking … · Revoke").
+                # Human-only, like minting; the agent-facing update tool has no such field.
+                task.revoke_rule(str(changes["revoke"]))
+            if self.task_store.save(task) is None:
+                return {"ok": False, "error": "not found"}
+            if changes.get("revoke"):
+                # A live run engine may still hold the revoked rule — reseed from the record.
+                for sid, engine in self._engines.items():
+                    owner = self.task_store.task_for_run_session(sid)
+                    if owner is not None and owner.id == task.id:
+                        engine.permissions.task_rules = task.standing_rules()
+            return {"ok": True, "task": task.public()}
 
     def delete_automation(self, task_id: str) -> dict[str, Any]:
-        return {"ok": self.task_store.delete(task_id), "id": task_id}
+        with self._session_lifecycle_lock:
+            task = self.task_store.get(task_id)
+            if task is None:
+                return {"ok": False, "id": task_id}
+            self._deleted_automation_tasks.add(task_id)
+            run_session_ids = {
+                run.session_id for run in self.task_store.runs(task_id, limit=None)
+            }
+            ok = self.task_store.delete(task_id)
+        for session_id in run_session_ids:
+            self._delete_session(session_id, allow_internal=True)
+        self._delete_session(task.task_session_id, allow_internal=True)
+        return {"ok": ok, "id": task_id}
 
     def prepare_manual_run(self, task_id: str) -> dict[str, Any]:
         """Create a 'running' manual run and return its session, so the GUI can open it and
         drive the task LIVE over the normal session WS (you watch the agent + follow up). The
         automatic scheduler path stays headless (`_run_scheduled_task`)."""
-        task = self.task_store.get(task_id)
-        if task is None:
-            return {"ok": False, "error": "not found"}
-        Path(task.workspace).mkdir(parents=True, exist_ok=True)
-        run = TaskRun(
-            task_id=task.id, trigger="manual"
-        )  # status "running", session_id auto
-        self.task_store.add_run(run)
-        return {
-            "ok": True,
-            "run_id": run.run_id,
-            "session_id": run.session_id,
-            "workspace": task.workspace,
-            "agent": task.agent,
-            # Same execute-now framing as the headless path — manual runs ride a normal live
-            # session whose engine DOES have scheduling tools, so be explicit.
-            "prompt": (
-                f"⏰ Running automation '{task.title}' now. Carry out these instructions "
-                "immediately and produce the result. The schedule already exists — do not create "
-                f"or modify any scheduled tasks.\n\n{task.instructions}"
-            ),
-        }
+        with self._session_lifecycle_lock:
+            task = (
+                None
+                if task_id in self._deleted_automation_tasks
+                else self.task_store.get(task_id)
+            )
+            if task is None:
+                return {"ok": False, "error": "not found"}
+            Path(task.workspace).mkdir(parents=True, exist_ok=True)
+            run = TaskRun(
+                task_id=task.id, trigger="manual"
+            )  # status "running", session_id auto
+            if self.task_store.add_run(run) is None:
+                return {"ok": False, "error": "not found"}
+            return {
+                "ok": True,
+                "run_id": run.run_id,
+                "session_id": run.session_id,
+                "workspace": task.workspace,
+                "agent": task.agent,
+                # Same execute-now framing as the headless path — manual runs ride a normal live
+                # session whose engine DOES have scheduling tools, so be explicit.
+                "prompt": (
+                    f"⏰ Running automation '{task.title}' now. Carry out these instructions "
+                    "immediately and produce the result. The schedule already exists — do not "
+                    "create or modify any scheduled tasks.\n\n"
+                    f"{task.instructions}"
+                ),
+            }
 
     def finalize_manual_run(self, task_id: str, run_id: str) -> dict[str, Any]:
         """Mark a manual run complete once its first turn finished (the WS already saved the
         session). Pulls result text + artifacts from the persisted transcript/workspace.
         """
-        run = next(
-            (r for r in self.task_store.runs(task_id) if r.run_id == run_id), None
-        )
-        task = self.task_store.get(task_id)
-        if run is None or task is None:
-            return {"ok": False, "error": "not found"}
-        if run.status == "running":
-            record = self.session_store.load(run.session_id)
-            run.result_text = _last_assistant_text(record.messages) if record else None
-            run.artifacts = _recent_files(task.workspace, since=run.started_at)
-            run.status = "ok"
-            run.finished_at = _epoch()
-            self.task_store.add_run(run)
-            task.last_run, task.last_status = run.finished_at, "ok"
-            task.run_count += 1
-            self.task_store.save(task)
-        return {"ok": True, "run": run.to_dict()}
+        with self._session_lifecycle_lock:
+            if task_id in self._deleted_automation_tasks:
+                return {"ok": False, "error": "not found"}
+            run = next(
+                (r for r in self.task_store.runs(task_id) if r.run_id == run_id),
+                None,
+            )
+            task = self.task_store.get(task_id)
+            if run is None or task is None:
+                return {"ok": False, "error": "not found"}
+            if run.status == "running":
+                record = self.session_store.load(run.session_id)
+                run.result_text = (
+                    _last_assistant_text(record.messages) if record else None
+                )
+                run.artifacts = _recent_files(task.workspace, since=run.started_at)
+                run.status = "ok"
+                run.finished_at = _epoch()
+                if self.task_store.add_run(run) is None:
+                    return {"ok": False, "error": "not found"}
+                task.last_run, task.last_status = run.finished_at, "ok"
+                task.run_count += 1
+                if self.task_store.save(task) is None:
+                    return {"ok": False, "error": "not found"}
+            return {"ok": True, "run": run.to_dict()}
 
     def save(self, session_id: str, engine: TurnEngine) -> None:
-        executor = getattr(engine, "executor", None)
-        workspace = os.path.realpath(str(executor.cwd)) if executor else ""
-        self.session_store.save(
-            SessionRecord(
-                session_id=session_id,
-                workspace=workspace,
-                model=engine.model,
-                mode=engine.permissions.mode.value,
-                messages=engine.messages,
-                title=title_from(engine.messages),
-                agent=getattr(engine, "agent_name", "code"),
-                extra_roots=self._extra_roots_of(engine),
-                grants=_grants_of(engine),
+        # The tombstone check and durable write are one lifecycle transaction.
+        # Otherwise delete_session can remove the row between them and this stale
+        # callback will recreate it after deletion has returned.
+        with self._session_lifecycle_lock:
+            if session_id in self._deleted_sessions:
+                return
+            executor = getattr(engine, "executor", None)
+            workspace = os.path.realpath(str(executor.cwd)) if executor else ""
+            self.session_store.save(
+                SessionRecord(
+                    session_id=session_id,
+                    workspace=workspace,
+                    model=engine.model,
+                    mode=engine.permissions.mode.value,
+                    messages=engine.messages,
+                    title=title_from(engine.messages),
+                    agent=getattr(engine, "agent_name", "code"),
+                    extra_roots=self._extra_roots_of(engine),
+                    grants=_grants_of(engine),
+                )
             )
-        )
 
     @staticmethod
     def _apply_grants(engine: TurnEngine, grants: dict[str, Any]) -> None:
@@ -3379,6 +3498,12 @@ class SessionManager:
 
     # -- session roots (orphan Cowork: scratch + added folders) ------------------
     def get_roots(self, session_id: str) -> list[dict[str, Any]]:
+        with self._session_lifecycle_lock:
+            if session_id in self._deleted_sessions:
+                return []
+            return self._get_roots_locked(session_id)
+
+    def _get_roots_locked(self, session_id: str) -> list[dict[str, Any]]:
         """The directories this session can touch: primary scratch first, then added folders.
         Reads the live engine when one is running; otherwise reconstructs from persisted state.
         """
@@ -3424,6 +3549,14 @@ class SessionManager:
         return out
 
     def add_root(
+        self, session_id: str, path: str, writable: bool = False
+    ) -> dict[str, Any]:
+        with self._session_lifecycle_lock:
+            if session_id in self._deleted_sessions:
+                return {"ok": False, "error": "session was deleted"}
+            return self._add_root_locked(session_id, path, writable)
+
+    def _add_root_locked(
         self, session_id: str, path: str, writable: bool = False
     ) -> dict[str, Any]:
         """Grant the session access to another folder (read-only or read-write). Mutates the live
@@ -3481,6 +3614,12 @@ class SessionManager:
         return {"ok": True, "roots": self.get_roots(session_id)}
 
     def remove_root(self, session_id: str, path: str) -> dict[str, Any]:
+        with self._session_lifecycle_lock:
+            if session_id in self._deleted_sessions:
+                return {"ok": False, "error": "session was deleted"}
+            return self._remove_root_locked(session_id, path)
+
+    def _remove_root_locked(self, session_id: str, path: str) -> dict[str, Any]:
         """Revoke a previously-added folder. The primary scratch cannot be removed."""
         resolved = Path(path).expanduser().resolve()
         engine = self._engines.get(session_id)
@@ -3525,16 +3664,24 @@ class SessionManager:
         # A live engine's in-memory thread is authoritative: mid-turn it's ahead of the
         # persisted record — which may not even exist yet for a scheduled run's first turn
         # (opening a "running" automation showed a blank session; owner report 2026-07-04).
-        engine = self._engines.get(session_id)
-        if engine is not None:
-            return list(engine.messages)
-        record = self.session_store.load(session_id)
-        return record.messages if record else []
+        with self._session_lifecycle_lock:
+            if session_id in self._deleted_sessions:
+                return []
+            engine = self._engines.get(session_id)
+            if engine is not None:
+                return list(engine.messages)
+            record = self.session_store.load(session_id)
+            return record.messages if record else []
 
     def rename_session(self, session_id: str, title: str) -> dict[str, Any]:
         if session_id.startswith("__"):
             return {"ok": False, "error": "internal sessions cannot be renamed"}
-        ok = self.session_store.rename(session_id, title)
+        with self._session_lifecycle_lock:
+            ok = (
+                False
+                if session_id in self._deleted_sessions
+                else self.session_store.rename(session_id, title)
+            )
         return {
             "ok": ok,
             "session_id": session_id,
@@ -3550,13 +3697,36 @@ class SessionManager:
     ) -> dict[str, Any]:
         if session_id.startswith("__"):
             return {"ok": False, "error": "internal sessions cannot be modified here"}
-        ok = self.session_store.set_flags(session_id, pinned=pinned, archived=archived)
+        with self._session_lifecycle_lock:
+            ok = (
+                False
+                if session_id in self._deleted_sessions
+                else self.session_store.set_flags(
+                    session_id,
+                    pinned=pinned,
+                    archived=archived,
+                )
+            )
         return {"ok": ok, "session_id": session_id}
 
     def delete_session(self, session_id: str) -> dict[str, Any]:
-        if session_id.startswith("__"):
+        return self._delete_session(session_id)
+
+    def _delete_session(
+        self,
+        session_id: str,
+        *,
+        allow_internal: bool = False,
+    ) -> dict[str, Any]:
+        if session_id.startswith("__") and not allow_internal:
             return {"ok": False, "error": "internal sessions cannot be deleted here"}
-        engine = self._engines.pop(session_id, None)
+        with self._session_lifecycle_lock:
+            was_running = session_id in self._running_sessions
+            engine = self._engines.pop(session_id, None)
+            record = self.session_store.load(session_id)
+            if was_running or engine is not None or record is not None:
+                self._deleted_sessions.add(session_id)
+            ok = self.session_store.delete(session_id)
         if engine is not None:
             try:
                 # (was engine.interrupt() — a method that never existed; the AttributeError
@@ -3564,8 +3734,11 @@ class SessionManager:
                 engine.request_interrupt()
             except Exception:
                 pass
-        record = self.session_store.load(session_id)
-        ok = self.session_store.delete(session_id)
+        # An active tool may still be publishing its retained result. Interrupt it
+        # now, but defer filesystem cleanup until the shared turn-finally calls
+        # mark_idle; saves are already blocked by the tombstone above.
+        if not was_running:
+            self._delete_tool_outputs(session_id)
         # Deleting a session is the one implicit unsubscribe (otherwise subscriptions are permanent).
         self.subscriptions.remove_session(session_id)
         # ...and releases any Slack threads it owned (§31): the next tag there spawns fresh.
@@ -3591,6 +3764,95 @@ class SessionManager:
             except OSError:
                 pass  # a stale/foreign path must not fail the delete
         return {"ok": ok, "session_id": session_id}
+
+    def session_exists(self, session_id: str) -> bool:
+        """Cheap route guard that never parses the conversation JSONL."""
+
+        with self._session_lifecycle_lock:
+            return (
+                session_id not in self._deleted_sessions
+                and (
+                    session_id in self._engines
+                    or self.session_store.exists(session_id)
+                )
+            )
+
+    def tool_output_store(self, session_id: str, *, create: bool = True):
+        """Open the filesystem-backed output store isolated to one session."""
+        from ..tool_outputs import SessionToolOutputStore
+
+        with self._session_lifecycle_lock:
+            if create and session_id in self._deleted_sessions:
+                raise FileNotFoundError("session was deleted")
+            store = self._tool_output_stores.get(session_id)
+            if store is not None:
+                if store.is_available():
+                    return store
+                self._tool_output_stores.pop(session_id, None)
+            store = SessionToolOutputStore(self._data_base, session_id, create=create)
+            self._tool_output_stores[session_id] = store
+            return store
+
+    def _delete_tool_outputs(self, session_id: str) -> None:
+        """Remove one session's retained data after no writer can still use it."""
+
+        from ..tool_outputs import SessionToolOutputStore, ToolOutputStoreError
+
+        with self._session_lifecycle_lock:
+            store = self._tool_output_stores.pop(session_id, None)
+        try:
+            if store is None:
+                store = SessionToolOutputStore(
+                    self._data_base,
+                    session_id,
+                    create=False,
+                )
+            store.delete_all()
+        except FileNotFoundError:
+            pass
+        except (OSError, ToolOutputStoreError):
+            logger.warning(
+                "failed to remove retained tool outputs for session %s",
+                session_id,
+                exc_info=True,
+            )
+
+    def collect_tool_output_orphans(
+        self,
+        grace_seconds: float = 24 * 60 * 60,
+        *,
+        policy: Optional[Any] = None,
+        now: Optional[float] = None,
+    ) -> int:
+        """Apply orphan, age, and global-cap retention at server startup."""
+
+        from ..tool_outputs import collect_retained_output_stores
+
+        result = collect_retained_output_stores(
+            self._data_base,
+            known_session_ids={
+                record.session_id for record in self.session_store.list()
+            },
+            active_session_ids={
+                *self._engines.keys(),
+                *self._running_sessions,
+            },
+            orphan_grace_seconds=grace_seconds,
+            policy=policy,
+            now=now,
+        )
+        if result.skipped_unsafe_entries:
+            logger.warning(
+                "skipped %d unsafe retained tool output entries",
+                result.skipped_unsafe_entries,
+            )
+        if result.over_cap_bytes:
+            logger.warning(
+                "retained tool outputs remain %d bytes over the global cap "
+                "because active or unsafe stores cannot be evicted",
+                result.over_cap_bytes,
+            )
+        return result.removed_sessions
 
     # -- provider proxy ---------------------------------------------------------
     def provider_complete(self, model, messages, tools=None):

--- a/coworker/tool_outputs.py
+++ b/coworker/tool_outputs.py
@@ -1,0 +1,1137 @@
+"""Session-scoped storage and bounded model projection for tool results."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import shutil
+import stat
+import tempfile
+import threading
+import time
+from dataclasses import asdict, dataclass
+from itertools import chain
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+import aisuite as ai
+
+from .secrets import _restrict_to_user as restrict_to_user
+
+_OUTPUT_REF = re.compile(r"^out_[0-9a-f]{32}$")
+_SESSION_OUTPUT_KEY = re.compile(r"^[0-9a-f]{64}$")
+_SCHEMA_VERSION = 1
+DEFAULT_MAX_GLOBAL_OUTPUT_BYTES = 2 * 1024 * 1024 * 1024
+DEFAULT_MAX_RETENTION_AGE_SECONDS = 30 * 24 * 60 * 60
+_GLOBAL_STORE_LOCK = threading.RLock()
+_EVICTION_PREFIX = ".evict-"
+_SERIALIZATION_CHUNK_CHARS = 64 * 1024
+_MAX_METADATA_BYTES = 64 * 1024
+_MANAGED_RESULT_FILE = re.compile(r"^(out_[0-9a-f]{32})\.(txt|json)$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class ToolOutputPolicy:
+    """Limits applied while retaining and exposing tool output."""
+
+    inline_limit_chars: int = 8_000
+    preview_chars: int = 2_000
+    read_default_bytes: int = 4_000
+    read_max_bytes: int = 8_000
+    max_single_output_bytes: int = 64 * 1024 * 1024
+    max_session_output_bytes: int = 512 * 1024 * 1024
+    max_global_output_bytes: int = DEFAULT_MAX_GLOBAL_OUTPUT_BYTES
+    max_retention_age_seconds: int = DEFAULT_MAX_RETENTION_AGE_SECONDS
+    min_disk_headroom_bytes: int = 64 * 1024 * 1024
+
+
+class ToolOutputStoreError(RuntimeError):
+    """A retained result could not be stored or verified safely."""
+
+
+@dataclass(frozen=True)
+class ProjectedToolOutput:
+    """The bounded value for the model and any durable backing record."""
+
+    model_value: Any
+    stored: StoredToolOutput | None
+
+
+@dataclass(frozen=True)
+class StoredToolOutput:
+    """Metadata required to retrieve and verify one retained result."""
+
+    ref: str
+    tool_call_id: str
+    tool_name: str
+    chars: int
+    bytes: int
+    sha256: str
+    created_at: float
+    content_complete: bool = True
+    schema_version: int = _SCHEMA_VERSION
+
+
+@dataclass(frozen=True)
+class ToolOutputPage:
+    """One UTF-8-safe byte page of retained output."""
+
+    output_ref: str
+    offset_bytes: int
+    content: str
+    next_offset_bytes: int | None
+    complete: bool
+    total_chars: int
+    total_bytes: int
+    sha256: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RetainedOutputCollection:
+    """Result of applying orphan, age, and global-cap retention."""
+
+    removed_sessions: int
+    removed_bytes: int
+    remaining_bytes: int
+    over_cap_bytes: int
+    skipped_unsafe_entries: int
+
+
+@dataclass(frozen=True)
+class _StoreDirectory:
+    path: Path
+    key: str
+    bytes: int
+    modified_at: float
+
+
+def serialize_tool_result(result: Any) -> str:
+    """Serialize a result exactly once for sizing and durable retention."""
+
+    return result if isinstance(result, str) else json.dumps(result, default=str)
+
+
+def _iter_text_chunks(value: str) -> Iterator[str]:
+    """Yield bounded slices without copying the complete string."""
+
+    for start in range(0, len(value), _SERIALIZATION_CHUNK_CHARS):
+        yield value[start : start + _SERIALIZATION_CHUNK_CHARS]
+
+
+def _iter_json_string(value: str) -> Iterator[str]:
+    """Encode a JSON string in bounded pieces.
+
+    Each slice can be escaped independently because the surrounding quotes are
+    emitted only once. This keeps a large nested string from becoming a second
+    equally large allocation inside ``json.dumps``.
+    """
+
+    yield '"'
+    for chunk in _iter_text_chunks(value):
+        yield json.dumps(chunk)[1:-1]
+    yield '"'
+
+
+def _json_object_key(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if value is None:
+        return "null"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return json.dumps(value)
+    raise TypeError(
+        f"keys must be str, int, float, bool or None, not {type(value).__name__}"
+    )
+
+
+def _iter_json_value(value: Any, active_containers: set[int]) -> Iterator[str]:
+    """Stream the subset of JSON used by tool results with ``default=str``."""
+
+    if isinstance(value, str):
+        yield from _iter_json_string(value)
+        return
+    if value is None:
+        yield "null"
+        return
+    if value is True:
+        yield "true"
+        return
+    if value is False:
+        yield "false"
+        return
+    if isinstance(value, (int, float)):
+        yield json.dumps(value)
+        return
+
+    if isinstance(value, dict):
+        container_id = id(value)
+        if container_id in active_containers:
+            raise ValueError("Circular reference detected")
+        active_containers.add(container_id)
+        try:
+            yield "{"
+            for index, (key, item) in enumerate(value.items()):
+                if index:
+                    yield ", "
+                yield from _iter_json_string(_json_object_key(key))
+                yield ": "
+                yield from _iter_json_value(item, active_containers)
+            yield "}"
+        finally:
+            active_containers.remove(container_id)
+        return
+
+    if isinstance(value, (list, tuple)):
+        container_id = id(value)
+        if container_id in active_containers:
+            raise ValueError("Circular reference detected")
+        active_containers.add(container_id)
+        try:
+            yield "["
+            for index, item in enumerate(value):
+                if index:
+                    yield ", "
+                yield from _iter_json_value(item, active_containers)
+            yield "]"
+        finally:
+            active_containers.remove(container_id)
+        return
+
+    yield from _iter_json_string(str(value))
+
+
+def _iter_serialized_tool_result(result: Any) -> Iterator[str]:
+    if isinstance(result, str):
+        yield from _iter_text_chunks(result)
+    else:
+        yield from _iter_json_value(result, set())
+
+
+def session_output_key(session_id: str) -> str:
+    """Return a stable directory key without exposing the session identifier."""
+
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+
+
+def is_valid_output_ref(ref: str) -> bool:
+    """Return whether a value is an opaque retained-output reference."""
+
+    return isinstance(ref, str) and bool(_OUTPUT_REF.fullmatch(ref))
+
+
+def _real_directory_stat(path: Path) -> os.stat_result | None:
+    """lstat a directory, rejecting symlinks and other file types."""
+
+    try:
+        path_stat = os.lstat(path)
+    except FileNotFoundError:
+        return None
+    if stat.S_ISLNK(path_stat.st_mode) or not stat.S_ISDIR(path_stat.st_mode):
+        return None
+    return path_stat
+
+
+def _inspect_flat_store(path: Path, key: str) -> _StoreDirectory | None:
+    """Size one store without following links or descending into subdirectories."""
+
+    directory_stat = _real_directory_stat(path)
+    if directory_stat is None:
+        return None
+    total = 0
+    try:
+        entries = os.scandir(path)
+        with entries:
+            for entry in entries:
+                entry_stat = entry.stat(follow_symlinks=False)
+                if not stat.S_ISREG(entry_stat.st_mode):
+                    return None
+                total += entry_stat.st_size
+    except OSError:
+        return None
+    return _StoreDirectory(
+        path=path,
+        key=key,
+        bytes=total,
+        modified_at=directory_stat.st_mtime,
+    )
+
+
+def _managed_output_bytes(output_root: Path, *, strict: bool) -> int:
+    """Count managed store/quarantine bytes without traversing symlinks."""
+
+    if _real_directory_stat(output_root) is None:
+        if output_root.exists() and strict:
+            raise ToolOutputStoreError("unsafe global tool output store")
+        return 0
+    total = 0
+    try:
+        entries = os.scandir(output_root)
+        with entries:
+            for entry in entries:
+                if not (
+                    _SESSION_OUTPUT_KEY.fullmatch(entry.name)
+                    or entry.name.startswith(_EVICTION_PREFIX)
+                ):
+                    continue
+                inspected = _inspect_flat_store(Path(entry.path), entry.name)
+                if inspected is None:
+                    if strict:
+                        raise ToolOutputStoreError(
+                            "unsafe retained tool output directory"
+                        )
+                    continue
+                total += inspected.bytes
+    except ToolOutputStoreError:
+        raise
+    except OSError as exc:
+        if strict:
+            raise ToolOutputStoreError(
+                "global tool output quota is unavailable"
+            ) from exc
+    return total
+
+
+def _unlink_flat_entry(path: Path) -> bool:
+    """Remove a quarantined flat store without ever following a symlink."""
+
+    try:
+        path_stat = os.lstat(path)
+    except FileNotFoundError:
+        return True
+    if stat.S_ISLNK(path_stat.st_mode) or not stat.S_ISDIR(path_stat.st_mode):
+        try:
+            os.unlink(path)
+            return True
+        except OSError:
+            return False
+    try:
+        entries = os.scandir(path)
+        with entries:
+            for entry in entries:
+                entry_stat = entry.stat(follow_symlinks=False)
+                if stat.S_ISDIR(entry_stat.st_mode):
+                    return False
+                os.unlink(entry.path)
+        os.rmdir(path)
+        return True
+    except OSError:
+        return False
+
+
+def _evict_flat_store(output_root: Path, path: Path) -> bool:
+    """Atomically quarantine then unlink one managed store."""
+
+    if path.parent != output_root or not _SESSION_OUTPUT_KEY.fullmatch(path.name):
+        return False
+    quarantine = output_root / (f"{_EVICTION_PREFIX}{path.name}-{secrets.token_hex(8)}")
+    try:
+        os.replace(path, quarantine)
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    return _unlink_flat_entry(quarantine)
+
+
+def collect_retained_output_stores(
+    root: str | Path,
+    *,
+    known_session_ids: set[str] | None = None,
+    active_session_ids: set[str] | None = None,
+    orphan_grace_seconds: float = 24 * 60 * 60,
+    policy: ToolOutputPolicy | None = None,
+    now: float | None = None,
+) -> RetainedOutputCollection:
+    """Apply bounded cross-session retention without touching active stores.
+
+    Unknown stores first become eligible after the orphan grace period. Every
+    inactive store becomes eligible after the age limit. If managed bytes still
+    exceed the global cap, the oldest remaining inactive stores are evicted.
+    """
+
+    chosen_policy = policy or ToolOutputPolicy()
+    output_root = Path(root) / "tool-outputs"
+    current_time = time.time() if now is None else now
+    known_keys = {
+        session_output_key(session_id) for session_id in known_session_ids or set()
+    }
+    active_keys = {
+        session_output_key(session_id) for session_id in active_session_ids or set()
+    }
+    removed_sessions = 0
+    removed_bytes = 0
+    skipped_unsafe = 0
+
+    with _GLOBAL_STORE_LOCK:
+        if _real_directory_stat(output_root) is None:
+            return RetainedOutputCollection(0, 0, 0, 0, 0)
+
+        try:
+            raw_entries = list(os.scandir(output_root))
+        except OSError:
+            return RetainedOutputCollection(0, 0, 0, 0, 1)
+
+        stores: list[_StoreDirectory] = []
+        for entry in raw_entries:
+            if entry.name.startswith(_EVICTION_PREFIX):
+                if not _unlink_flat_entry(Path(entry.path)):
+                    skipped_unsafe += 1
+                continue
+            if not _SESSION_OUTPUT_KEY.fullmatch(entry.name):
+                continue
+            inspected = _inspect_flat_store(Path(entry.path), entry.name)
+            if inspected is None:
+                skipped_unsafe += 1
+                continue
+            stores.append(inspected)
+
+        removed_keys: set[str] = set()
+
+        def evict(store: _StoreDirectory) -> bool:
+            nonlocal removed_sessions, removed_bytes
+            if store.key in active_keys or store.key in removed_keys:
+                return False
+            if not _evict_flat_store(output_root, store.path):
+                return False
+            removed_keys.add(store.key)
+            removed_sessions += 1
+            removed_bytes += store.bytes
+            return True
+
+        oldest_first = sorted(stores, key=lambda item: (item.modified_at, item.key))
+        orphan_grace = max(0.0, orphan_grace_seconds)
+        max_age = max(0.0, float(chosen_policy.max_retention_age_seconds))
+        for store in oldest_first:
+            age = current_time - store.modified_at
+            if (store.key not in known_keys and age >= orphan_grace) or age >= max_age:
+                evict(store)
+
+        remaining = sum(
+            store.bytes for store in stores if store.key not in removed_keys
+        )
+        cap = max(0, int(chosen_policy.max_global_output_bytes))
+        if remaining > cap:
+            for store in oldest_first:
+                if remaining <= cap:
+                    break
+                if evict(store):
+                    remaining -= store.bytes
+
+        remaining = _managed_output_bytes(output_root, strict=False)
+        return RetainedOutputCollection(
+            removed_sessions=removed_sessions,
+            removed_bytes=removed_bytes,
+            remaining_bytes=remaining,
+            over_cap_bytes=max(0, remaining - cap),
+            skipped_unsafe_entries=skipped_unsafe,
+        )
+
+
+class SessionToolOutputStore:
+    """Filesystem store isolated to one session."""
+
+    def __init__(
+        self,
+        root: str | Path,
+        session_id: str,
+        policy: ToolOutputPolicy | None = None,
+        *,
+        create: bool = True,
+    ) -> None:
+        if not session_id:
+            raise ValueError("session_id is required")
+        self.policy = policy or ToolOutputPolicy()
+        self._lock = threading.Lock()
+        self._verified_content: dict[
+            str,
+            tuple[int, int, int, int, int, str],
+        ] = {}
+        self.output_root = Path(root) / "tool-outputs"
+        self.directory = self.output_root / session_output_key(session_id)
+        if create:
+            for directory, parents in (
+                (self.output_root, True),
+                (self.directory, False),
+            ):
+                try:
+                    directory_stat = os.lstat(directory)
+                except FileNotFoundError:
+                    try:
+                        directory.mkdir(parents=parents, exist_ok=False)
+                    except FileExistsError:
+                        pass
+                    directory_stat = os.lstat(directory)
+                if stat.S_ISLNK(directory_stat.st_mode) or not stat.S_ISDIR(
+                    directory_stat.st_mode
+                ):
+                    raise ToolOutputStoreError("unsafe retained tool output directory")
+                restrict_to_user(directory, is_dir=True)
+        else:
+            try:
+                root_stat = os.lstat(self.output_root)
+                directory_stat = os.lstat(self.directory)
+            except FileNotFoundError as exc:
+                raise FileNotFoundError("session tool output store not found") from exc
+            if (
+                stat.S_ISLNK(root_stat.st_mode)
+                or not stat.S_ISDIR(root_stat.st_mode)
+                or stat.S_ISLNK(directory_stat.st_mode)
+                or not stat.S_ISDIR(directory_stat.st_mode)
+            ):
+                raise ToolOutputStoreError("unsafe retained tool output directory")
+        with _GLOBAL_STORE_LOCK, self._lock:
+            self._reconcile_interrupted_writes()
+
+    def _path(self, ref: str, suffix: str) -> Path:
+        if not is_valid_output_ref(ref):
+            raise ValueError("invalid output reference")
+        return self.directory / f"{ref}{suffix}"
+
+    def _assert_directories_safe(self) -> None:
+        if (
+            _real_directory_stat(self.output_root) is None
+            or _real_directory_stat(self.directory) is None
+        ):
+            raise ToolOutputStoreError("unsafe retained tool output directory")
+
+    def is_available(self) -> bool:
+        """Return whether both managed directories still exist without links."""
+
+        return (
+            _real_directory_stat(self.output_root) is not None
+            and _real_directory_stat(self.directory) is not None
+        )
+
+    def _fsync_directory(self) -> None:
+        self._assert_directories_safe()
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        descriptor = os.open(self.directory, flags)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def _reconcile_interrupted_writes(self) -> None:
+        """Remove unpublished and half-published records after a crash."""
+
+        self._assert_directories_safe()
+        result_files: dict[str, dict[str, Path]] = {}
+        removed = False
+        try:
+            entries = list(os.scandir(self.directory))
+        except OSError as exc:
+            raise ToolOutputStoreError(
+                "retained tool output directory is unavailable"
+            ) from exc
+        for entry in entries:
+            try:
+                entry_stat = entry.stat(follow_symlinks=False)
+            except OSError as exc:
+                raise ToolOutputStoreError(
+                    "retained tool output directory is unavailable"
+                ) from exc
+            entry_path = Path(entry.path)
+            if entry.name.startswith(".pending-"):
+                if stat.S_ISDIR(entry_stat.st_mode):
+                    raise ToolOutputStoreError("unsafe retained tool output directory")
+                try:
+                    os.unlink(entry_path)
+                except OSError as exc:
+                    raise ToolOutputStoreError(
+                        "interrupted tool output could not be reconciled"
+                    ) from exc
+                removed = True
+                continue
+            match = _MANAGED_RESULT_FILE.fullmatch(entry.name)
+            if match:
+                if not stat.S_ISREG(entry_stat.st_mode):
+                    raise ToolOutputStoreError("unsafe retained tool output file")
+                result_files.setdefault(match.group(1), {})[match.group(2)] = entry_path
+            elif not stat.S_ISREG(entry_stat.st_mode):
+                raise ToolOutputStoreError("unsafe retained tool output directory")
+
+        for files in result_files.values():
+            if set(files) == {"txt", "json"}:
+                continue
+            for path in files.values():
+                try:
+                    os.unlink(path)
+                except OSError as exc:
+                    raise ToolOutputStoreError(
+                        "interrupted tool output could not be reconciled"
+                    ) from exc
+                removed = True
+        if removed:
+            self._fsync_directory()
+
+    def _atomic_write(self, path: Path, data: bytes) -> None:
+        self._assert_directories_safe()
+        descriptor, pending_path = tempfile.mkstemp(
+            prefix=".pending-",
+            dir=self.directory,
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+            restrict_to_user(Path(pending_path), is_dir=False)
+            os.replace(pending_path, path)
+            self._fsync_directory()
+        except BaseException:
+            try:
+                os.unlink(pending_path)
+            except OSError:
+                pass
+            raise
+
+    @staticmethod
+    def _content_signature(stat: os.stat_result) -> tuple[int, int, int, int, int]:
+        return (
+            stat.st_dev,
+            stat.st_ino,
+            stat.st_size,
+            stat.st_mtime_ns,
+            stat.st_ctime_ns,
+        )
+
+    def _used_bytes(self) -> int:
+        inspected = _inspect_flat_store(self.directory, self.directory.name)
+        if inspected is None:
+            raise ToolOutputStoreError("unsafe retained tool output directory")
+        return inspected.bytes
+
+    def _global_used_bytes(self) -> int:
+        """Count managed regular files without traversing symlinks."""
+
+        return _managed_output_bytes(self.output_root, strict=True)
+
+    def _ensure_quota(
+        self,
+        total_write_bytes: int,
+        content_bytes: int,
+        *,
+        used_session_bytes: int,
+        used_global_bytes: int,
+        available_disk_bytes: int,
+    ) -> None:
+        if content_bytes > self.policy.max_single_output_bytes:
+            raise ToolOutputStoreError("tool output exceeds per-result quota")
+        if (
+            used_session_bytes + total_write_bytes
+            > self.policy.max_session_output_bytes
+        ):
+            raise ToolOutputStoreError("tool output exceeds session quota")
+        if used_global_bytes + total_write_bytes > self.policy.max_global_output_bytes:
+            raise ToolOutputStoreError("tool output exceeds global quota")
+        if (
+            available_disk_bytes
+            < self.policy.min_disk_headroom_bytes + total_write_bytes
+        ):
+            raise ToolOutputStoreError("insufficient disk headroom for tool output")
+
+    def _put_serialized_chunks(
+        self,
+        tool_call_id: str,
+        tool_name: str,
+        chunks: Iterable[str],
+        *,
+        content_complete: bool = True,
+        preview_chars: int | None = None,
+    ) -> tuple[StoredToolOutput, str, str]:
+        with _GLOBAL_STORE_LOCK, self._lock:
+            self._assert_directories_safe()
+            used_session_bytes = self._used_bytes()
+            used_global_bytes = self._global_used_bytes()
+            try:
+                available_disk_bytes = shutil.disk_usage(self.directory).free
+            except OSError as exc:
+                raise ToolOutputStoreError(
+                    "tool output disk quota is unavailable"
+                ) from exc
+
+            descriptor, pending_path_text = tempfile.mkstemp(
+                prefix=".pending-",
+                dir=self.directory,
+            )
+            pending_path = Path(pending_path_text)
+            chars = 0
+            content_bytes = 0
+            digest = hashlib.sha256()
+            preview_limit = max(
+                2,
+                self.policy.preview_chars if preview_chars is None else preview_chars,
+            )
+            preview_head = ""
+            preview_tail = ""
+            try:
+                with os.fdopen(descriptor, "wb") as handle:
+                    for chunk in chunks:
+                        if not isinstance(chunk, str):
+                            raise TypeError(
+                                "serialized tool output chunks must be strings"
+                            )
+                        for text_chunk in _iter_text_chunks(chunk):
+                            chars += len(text_chunk)
+                            raw_chunk = text_chunk.encode("utf-8")
+                            content_bytes += len(raw_chunk)
+                            self._ensure_quota(
+                                content_bytes,
+                                content_bytes,
+                                used_session_bytes=used_session_bytes,
+                                used_global_bytes=used_global_bytes,
+                                available_disk_bytes=available_disk_bytes,
+                            )
+                            handle.write(raw_chunk)
+                            digest.update(raw_chunk)
+                            if len(preview_head) < preview_limit:
+                                needed = preview_limit - len(preview_head)
+                                preview_head += text_chunk[:needed]
+                            preview_tail = (preview_tail + text_chunk)[-preview_limit:]
+                    handle.flush()
+                    os.fsync(handle.fileno())
+
+                record = StoredToolOutput(
+                    ref=f"out_{secrets.token_hex(16)}",
+                    tool_call_id=str(tool_call_id),
+                    tool_name=str(tool_name),
+                    chars=chars,
+                    bytes=content_bytes,
+                    sha256=digest.hexdigest(),
+                    created_at=time.time(),
+                    content_complete=content_complete,
+                )
+                content_path = self._path(record.ref, ".txt")
+                metadata_path = self._path(record.ref, ".json")
+                metadata = json.dumps(
+                    asdict(record),
+                    sort_keys=True,
+                ).encode("utf-8")
+                if len(metadata) > _MAX_METADATA_BYTES:
+                    raise ToolOutputStoreError(
+                        "tool output metadata exceeds the supported limit"
+                    )
+                self._ensure_quota(
+                    content_bytes + len(metadata),
+                    content_bytes,
+                    used_session_bytes=used_session_bytes,
+                    used_global_bytes=used_global_bytes,
+                    available_disk_bytes=available_disk_bytes,
+                )
+                restrict_to_user(pending_path, is_dir=False)
+                os.replace(pending_path, content_path)
+                self._fsync_directory()
+                try:
+                    self._atomic_write(metadata_path, metadata)
+                except BaseException:
+                    try:
+                        os.unlink(content_path)
+                        self._fsync_directory()
+                    except OSError:
+                        pass
+                    raise
+                content_stat = os.stat(content_path, follow_symlinks=False)
+                if not stat.S_ISREG(content_stat.st_mode):
+                    raise ToolOutputStoreError("unsafe retained tool output file")
+                self._verified_content[record.ref] = (
+                    *self._content_signature(content_stat),
+                    record.sha256,
+                )
+                return record, preview_head, preview_tail
+            except BaseException:
+                try:
+                    os.unlink(pending_path)
+                except OSError:
+                    pass
+                raise
+
+    def put(
+        self,
+        tool_call_id: str,
+        tool_name: str,
+        serialized: str,
+        *,
+        content_complete: bool = True,
+    ) -> StoredToolOutput:
+        if not isinstance(serialized, str):
+            raise TypeError("serialized tool output must be a string")
+        if len(serialized) > self.policy.max_single_output_bytes:
+            raise ToolOutputStoreError("tool output exceeds per-result quota")
+        record, _, _ = self._put_serialized_chunks(
+            tool_call_id,
+            tool_name,
+            _iter_text_chunks(serialized),
+            content_complete=content_complete,
+        )
+        return record
+
+    @staticmethod
+    def _open_regular_binary(path: Path):
+        try:
+            path_stat = os.lstat(path)
+        except FileNotFoundError:
+            raise
+        except OSError as exc:
+            raise ToolOutputStoreError(
+                "retained tool output file is unavailable"
+            ) from exc
+        if stat.S_ISLNK(path_stat.st_mode) or not stat.S_ISREG(path_stat.st_mode):
+            raise ToolOutputStoreError("unsafe retained tool output file")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(path, flags)
+        except FileNotFoundError:
+            raise
+        except OSError as exc:
+            raise ToolOutputStoreError(
+                "unsafe or unavailable retained tool output file"
+            ) from exc
+        try:
+            opened_stat = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(opened_stat.st_mode)
+                or opened_stat.st_dev != path_stat.st_dev
+                or opened_stat.st_ino != path_stat.st_ino
+            ):
+                raise ToolOutputStoreError("unsafe retained tool output file")
+            return os.fdopen(descriptor, "rb")
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    def read(
+        self,
+        ref: str,
+        offset_bytes: int = 0,
+        limit_bytes: int | None = None,
+    ) -> dict[str, Any]:
+        if not isinstance(offset_bytes, int) or offset_bytes < 0:
+            raise ValueError("offset_bytes must be non-negative")
+        limit = self.policy.read_default_bytes if limit_bytes is None else limit_bytes
+        if (
+            not isinstance(limit, int)
+            or limit < 1
+            or limit > self.policy.read_max_bytes
+        ):
+            raise ValueError("invalid limit_bytes")
+
+        metadata_path = self._path(ref, ".json")
+        content_path = self._path(ref, ".txt")
+        with self._lock:
+            self._assert_directories_safe()
+            try:
+                with self._open_regular_binary(metadata_path) as metadata_stream:
+                    raw_metadata = metadata_stream.read(_MAX_METADATA_BYTES + 1)
+            except FileNotFoundError as exc:
+                raise KeyError("unknown output reference") from exc
+            if len(raw_metadata) > _MAX_METADATA_BYTES:
+                raise ToolOutputStoreError("tool output metadata is corrupt")
+            try:
+                metadata = json.loads(raw_metadata.decode("utf-8"))
+                total_chars = int(metadata["chars"])
+                total_bytes = int(metadata["bytes"])
+                digest = str(metadata["sha256"])
+                metadata_ref = str(metadata["ref"])
+                schema_version = int(metadata["schema_version"])
+            except (UnicodeDecodeError, ValueError, KeyError, TypeError) as exc:
+                raise ToolOutputStoreError("tool output metadata is corrupt") from exc
+            if (
+                total_chars < 0
+                or total_bytes < 0
+                or metadata_ref != ref
+                or schema_version != _SCHEMA_VERSION
+                or not _SHA256.fullmatch(digest)
+            ):
+                raise ToolOutputStoreError("tool output metadata is corrupt")
+            if offset_bytes > total_bytes:
+                raise ValueError("offset beyond output")
+
+            try:
+                stream = self._open_regular_binary(content_path)
+            except FileNotFoundError as exc:
+                raise KeyError("unknown output reference") from exc
+            try:
+                with stream:
+                    opened_stat = os.fstat(stream.fileno())
+                    if opened_stat.st_size != total_bytes:
+                        raise ToolOutputStoreError("tool output content is corrupt")
+                    signature = self._content_signature(opened_stat)
+                    if self._verified_content.get(ref) != (*signature, digest):
+                        hasher = hashlib.sha256()
+                        for chunk in iter(
+                            lambda: stream.read(1024 * 1024),
+                            b"",
+                        ):
+                            hasher.update(chunk)
+                        if not secrets.compare_digest(
+                            hasher.hexdigest(),
+                            digest,
+                        ):
+                            raise ToolOutputStoreError("tool output content is corrupt")
+                        self._verified_content[ref] = (*signature, digest)
+                    if 0 < offset_bytes < total_bytes:
+                        stream.seek(offset_bytes)
+                        current = stream.read(1)
+                        if current and current[0] & 0xC0 == 0x80:
+                            raise ValueError("offset_bytes is not on a UTF-8 boundary")
+                    stream.seek(offset_bytes)
+                    raw_page = stream.read(limit)
+            except OSError as exc:
+                raise ToolOutputStoreError(
+                    "tool output content is unavailable"
+                ) from exc
+
+        complete = offset_bytes + len(raw_page) >= total_bytes
+        if complete:
+            try:
+                text = raw_page.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ValueError("offset_bytes is not on a UTF-8 boundary") from exc
+        else:
+            while raw_page:
+                try:
+                    text = raw_page.decode("utf-8")
+                    break
+                except UnicodeDecodeError as exc:
+                    if exc.reason != "unexpected end of data":
+                        raise ValueError(
+                            "offset_bytes is not on a UTF-8 boundary"
+                        ) from exc
+                    raw_page = raw_page[: exc.start]
+            else:
+                raise ValueError(
+                    "limit_bytes is too small for the next UTF-8 character"
+                )
+
+        next_offset = offset_bytes + len(raw_page)
+        return ToolOutputPage(
+            output_ref=ref,
+            offset_bytes=offset_bytes,
+            content=text,
+            next_offset_bytes=None if complete else next_offset,
+            complete=complete,
+            total_chars=total_chars,
+            total_bytes=total_bytes,
+            sha256=digest,
+        ).as_dict()
+
+    def list_references(self) -> set[str]:
+        with self._lock:
+            self._assert_directories_safe()
+            parts: dict[str, set[str]] = {}
+            try:
+                entries = os.scandir(self.directory)
+                with entries:
+                    for entry in entries:
+                        match = _MANAGED_RESULT_FILE.fullmatch(entry.name)
+                        if not match:
+                            continue
+                        entry_stat = entry.stat(follow_symlinks=False)
+                        if not stat.S_ISREG(entry_stat.st_mode):
+                            raise ToolOutputStoreError(
+                                "unsafe retained tool output file"
+                            )
+                        parts.setdefault(match.group(1), set()).add(match.group(2))
+            except ToolOutputStoreError:
+                raise
+            except OSError as exc:
+                raise ToolOutputStoreError(
+                    "retained tool output directory is unavailable"
+                ) from exc
+            return {
+                ref for ref, suffixes in parts.items() if suffixes == {"txt", "json"}
+            }
+
+    def delete_all(self) -> None:
+        """Delete every retained result for this session."""
+
+        self._verified_content.clear()
+        try:
+            shutil.rmtree(self.directory)
+        except FileNotFoundError:
+            pass
+
+
+class ToolResultProjector:
+    """Keep small results inline and retain oversized results outside context."""
+
+    def __init__(
+        self,
+        store: SessionToolOutputStore,
+        policy: ToolOutputPolicy | None = None,
+    ) -> None:
+        self.store = store
+        self.policy = policy or store.policy
+        if self.policy.preview_chars < 2:
+            raise ValueError("preview_chars must be at least 2")
+        if self.policy.preview_chars >= self.policy.inline_limit_chars:
+            raise ValueError("preview_chars must be smaller than inline_limit_chars")
+
+    def project(
+        self,
+        tool_call_id: str,
+        tool_name: str,
+        result: Any,
+    ) -> ProjectedToolOutput:
+        if tool_name == "read_tool_output":
+            serialized = serialize_tool_result(result)
+            if len(serialized) > self.policy.inline_limit_chars:
+                return ProjectedToolOutput(
+                    model_value={
+                        "error": "retrieved page exceeds the inline output limit",
+                        "error_kind": "limit",
+                    },
+                    stored=None,
+                )
+            return ProjectedToolOutput(model_value=result, stored=None)
+        if isinstance(result, str):
+            if len(result) <= self.policy.inline_limit_chars:
+                return ProjectedToolOutput(model_value=result, stored=None)
+            serialized_chunks: Iterable[str] = _iter_text_chunks(result)
+        else:
+            iterator = _iter_serialized_tool_result(result)
+            buffered_chunks: list[str] = []
+            buffered_chars = 0
+            for chunk in iterator:
+                buffered_chunks.append(chunk)
+                buffered_chars += len(chunk)
+                if buffered_chars > self.policy.inline_limit_chars:
+                    break
+            else:
+                return ProjectedToolOutput(model_value=result, stored=None)
+            serialized_chunks = chain(buffered_chunks, iterator)
+        content_complete = not (
+            isinstance(result, dict)
+            and (
+                result.get("retained_complete") is False
+                or result.get("truncated") is True
+            )
+        )
+        record, retained_head, retained_tail = self.store._put_serialized_chunks(
+            tool_call_id,
+            tool_name,
+            serialized_chunks,
+            content_complete=content_complete,
+            preview_chars=self.policy.preview_chars,
+        )
+        preview_chars = self.policy.preview_chars
+        while True:
+            head_chars = preview_chars // 2
+            tail_chars = preview_chars - head_chars
+            omitted_chars = record.chars - preview_chars
+            preview = (
+                retained_head[:head_chars]
+                + f"\n\n[... {omitted_chars} characters omitted ...]\n\n"
+                + retained_tail[-tail_chars:]
+            )
+            envelope = {
+                "output_ref_version": _SCHEMA_VERSION,
+                "output_ref": record.ref,
+                "truncated": True,
+                "original_chars": record.chars,
+                "original_bytes": record.bytes,
+                "sha256": record.sha256,
+                "content_complete": record.content_complete,
+                "preview": preview,
+                "instruction": (
+                    (
+                        "Use read_tool_output with output_ref and offset_bytes to inspect "
+                        "the complete result."
+                    )
+                    if record.content_complete
+                    else (
+                        "Use read_tool_output with output_ref and offset_bytes to inspect "
+                        "the retained portion. The source exceeded its capture quota, so "
+                        "the original output is not fully recoverable."
+                    )
+                ),
+            }
+            if (
+                len(serialize_tool_result(envelope)) <= self.policy.inline_limit_chars
+                or preview_chars <= 2
+            ):
+                return ProjectedToolOutput(model_value=envelope, stored=record)
+            preview_chars = max(2, preview_chars // 2)
+
+
+def read_tool_output_tool(store: SessionToolOutputStore):
+    """Create the low-risk tool used to retrieve retained output by opaque ref."""
+
+    default_limit = store.policy.read_default_bytes
+
+    def read_tool_output(
+        output_ref: str,
+        offset_bytes: int = 0,
+        limit_bytes: int = default_limit,
+    ) -> dict[str, Any]:
+        try:
+            requested_bytes = limit_bytes
+            while requested_bytes >= 1:
+                page = store.read(output_ref, offset_bytes, requested_bytes)
+                if len(serialize_tool_result(page)) <= store.policy.inline_limit_chars:
+                    return page
+                requested_bytes //= 2
+            return {
+                "error": "retrieved page exceeds the inline output limit",
+                "error_kind": "limit",
+            }
+        except ValueError as exc:
+            return {"error": str(exc), "error_kind": "invalid"}
+        except KeyError as exc:
+            return {"error": str(exc), "error_kind": "missing"}
+        except ToolOutputStoreError as exc:
+            return {"error": str(exc), "error_kind": "corrupt"}
+
+    read_tool_output.__name__ = "read_tool_output"
+    read_tool_output.__coworker_schema__ = {
+        "type": "function",
+        "function": {
+            "name": "read_tool_output",
+            "description": (
+                "Read an exact bounded page of a retained tool output. Pass the "
+                "opaque output_ref from a truncated result envelope."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "output_ref": {
+                        "type": "string",
+                        "description": "Opaque reference from a truncated tool result.",
+                    },
+                    "offset_bytes": {
+                        "type": "integer",
+                        "description": "Byte offset into the retained UTF-8 output.",
+                    },
+                    "limit_bytes": {
+                        "type": "integer",
+                        "description": (
+                            f"Maximum bytes to return (default {default_limit}, "
+                            f"maximum {store.policy.read_max_bytes})."
+                        ),
+                    },
+                },
+                "required": ["output_ref"],
+            },
+        },
+    }
+    read_tool_output.__aisuite_tool_metadata__ = ai.ToolMetadata(
+        name="read_tool_output",
+        category="context",
+        risk_level="low",
+        capabilities=["read"],
+        requires_approval=False,
+    )
+    return read_tool_output

--- a/coworker/tools/registry.py
+++ b/coworker/tools/registry.py
@@ -32,10 +32,13 @@ class ToolRegistry:
         *,
         metadata: Any = None,
         schema: Optional[dict[str, Any]] = None,
+        replace: bool = True,
     ) -> ToolSpec:
         name = getattr(func, "__name__", None)
         if not name:
             raise ValueError("Tool function must have a __name__.")
+        if not replace and name in self._tools:
+            raise ValueError(f"Tool name is reserved or already registered: {name}")
         meta = metadata or getattr(func, "__aisuite_tool_metadata__", None)
         # Allow an explicit schema override (param or a `__coworker_schema__` attribute)
         # for tools whose signature can't be auto-converted to a valid JSON schema.

--- a/coworker/tools/subagent.py
+++ b/coworker/tools/subagent.py
@@ -45,6 +45,8 @@ def build_explorer_engine(
     provider: Any,
     model: str,
     model_settings: Optional[dict[str, Any]] = None,
+    context_windows: Optional[dict[str, int]] = None,
+    context_budget: Any = None,
     max_iterations: int = _CHILD_MAX_ITERATIONS,
 ) -> TurnEngine:
     """A child engine with the Code agent's read-only tools and a fresh context."""
@@ -73,6 +75,8 @@ def build_explorer_engine(
         instructions=EXPLORER_INSTRUCTIONS,
         max_iterations=max_iterations,
         model_settings=model_settings,
+        context_windows=context_windows,
+        context_budget=context_budget,
     )
 
 
@@ -82,6 +86,8 @@ def explorer_tools(
     provider: Any,
     model: str,
     model_settings: Optional[dict[str, Any]] = None,
+    context_windows: Optional[dict[str, int]] = None,
+    context_budget: Any = None,
 ) -> list:
     def explore(task: str) -> dict:
         """Delegate a broad, read-only research task to a subagent with its own fresh
@@ -101,6 +107,8 @@ def explorer_tools(
             provider=provider,
             model=model,
             model_settings=model_settings,
+            context_windows=context_windows,
+            context_budget=context_budget,
         )
 
         async def _run() -> tuple[str, str]:

--- a/coworker/tui/app.py
+++ b/coworker/tui/app.py
@@ -117,6 +117,7 @@ class CoworkerApp(App):
             provider=self._provider,
             memory_store=self._memory_store,
             messages=self._resume_messages,
+            session_id=self._session_id,
         )
         self._write(
             f"[b]coworker · code[/b]  ·  model {self.model}  ·  mode {self.mode.value}"
@@ -222,13 +223,27 @@ class CoworkerApp(App):
             self._write(f"model → {arg}")
         elif name == "/clear":
             if self.engine:
-                self.engine.messages = []
+                old_engine = self.engine
+                old_engine.messages = []
+                self._persist_session()
+                executor = getattr(old_engine, "executor", None)
+                if executor is not None:
+                    close_background = getattr(
+                        executor, "close_background_tasks", None
+                    )
+                    if callable(close_background):
+                        close_background()
+                    executor.close()
+                output_store = getattr(old_engine, "tool_output_store", None)
+                if output_store is not None:
+                    output_store.delete_all()
                 self.engine = build_code_engine(
                     workspace=self.workspace,
                     model=self.model,
                     mode=self.mode,
                     approver=self._approve,
                     provider=self._provider,
+                    session_id=self._session_id,
                 )
             self.query_one("#log", RichLog).clear()
             self.rendered.clear()

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -7,6 +7,7 @@ operate on a real SQLite store; execution policy (catch-up, overlap) is exercise
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from datetime import datetime, timezone
 
@@ -98,6 +99,26 @@ def test_store_runs_history(tmp_path):
     assert len(runs) == 2 and runs[0].status in ("ok", "error")
 
 
+def test_store_tombstone_rejects_stale_task_and_run_writes(tmp_path):
+    store = TaskStore(tmp_path / "auto.db")
+    task = _task()
+    store.save(task)
+    stale_task = store.get(task.id)
+    stale_run = TaskRun(task_id=task.id)
+
+    assert store.delete(task.id) is True
+    assert store.save(stale_task) is None
+    assert store.add_run(stale_run) is None
+    assert store.get(task.id) is None
+    assert store.runs(task.id, limit=None) == []
+
+    # Unknown deletes are not tombstoned: a genuinely new task with that ID
+    # remains creatable.
+    new_task = _task()
+    assert store.delete(new_task.id) is False
+    assert store.save(new_task) is new_task
+
+
 # -- scheduler loop ------------------------------------------------------------
 async def test_scheduler_runs_due_task_and_advances(tmp_path):
     store = TaskStore(tmp_path / "auto.db")
@@ -148,6 +169,48 @@ async def test_scheduler_skips_overlapping_run(tmp_path):
     assert second is None and started == 1
     gate.set()
     await first
+
+
+def test_scheduler_finalization_cannot_resurrect_deleted_task(tmp_path, monkeypatch):
+    store = TaskStore(tmp_path / "auto.db")
+    task = _task()
+    store.save(task)
+    write_entered = threading.Event()
+    release_write = threading.Event()
+    errors = []
+    original_save = store.save
+    scheduler_thread = None
+
+    async def runner(task, trigger):
+        return TaskRun(task_id=task.id, status="ok", trigger=trigger)
+
+    scheduler = Scheduler(store, runner)
+
+    def blocked_save(stale_task):
+        if threading.current_thread() is scheduler_thread:
+            write_entered.set()
+            assert release_write.wait(timeout=5)
+        return original_save(stale_task)
+
+    monkeypatch.setattr(store, "save", blocked_save)
+
+    def finalize():
+        try:
+            asyncio.run(scheduler.run_task(task, trigger="scheduled"))
+        except BaseException as exc:
+            errors.append(exc)
+
+    scheduler_thread = threading.Thread(target=finalize)
+    scheduler_thread.start()
+    assert write_entered.wait(timeout=5)
+    assert store.delete(task.id) is True
+    release_write.set()
+    scheduler_thread.join(timeout=5)
+
+    assert not scheduler_thread.is_alive()
+    assert errors == []
+    assert store.get(task.id) is None
+    assert store.runs(task.id, limit=None) == []
 
 
 # -- agent-facing tools --------------------------------------------------------
@@ -206,6 +269,271 @@ def test_update_and_delete_tools(tmp_path):
     assert store.get(tid).next_run is None  # disabled → no next run
     assert tools["delete_scheduled_task"](id=tid)["ok"] is True
     assert tools["update_scheduled_task"](id=tid)["error"]
+
+
+def test_agent_update_cannot_resurrect_task_deleted_after_lookup(
+    tmp_path, monkeypatch
+):
+    store = TaskStore(tmp_path / "auto.db")
+    task = _task()
+    store.save(task)
+    tools = {
+        tool.__name__: tool
+        for tool in scheduling_tools(
+            store,
+            origin={"workspace": "/tmp/ws"},
+            default_workspace="/tmp/ws",
+        )
+    }
+    write_entered = threading.Event()
+    release_write = threading.Event()
+    results = []
+    errors = []
+    original_save = store.save
+    update_thread = None
+
+    def blocked_save(stale_task):
+        if threading.current_thread() is update_thread:
+            write_entered.set()
+            assert release_write.wait(timeout=5)
+        return original_save(stale_task)
+
+    monkeypatch.setattr(store, "save", blocked_save)
+
+    def update():
+        try:
+            results.append(
+                tools["update_scheduled_task"](id=task.id, title="stale update")
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    update_thread = threading.Thread(target=update)
+    update_thread.start()
+    assert write_entered.wait(timeout=5)
+    assert store.delete(task.id) is True
+    release_write.set()
+    update_thread.join(timeout=5)
+
+    assert not update_thread.is_alive()
+    assert errors == []
+    assert results == [{"error": f"no such task: {task.id}"}]
+    assert store.get(task.id) is None
+
+
+def test_delete_tool_can_delegate_lifecycle_cleanup(tmp_path):
+    store = TaskStore(tmp_path / "auto.db")
+    deleted = []
+    tools = {
+        tool.__name__: tool
+        for tool in scheduling_tools(
+            store,
+            origin={"workspace": "/tmp/ws"},
+            default_workspace="/tmp/ws",
+            delete_task=lambda task_id: deleted.append(task_id) is None,
+        )
+    }
+
+    result = tools["delete_scheduled_task"](id="task-id")
+
+    assert result == {"ok": True, "id": "task-id"}
+    assert deleted == ["task-id"]
+
+
+def test_manager_delete_automation_removes_run_sessions_and_outputs(tmp_path):
+    from coworker.providers import AssistantTurn, ModelCapabilities, ProviderClient
+    from coworker.server.manager import SessionManager
+    from coworker.sessions import SessionRecord
+
+    class Provider(ProviderClient):
+        def complete(self, *, model, messages, tools=None, **settings):
+            return AssistantTurn(text="done", finish_reason="stop")
+
+        def capabilities(self, model):
+            return ModelCapabilities()
+
+    manager = SessionManager(data_dir=tmp_path / "state", provider=Provider())
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task = _task()
+    task.workspace = str(workspace)
+    manager.task_store.save(task)
+    run = TaskRun(task_id=task.id, status="ok")
+    manager.task_store.add_run(run)
+    manager.session_store.save(
+        SessionRecord(
+            session_id=run.session_id,
+            workspace=str(workspace),
+            model="m",
+            mode="interactive",
+        )
+    )
+    retained = manager.tool_output_store(run.session_id)
+    retained.put("call", "tool", "retained")
+
+    result = manager.delete_automation(task.id)
+
+    assert result["ok"] is True
+    assert manager.task_store.get(task.id) is None
+    assert manager.task_store.runs(task.id, limit=None) == []
+    assert manager.session_store.exists(run.session_id) is False
+    assert not retained.directory.exists()
+
+
+async def test_deleting_running_automation_cannot_resurrect_run_or_outputs(tmp_path):
+    from coworker.providers import AssistantTurn, ModelCapabilities, ProviderClient
+    from coworker.server.manager import SessionManager
+
+    started = threading.Event()
+    release = threading.Event()
+
+    class BlockingProvider(ProviderClient):
+        def complete(self, *, model, messages, tools=None, **settings):
+            started.set()
+            assert release.wait(timeout=5)
+            return AssistantTurn(text="done", finish_reason="stop")
+
+        def capabilities(self, model):
+            return ModelCapabilities()
+
+    manager = SessionManager(
+        data_dir=tmp_path / "state",
+        provider=BlockingProvider(),
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task = _task()
+    task.workspace = str(workspace)
+    manager.task_store.save(task)
+
+    running = asyncio.create_task(manager._run_scheduled_task(task, "scheduled"))
+    assert await asyncio.to_thread(started.wait, 5)
+    run = manager.task_store.runs(task.id, limit=None)[0]
+    retained_directory = manager.tool_output_store(run.session_id).directory
+
+    assert manager.delete_automation(task.id)["ok"] is True
+    release.set()
+    await running
+
+    assert manager.task_store.get(task.id) is None
+    assert manager.task_store.runs(task.id, limit=None) == []
+    assert manager.session_store.exists(run.session_id) is False
+    assert not retained_directory.exists()
+    assert run.session_id not in manager._engines
+
+
+@pytest.mark.parametrize(
+    "operation_name",
+    ["mark_seen", "update", "prepare_manual_run", "finalize_manual_run"],
+)
+def test_automation_mutations_serialize_with_deletion(
+    tmp_path, monkeypatch, operation_name
+):
+    from coworker.server.manager import SessionManager
+    from coworker.sessions import SessionRecord
+
+    manager = SessionManager(data_dir=tmp_path / operation_name)
+    workspace = tmp_path / f"{operation_name}-workspace"
+    workspace.mkdir()
+    task = _task(workspace=str(workspace), agent="cowork")
+    manager.task_store.save(task)
+
+    run = None
+    if operation_name == "finalize_manual_run":
+        run = TaskRun(task_id=task.id, trigger="manual")
+        manager.task_store.add_run(run)
+        manager.session_store.save(
+            SessionRecord(
+                session_id=run.session_id,
+                workspace=str(workspace),
+                model="m",
+                mode="interactive",
+                messages=[{"role": "assistant", "content": "done"}],
+            )
+        )
+
+    if operation_name == "mark_seen":
+        def operation():
+            return manager.mark_automation_seen(task.id)
+
+        write_name = "save"
+    elif operation_name == "update":
+        def operation():
+            return manager.update_automation(task.id, {"title": "updated"})
+
+        write_name = "save"
+    elif operation_name == "prepare_manual_run":
+        def operation():
+            return manager.prepare_manual_run(task.id)
+
+        write_name = "add_run"
+    else:
+        assert run is not None
+        def operation():
+            return manager.finalize_manual_run(task.id, run.run_id)
+
+        write_name = "add_run"
+
+    write_entered = threading.Event()
+    release_write = threading.Event()
+    delete_started = threading.Event()
+    delete_done = threading.Event()
+    operation_results = []
+    delete_results = []
+    errors = []
+    original_write = getattr(manager.task_store, write_name)
+    operation_thread = None
+
+    def blocked_write(*args, **kwargs):
+        if threading.current_thread() is operation_thread:
+            write_entered.set()
+            assert release_write.wait(timeout=5)
+        return original_write(*args, **kwargs)
+
+    monkeypatch.setattr(manager.task_store, write_name, blocked_write)
+
+    def run_operation():
+        try:
+            operation_results.append(operation())
+        except BaseException as exc:
+            errors.append(exc)
+
+    def delete():
+        delete_started.set()
+        try:
+            delete_results.append(manager.delete_automation(task.id))
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            delete_done.set()
+
+    operation_thread = threading.Thread(target=run_operation)
+    delete_thread = threading.Thread(target=delete)
+    operation_thread.start()
+    assert write_entered.wait(timeout=5)
+
+    lifecycle_lock_was_free = manager._session_lifecycle_lock.acquire(
+        blocking=False
+    )
+    if lifecycle_lock_was_free:
+        manager._session_lifecycle_lock.release()
+
+    delete_thread.start()
+    assert delete_started.wait(timeout=5)
+    delete_interleaved = delete_done.wait(timeout=0.05)
+    release_write.set()
+    operation_thread.join(timeout=5)
+    delete_thread.join(timeout=5)
+
+    assert lifecycle_lock_was_free is False
+    assert delete_interleaved is False
+    assert not operation_thread.is_alive()
+    assert not delete_thread.is_alive()
+    assert errors == []
+    assert operation_results[0]["ok"] is True
+    assert delete_results == [{"ok": True, "id": task.id}]
+    assert manager.task_store.get(task.id) is None
+    assert manager.task_store.runs(task.id, limit=None) == []
 
 
 # -- run persists as a continuable session -------------------------------------

--- a/tests/test_bedrock_provider.py
+++ b/tests/test_bedrock_provider.py
@@ -288,6 +288,21 @@ def test_family_dispatch():
     ]
 
 
+def test_family_replay_sidecars_follow_native_provider():
+    from coworker.providers import AnthropicProvider
+
+    p = BedrockProvider(
+        region="us-east-1",
+        claude_client=AnthropicProvider(client=object()),
+        converse_client=_Recorder(),
+    )
+
+    assert p.replay_sidecar_keys(
+        "claude/anthropic.claude-sonnet-4-6-v1:0"
+    ) == frozenset({"_anthropic"})
+    assert p.replay_sidecar_keys("other/amazon.nova-2-pro-v1:0") == frozenset()
+
+
 def test_claude_family_builds_native_anthropic_over_bedrock(monkeypatch):
     from anthropic import AnthropicBedrock
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,743 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+
+from coworker.context import ContextBudget, ContextProjection
+
+
+def test_budget_defaults_preserve_direct_provider_attachment_limits():
+    budget = ContextBudget()
+
+    assert budget.soft_message_limit == 220
+    assert budget.hard_message_limit == 256
+    assert budget.soft_request_bytes is None
+    assert budget.hard_request_bytes is None
+    assert budget.historical_tool_argument_redaction_bytes == 8_192
+
+
+def test_gateway_budget_reserves_wire_adapter_headroom_below_two_mebibytes():
+    budget = ContextBudget.gateway()
+
+    assert budget.soft_request_bytes == 1_572_864
+    assert budget.hard_request_bytes == 2_031_616
+    assert budget.hard_request_bytes < 2 * 1_024 * 1_024
+
+
+def test_projection_reports_exact_compact_utf8_request_size():
+    projection = ContextProjection.build(
+        [{"role": "user", "content": "é"}],
+        budget=ContextBudget(),
+        model="m",
+        tools=[{"type": "function"}],
+        settings={"temperature": 0},
+    )
+    expected_body = (
+        b'{"model":"m","messages":[{"role":"user","content":"'
+        + "é".encode("utf-8")
+        + b'"}],"tools":[{"type":"function"}],"temperature":0}'
+    )
+
+    assert projection.request_bytes == len(expected_body)
+    assert projection.estimated_tokens == math.ceil(len(expected_body) / 4)
+
+
+def test_projection_bounds_257_messages_and_keeps_latest_user():
+    messages = [{"role": "system", "content": "instructions"}]
+    messages.extend(
+        {"role": "user", "content": f"message {index}"} for index in range(255)
+    )
+    messages.append({"role": "user", "content": "latest user turn"})
+
+    budget = ContextBudget()
+    projection = ContextProjection.build(
+        messages,
+        budget=budget,
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    assert projection.message_count <= 220
+    assert projection.message_count == len(projection.messages)
+    assert projection.messages[0] == {
+        "role": "system",
+        "content": "instructions",
+    }
+    assert projection.messages[-1] == {
+        "role": "user",
+        "content": "latest user turn",
+    }
+    assert (
+        sum(
+            "Earlier conversation omitted" in message.get("content", "")
+            for message in projection.messages
+        )
+        == 1
+    )
+
+
+def test_projection_protects_the_entire_leading_system_prefix():
+    messages = [
+        {"role": "system", "content": "base instructions"},
+        {"role": "system", "content": "policy instructions"},
+        {"role": "user", "content": "old turn"},
+        {"role": "user", "content": "latest turn"},
+    ]
+
+    projection = ContextProjection.build(
+        messages,
+        budget=ContextBudget(
+            soft_message_limit=3,
+            hard_message_limit=4,
+        ),
+        model="test-model",
+    )
+
+    assert projection.messages[:2] == messages[:2]
+    assert projection.messages[-1] == messages[-1]
+    assert all(message.get("content") != "old turn" for message in projection.messages)
+
+
+def test_projection_uses_dynamic_token_target_from_model_context_window():
+    messages = [
+        {"role": "system", "content": "instructions"},
+        {"role": "user", "content": "o" * 160_000},
+        {"role": "user", "content": "l" * 160_000},
+    ]
+
+    budget = ContextBudget()
+    projection = ContextProjection.build(
+        messages,
+        budget=budget,
+        model="test-model",
+        model_context_window=100_000,
+        tools=[],
+        settings={},
+    )
+
+    assert projection.soft_token_limit == 80_000
+    assert projection.hard_token_limit == 100_000
+    assert projection.estimated_tokens <= 80_000
+    assert projection.messages[-1]["content"] == "l" * 160_000
+    assert all(
+        message.get("content") != "o" * 160_000 for message in projection.messages
+    )
+
+
+def test_projection_bounds_four_625kb_tool_results():
+    messages = [
+        {"role": "system", "content": "instructions"},
+        {"role": "user", "content": "latest user turn"},
+    ]
+    for index in range(4):
+        call_id = f"call-{index}"
+        messages.extend(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": "crm_read",
+                                "arguments": '{"query":"accounts"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": "x" * 625_000,
+                },
+            ]
+        )
+
+    projection = ContextProjection.build(
+        messages,
+        budget=ContextBudget.gateway(),
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    assert projection.request_bytes <= 1_572_864
+    assert projection.request_bytes < 2 * 1_024 * 1_024
+    assert projection.omitted_message_count > 0
+    assert projection.messages[1]["role"] == "system"
+    assert "Earlier conversation omitted" in projection.messages[1]["content"]
+    assert {"role": "user", "content": "latest user turn"} in projection.messages
+
+
+def test_projection_never_orphans_an_assistant_tool_call_or_its_results():
+    messages = [
+        {"role": "system", "content": "instructions"},
+        {"role": "user", "content": "older turn"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-a",
+                    "type": "function",
+                    "function": {"name": "read", "arguments": "{}"},
+                },
+                {
+                    "id": "call-b",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-a", "content": "a"},
+        {"role": "tool", "tool_call_id": "call-b", "content": "b"},
+        {"role": "user", "content": "latest user turn"},
+    ]
+
+    projection = ContextProjection.build(
+        messages,
+        budget=ContextBudget(
+            soft_message_limit=5,
+            hard_message_limit=6,
+            soft_request_bytes=10_000,
+            hard_request_bytes=20_000,
+        ),
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    call_ids = {
+        call["id"]
+        for message in projection.messages
+        for call in message.get("tool_calls", [])
+    }
+    result_ids = {
+        message["tool_call_id"]
+        for message in projection.messages
+        if message.get("role") == "tool"
+    }
+    assert call_ids == result_ids
+    assert projection.omitted_group_count == 1
+
+
+def test_projection_drops_historical_user_turns_without_leaving_their_answer():
+    messages = [
+        {"role": "system", "content": "instructions"},
+        {"role": "user", "content": "old prompt " + ("x" * 20_000)},
+        {"role": "assistant", "content": "answer that depends on the old prompt"},
+        {"role": "user", "content": "latest user turn"},
+    ]
+
+    projection = ContextProjection.build(
+        messages,
+        budget=ContextBudget(
+            soft_request_bytes=1_000,
+            hard_request_bytes=100_000,
+        ),
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    assert all(
+        "old prompt" not in str(message.get("content"))
+        and "answer that depends" not in str(message.get("content"))
+        for message in projection.messages
+    )
+    assert projection.messages[-1]["content"] == "latest user turn"
+
+
+def test_projection_strips_display_state_without_mutating_durable_history():
+    messages = [
+        {
+            "role": "system",
+            "content": "instructions",
+            "ts": 1.0,
+            "usage": {"input": 10},
+        },
+        {
+            "role": "notice",
+            "kind": "model_switch",
+            "text": "Model switched",
+            "ts": 2.0,
+        },
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "hello"}],
+            "source": {"connector": "slack"},
+            "_display": {"card": True},
+            "reasoning": "display-only thought",
+            "ts": 3.0,
+        },
+    ]
+    durable_snapshot = copy.deepcopy(messages)
+
+    projection = ContextProjection.build(
+        messages,
+        budget=ContextBudget(),
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    assert messages == durable_snapshot
+    assert [message["role"] for message in projection.messages] == ["system", "user"]
+    assert all(
+        sidecar not in message
+        for message in projection.messages
+        for sidecar in ("source", "_display", "ts", "reasoning", "usage")
+    )
+
+    projection.messages[-1]["content"][0]["text"] = "provider mutation"
+    assert messages[-1]["content"][0]["text"] == "hello"
+
+
+def test_projection_replaces_completed_write_file_content_with_bounded_metadata():
+    artifact_content = "résumé\n" * 20_000
+    messages = [
+        {"role": "system", "content": "instructions"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "write-1",
+                    "type": "function",
+                    "function": {
+                        "name": "write_file",
+                        "arguments": json.dumps(
+                            {
+                                "path": "artifacts/report.md",
+                                "content": artifact_content,
+                            }
+                        ),
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "write-1", "content": "report.md"},
+        {"role": "user", "content": "latest user turn"},
+    ]
+    durable_snapshot = copy.deepcopy(messages)
+
+    projection = ContextProjection.build(
+        messages,
+        budget=ContextBudget(),
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    assistant = next(
+        message for message in projection.messages if message["role"] == "assistant"
+    )
+    projected_arguments = json.loads(
+        assistant["tool_calls"][0]["function"]["arguments"]
+    )
+    artifact_bytes = artifact_content.encode("utf-8")
+
+    assert projected_arguments["path"] == "artifacts/report.md"
+    assert "content" not in projected_arguments
+    assert projected_arguments["content_bytes"] == len(artifact_bytes)
+    assert (
+        projected_arguments["content_sha256"]
+        == hashlib.sha256(artifact_bytes).hexdigest()
+    )
+    assert "read_file" in projected_arguments["context_note"]
+    assert artifact_content not in assistant["tool_calls"][0]["function"]["arguments"]
+    assert projection.redacted_tool_argument_bytes == len(artifact_bytes)
+    assert messages == durable_snapshot
+
+
+def test_projection_keeps_trailing_write_exchange_for_immediate_follow_up():
+    artifact_content = "x" * 20_000
+    messages = [
+        {"role": "system", "content": "instructions"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "write-current",
+                    "type": "function",
+                    "function": {
+                        "name": "write_file",
+                        "arguments": json.dumps(
+                            {"path": "current.md", "content": artifact_content}
+                        ),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "write-current",
+            "content": "current.md",
+        },
+    ]
+
+    projection = ContextProjection.build(
+        messages,
+        budget=ContextBudget(),
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    assistant = projection.messages[-2]
+    projected_arguments = json.loads(
+        assistant["tool_calls"][0]["function"]["arguments"]
+    )
+    assert projected_arguments["content"] == artifact_content
+    assert projection.redacted_tool_argument_bytes == 0
+
+
+def test_projection_never_drops_the_current_trailing_tool_exchange():
+    artifact_content = "x" * 1_600_000
+    budget = ContextBudget.gateway()
+    messages = [
+        {"role": "system", "content": "instructions"},
+        {"role": "user", "content": "write the artifact"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "write-current",
+                    "type": "function",
+                    "function": {
+                        "name": "write_file",
+                        "arguments": json.dumps(
+                            {"path": "current.md", "content": artifact_content}
+                        ),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "write-current",
+            "content": "current.md",
+        },
+    ]
+
+    projection = ContextProjection.build(
+        messages,
+        budget=budget,
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    assert any(
+        call.get("id") == "write-current"
+        for message in projection.messages
+        for call in message.get("tool_calls", [])
+    )
+    assert any(
+        message.get("tool_call_id") == "write-current"
+        for message in projection.messages
+    )
+    assert (
+        budget.soft_request_bytes
+        < projection.request_bytes
+        <= budget.hard_request_bytes
+    )
+
+
+def test_projection_preserves_current_tool_exchange_when_steering_follows_results():
+    budget = ContextBudget.gateway()
+    messages = [
+        {"role": "system", "content": "instructions"},
+        {"role": "user", "content": "look up the full account"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "lookup-current",
+                    "type": "function",
+                    "function": {
+                        "name": "crm_lookup",
+                        "arguments": '{"account":"Apollo"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "lookup-current",
+            "content": "x" * 1_600_000,
+        },
+        {
+            "role": "user",
+            "content": "focus on the supply-chain team",
+            "_steering": True,
+        },
+    ]
+
+    projection = ContextProjection.build(
+        messages,
+        budget=budget,
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    assert projection.messages == [
+        *messages[:-1],
+        {"role": "user", "content": "focus on the supply-chain team"},
+    ]
+    assert projection.omitted_message_count == 0
+    assert (
+        budget.soft_request_bytes
+        < projection.request_bytes
+        <= budget.hard_request_bytes
+    )
+
+
+def test_projection_keeps_just_completed_write_arguments_exact_before_steering():
+    artifact_content = "x" * 20_000
+    messages = [
+        {"role": "system", "content": "instructions"},
+        {"role": "user", "content": "write the artifact"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "write-current",
+                    "type": "function",
+                    "function": {
+                        "name": "write_file",
+                        "arguments": json.dumps(
+                            {"path": "current.md", "content": artifact_content}
+                        ),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "write-current",
+            "content": "current.md",
+        },
+        {"role": "user", "content": "also add a heading", "_steering": True},
+    ]
+
+    projection = ContextProjection.build(
+        messages,
+        budget=ContextBudget(),
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    assistant = next(
+        message for message in projection.messages if message.get("tool_calls")
+    )
+    projected_arguments = json.loads(
+        assistant["tool_calls"][0]["function"]["arguments"]
+    )
+    assert projected_arguments["content"] == artifact_content
+    assert projection.redacted_tool_argument_bytes == 0
+
+
+def test_projection_does_not_rewrite_signed_historical_tool_arguments():
+    artifact_content = "x" * 20_000
+    arguments = json.dumps({"path": "signed.md", "content": artifact_content})
+    signed_sidecar = {"text_sig": "", "call_sigs": ["c2lnbmF0dXJl"]}
+    messages = [
+        {
+            "role": "assistant",
+            "_gemini": signed_sidecar,
+            "tool_calls": [
+                {
+                    "id": "signed-write",
+                    "type": "function",
+                    "function": {
+                        "name": "write_file",
+                        "arguments": arguments,
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "signed-write", "content": "signed.md"},
+        {"role": "user", "content": "later turn"},
+    ]
+
+    projection = ContextProjection.build(
+        messages,
+        budget=ContextBudget(),
+        model="gemini",
+        replay_sidecar_keys={"_gemini"},
+    )
+
+    assistant = next(
+        message for message in projection.messages if message.get("tool_calls")
+    )
+    assert assistant["_gemini"] == signed_sidecar
+    assert assistant["tool_calls"][0]["function"]["arguments"] == arguments
+    assert projection.redacted_tool_argument_bytes == 0
+
+
+def test_direct_provider_token_estimate_does_not_treat_image_base64_as_text():
+    image_data = "data:image/png;base64," + ("A" * 3_000_000)
+    projection = ContextProjection.build(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "inspect this"},
+                    {"type": "image_url", "image_url": {"url": image_data}},
+                ],
+            }
+        ],
+        budget=ContextBudget(),
+        model="vision-model",
+        model_context_window=400_000,
+    )
+
+    assert projection.request_bytes > 3_000_000
+    assert projection.estimated_tokens < 40_000
+    assert projection.messages[0]["content"][1]["image_url"]["url"] == image_data
+
+
+def test_projection_keeps_small_historical_write_arguments_inline():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "write-small",
+                    "type": "function",
+                    "function": {
+                        "name": "write_file",
+                        "arguments": json.dumps(
+                            {"path": "small.md", "content": "small"}
+                        ),
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "write-small", "content": "small.md"},
+        {"role": "user", "content": "later turn"},
+    ]
+
+    projection = ContextProjection.build(
+        messages,
+        budget=ContextBudget(),
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    assistant = projection.messages[0]
+    projected_arguments = json.loads(
+        assistant["tool_calls"][0]["function"]["arguments"]
+    )
+    assert projected_arguments["content"] == "small"
+    assert projection.redacted_tool_argument_bytes == 0
+
+
+def test_projection_bounds_historical_replace_in_file_old_and_new_text():
+    old_text = "old\n" * 3_000
+    new_text = "new\n" * 4_000
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "replace-1",
+                    "type": "function",
+                    "function": {
+                        "name": "replace_in_file",
+                        "arguments": json.dumps(
+                            {
+                                "path": "large.py",
+                                "old": old_text,
+                                "new": new_text,
+                                "expected_replacements": 1,
+                            }
+                        ),
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "replace-1", "content": '{"ok":true}'},
+        {"role": "user", "content": "later turn"},
+    ]
+
+    projection = ContextProjection.build(
+        messages,
+        budget=ContextBudget(),
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    assistant = projection.messages[0]
+    projected_arguments = json.loads(
+        assistant["tool_calls"][0]["function"]["arguments"]
+    )
+    assert projected_arguments["path"] == "large.py"
+    assert projected_arguments["expected_replacements"] == 1
+    assert "old" not in projected_arguments
+    assert "new" not in projected_arguments
+    assert projected_arguments["old_bytes"] == len(old_text.encode("utf-8"))
+    assert projected_arguments["new_bytes"] == len(new_text.encode("utf-8"))
+    assert len(projected_arguments["old_sha256"]) == 64
+    assert len(projected_arguments["new_sha256"]) == 64
+    assert projection.redacted_tool_argument_bytes == len(
+        (old_text + new_text).encode("utf-8")
+    )
+
+
+def test_projection_drops_incomplete_tool_groups_and_orphan_results():
+    messages = [
+        {"role": "system", "content": "instructions"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-a",
+                    "type": "function",
+                    "function": {"name": "read", "arguments": "{}"},
+                },
+                {
+                    "id": "call-b",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-a", "content": "partial"},
+        {"role": "tool", "tool_call_id": "orphan", "content": "orphan"},
+        {"role": "user", "content": "latest user turn"},
+    ]
+
+    projection = ContextProjection.build(
+        messages,
+        budget=ContextBudget(),
+        model="test-model",
+        tools=[],
+        settings={},
+    )
+
+    assert [message["role"] for message in projection.messages] == [
+        "system",
+        "system",
+        "user",
+    ]
+    assert "Earlier conversation omitted" in projection.messages[1]["content"]
+    assert projection.omitted_message_count == 3
+    assert projection.omitted_group_count == 1

--- a/tests/test_context_integration.py
+++ b/tests/test_context_integration.py
@@ -1,0 +1,319 @@
+"""Provider-boundary coverage for bounded model context.
+
+The durable transcript may keep every record, but a provider call must stay inside the
+request limits used by the hosted Companion gateway.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from coworker.context import ContextBudget
+from coworker.engine import TurnEngine
+from coworker.permissions import PermissionEngine
+from coworker.providers import (
+    AnthropicProvider,
+    AssistantTurn,
+    GeminiProvider,
+    ModelCapabilities,
+    OpenAIProvider,
+    ProviderClient,
+    ToolCall,
+)
+from coworker.tools import ToolRegistry
+
+
+class RecordingProvider(ProviderClient):
+    def __init__(self) -> None:
+        self.requests: list[list[dict]] = []
+
+    def complete(self, *, model, messages, tools=None, **settings):
+        self.requests.append(messages)
+        return AssistantTurn(text="done", finish_reason="stop")
+
+    def capabilities(self, model):
+        return ModelCapabilities()
+
+
+class ReplayRecordingProvider(RecordingProvider):
+    def __init__(self, native_provider: ProviderClient) -> None:
+        super().__init__()
+        self.native_provider = native_provider
+
+    def replay_sidecar_keys(self, model):
+        return self.native_provider.replay_sidecar_keys(model)
+
+
+def _run(engine: TurnEngine, prompt: str) -> None:
+    async def collect() -> None:
+        async for _ in engine.run(prompt):
+            pass
+
+    asyncio.run(collect())
+
+
+def test_turn_engine_never_sends_more_than_gateway_message_budget(tmp_path):
+    provider = RecordingProvider()
+    durable = [{"role": "system", "content": "system"}]
+    durable.extend(
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"message-{index}",
+        }
+        for index in range(260)
+    )
+    engine = TurnEngine(
+        provider=provider,
+        registry=ToolRegistry(),
+        permissions=PermissionEngine(workspace_root=tmp_path),
+        model="gpt-5.5",
+        messages=durable,
+        context_budget=ContextBudget.gateway(),
+    )
+
+    _run(engine, "LATEST_USER_SENTINEL")
+
+    sent = provider.requests[0]
+    assert len(sent) <= 220
+    assert sent[0] == {"role": "system", "content": "system"}
+    assert sent[-1]["content"] == "LATEST_USER_SENTINEL"
+    assert len(engine.messages) == len(durable) + 2
+
+
+def _request_bytes(messages: list[dict]) -> int:
+    body = {
+        "model": "gpt-5.5",
+        "messages": messages,
+        "tools": None,
+    }
+    return len(
+        json.dumps(body, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    )
+
+
+def test_turn_engine_bounds_request_bytes_without_orphaning_tool_results(tmp_path):
+    provider = RecordingProvider()
+    durable = [{"role": "system", "content": "system"}]
+    for index in range(4):
+        call_id = f"call-{index}"
+        durable.extend(
+            [
+                {"role": "user", "content": f"look up record {index}"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": "crm_search",
+                                "arguments": json.dumps({"index": index}),
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": "x" * 625_000,
+                },
+                {"role": "assistant", "content": f"record {index} processed"},
+            ]
+        )
+    engine = TurnEngine(
+        provider=provider,
+        registry=ToolRegistry(),
+        permissions=PermissionEngine(workspace_root=tmp_path),
+        model="gpt-5.5",
+        messages=durable,
+        context_budget=ContextBudget.gateway(),
+    )
+
+    _run(engine, "LATEST_USER_SENTINEL")
+
+    sent = provider.requests[0]
+    assert _request_bytes(sent) <= 1_572_864
+    retained_call_ids = {
+        call["id"] for message in sent for call in message.get("tool_calls", [])
+    }
+    assert {
+        message["tool_call_id"] for message in sent if message.get("role") == "tool"
+    } <= retained_call_ids
+    assert sent[-1]["content"] == "LATEST_USER_SENTINEL"
+    assert len(engine.messages) == len(durable) + 2
+
+
+def test_model_switch_ignores_foreign_provider_replay_sidecars(tmp_path):
+    provider = RecordingProvider()
+    foreign_thinking = {
+        "blocks": [
+            {
+                "type": "thinking",
+                "thinking": "x" * (1_600 * 1_024),
+                "signature": "foreign-signature",
+            }
+        ]
+    }
+    durable = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "old question"},
+        {
+            "role": "assistant",
+            "content": "useful old answer",
+            "_anthropic": foreign_thinking,
+        },
+    ]
+    engine = TurnEngine(
+        provider=provider,
+        registry=ToolRegistry(),
+        permissions=PermissionEngine(workspace_root=tmp_path),
+        model="gpt-5.5",
+        messages=durable,
+    )
+
+    _run(engine, "question after switching providers")
+
+    sent = provider.requests[0]
+    assert any(message.get("content") == "useful old answer" for message in sent)
+    assert all("_anthropic" not in message for message in sent)
+    assert engine.messages[2]["_anthropic"] == foreign_thinking
+
+
+def test_native_providers_declare_only_their_signed_replay_sidecars():
+    assert AnthropicProvider().replay_sidecar_keys("claude-fable-5") == frozenset(
+        {"_anthropic"}
+    )
+    assert GeminiProvider().replay_sidecar_keys("gemini-3.6-flash") == frozenset(
+        {"_gemini"}
+    )
+    assert OpenAIProvider().replay_sidecar_keys(
+        "deepseek-v4-flash"
+    ) == frozenset({"_openai"})
+    assert OpenAIProvider().replay_sidecar_keys("deepseek-v4-pro") == frozenset(
+        {"_openai"}
+    )
+    assert OpenAIProvider().replay_sidecar_keys("gpt-5.6-sol") == frozenset()
+
+
+def test_active_signed_replay_sidecar_survives_projection_exactly(tmp_path):
+    cases = [
+        (
+            AnthropicProvider(),
+            "claude-fable-5",
+            "_anthropic",
+            {
+                "blocks": [
+                    {
+                        "type": "thinking",
+                        "thinking": "signed plan",
+                        "signature": "anthropic-signature",
+                    }
+                ]
+            },
+        ),
+        (
+            GeminiProvider(),
+            "gemini-3.6-flash",
+            "_gemini",
+            {"text_sig": "dGV4dA==", "call_sigs": ["Y2FsbA=="]},
+        ),
+        (
+            OpenAIProvider(),
+            "deepseek-v4-flash",
+            "_openai",
+            {"reasoning_content": "signed DeepSeek reasoning"},
+        ),
+    ]
+
+    for native_provider, model, sidecar_key, signed_value in cases:
+        provider = ReplayRecordingProvider(native_provider)
+        durable = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "old question"},
+            {
+                "role": "assistant",
+                "content": "calling",
+                sidecar_key: signed_value,
+                "_foreign": {"payload": "must not leak"},
+                "tool_calls": [
+                    {
+                        "id": "signed-call",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "signed-call", "content": "result"},
+        ]
+        engine = TurnEngine(
+            provider=provider,
+            registry=ToolRegistry(),
+            permissions=PermissionEngine(workspace_root=tmp_path),
+            model=model,
+            messages=durable,
+        )
+
+        _run(engine, "next question")
+
+        signed_message = next(
+            message for message in provider.requests[0] if message.get("tool_calls")
+        )
+        assert signed_message[sidecar_key] == signed_value
+        assert "_foreign" not in signed_message
+        assert engine.messages[2][sidecar_key] == signed_value
+        assert engine.messages[2]["_foreign"] == {"payload": "must not leak"}
+
+
+class ToolThenDoneProvider(ProviderClient):
+    def __init__(self) -> None:
+        self.requests: list[list[dict]] = []
+
+    def complete(self, *, model, messages, tools=None, **settings):
+        self.requests.append(messages)
+        if len(self.requests) == 1:
+            return AssistantTurn(
+                tool_calls=[
+                    ToolCall(id="large-call", name="large_lookup", arguments={})
+                ],
+                finish_reason="tool_calls",
+            )
+        return AssistantTurn(text="done", finish_reason="stop")
+
+    def capabilities(self, model):
+        return ModelCapabilities()
+
+
+def test_oversized_tool_result_is_recoverable_but_not_replayed_in_full(tmp_path):
+    from coworker.tool_outputs import SessionToolOutputStore
+
+    provider = ToolThenDoneProvider()
+    registry = ToolRegistry()
+
+    def large_lookup() -> str:
+        return "HEAD" + ("z" * 20_000) + "TAIL"
+
+    registry.register(large_lookup)
+    store = SessionToolOutputStore(tmp_path / "state", "session-1")
+    engine = TurnEngine(
+        provider=provider,
+        registry=registry,
+        permissions=PermissionEngine(workspace_root=tmp_path),
+        model="gpt-5.5",
+        tool_output_store=store,
+    )
+
+    _run(engine, "find it")
+
+    result = next(
+        message for message in engine.messages if message.get("role") == "tool"
+    )
+    envelope = json.loads(result["content"])
+    assert envelope["truncated"] is True
+    assert envelope["original_chars"] == 20_008
+    assert envelope["output_ref"] in store.list_references()
+    assert "HEAD" in envelope["preview"]
+    assert "TAIL" in envelope["preview"]
+    assert len(result["content"]) <= 8_000
+    assert all("z" * 20_000 not in json.dumps(request) for request in provider.requests)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -38,9 +38,11 @@ class ScriptedProvider(ProviderClient):
         self._turns = list(turns)
         self._loop = loop
         self.calls = 0
+        self.requests = []
 
     def complete(self, *, model, messages, tools=None, **settings):
         self.calls += 1
+        self.requests.append(messages)
         return self._turns[0] if self._loop else self._turns.pop(0)
 
     def capabilities(self, model):
@@ -196,6 +198,33 @@ def test_steering_injects_next_turn(tmp_path):
         for m in engine.messages
     )
     assert events[-1].data["status"] == "completed"
+
+
+def test_steering_after_tool_result_preserves_active_exchange(tmp_path):
+    (tmp_path / "a.txt").write_text("hello", encoding="utf-8")
+    engine, provider = _engine(
+        tmp_path,
+        [_tool_turn("read_file", {"path": "a.txt"}), _text_turn("second")],
+    )
+    engine.queue_steering("focus on the greeting")
+
+    _collect(engine, "read a.txt")
+
+    follow_up = provider.requests[1]
+    assert [message["role"] for message in follow_up] == [
+        "user",
+        "assistant",
+        "tool",
+        "user",
+    ]
+    assert follow_up[0]["content"] == "read a.txt"
+    assert follow_up[-1] == {"role": "user", "content": "focus on the greeting"}
+    durable_steering = next(
+        message
+        for message in engine.messages
+        if message.get("content") == "focus on the greeting"
+    )
+    assert durable_steering["_steering"] is True
 
 
 # -- parallel tool execution ------------------------------------------------------
@@ -366,14 +395,19 @@ def test_outbound_keeps_pdf_for_native_models(tmp_path):
 
 def test_provider_extras_persist_on_message_and_survive_outbound(tmp_path):
     """A turn's provider-private sidecar (`extras`, e.g. Gemini thought signatures) rides
-    the persisted assistant message and is NOT stripped by _outbound_messages — the owning
-    provider needs it back; foreign providers strip it themselves."""
+    the persisted assistant message and survives outbound projection for its owning provider."""
+
+    class GeminiScriptedProvider(ScriptedProvider):
+        def replay_sidecar_keys(self, model):
+            return frozenset({"_gemini"})
+
     turn = AssistantTurn(
         text="ok",
         finish_reason="stop",
         extras={"_gemini": {"text_sig": "c2ln", "call_sigs": []}},
     )
     engine, _ = _engine(tmp_path, [turn])
+    engine.provider = GeminiScriptedProvider([turn])
     _collect(engine, "hi")
 
     persisted = engine.messages[-1]

--- a/tests/test_provider_router.py
+++ b/tests/test_provider_router.py
@@ -76,6 +76,7 @@ class _Recorder(ProviderClient):
     def __init__(self, name: str):
         self.name = name
         self.models: list[str] = []
+        self.sidecar_models: list[str] = []
 
     def complete(self, *, model, messages, tools=None, **settings):
         self.models.append(model)
@@ -87,6 +88,10 @@ class _Recorder(ProviderClient):
 
     def capabilities(self, model):
         return ModelCapabilities()
+
+    def replay_sidecar_keys(self, model):
+        self.sidecar_models.append(model)
+        return frozenset({f"_{self.name}"})
 
 
 def _patch_build(monkeypatch):
@@ -146,6 +151,16 @@ def test_router_capabilities_prefix_aware():
     router = ProviderRouter(secrets=None)
     assert router.capabilities("ollama:qwen2.5-coder").tools is True
     assert router.capabilities("ollama:qwen2.5-coder").parallel_tool_calls is False
+
+
+def test_router_delegates_replay_sidecars_with_the_bare_model(monkeypatch):
+    state = _patch_build(monkeypatch)
+    router = ProviderRouter(secrets=None)
+
+    assert router.replay_sidecar_keys("gemini:gemini-3.6-flash") == frozenset(
+        {"_gemini"}
+    )
+    assert state["latest"]["gemini"].sidecar_models == ["gemini-3.6-flash"]
 
 
 # -- capabilities ---------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+
+import anyio
 import pytest
 from fastapi.testclient import TestClient
 
@@ -321,6 +324,46 @@ def test_ws_simple_turn(tmp_path):
         types = _drain(ws)
         assert "assistant_message" in types
         assert "turn_end" in types
+
+
+def test_ws_final_save_failure_still_marks_idle_and_broadcasts_turn_done(
+    tmp_path, monkeypatch
+):
+    manager = SessionManager(
+        workspace=tmp_path, provider=ScriptedProvider([_text("done")])
+    )
+    original_save = manager.save
+    save_calls = 0
+    failures = 0
+
+    def fail_final_save(session_id, engine):
+        nonlocal save_calls, failures
+        save_calls += 1
+        if save_calls == 2:
+            failures += 1
+            raise RuntimeError("final save failed")
+        return original_save(session_id, engine)
+
+    async def receive_event_with_timeout(ws):
+        with anyio.fail_after(1):
+            message = await ws._send_rx.receive()
+        ws._raise_on_close(message)
+        return json.loads(message["text"])
+
+    monkeypatch.setattr(manager, "save", fail_final_save)
+    client = TestClient(create_app(manager))
+    with client.websocket_connect("/ws/session/final-save-fails") as ws:
+        assert ws.receive_json()["type"] == "ready"
+        ws.send_json({"type": "user_message", "text": "hello"})
+        types = []
+        while "turn_done" not in types:
+            event = ws.portal.call(receive_event_with_timeout, ws)
+            types.append(event["type"])
+
+    assert failures == 1
+    assert save_calls == 2
+    assert "turn_done" in types
+    assert manager.is_running("final-save-fails") is False
 
 
 def test_ws_rejects_oversized_message(tmp_path):

--- a/tests/test_standing_approvals.py
+++ b/tests/test_standing_approvals.py
@@ -8,9 +8,9 @@ task-persistent "Allow every time" on run approvals, and revocation. No network,
 from __future__ import annotations
 
 import asyncio
+import threading
 
 import aisuite as ai
-import pytest
 
 from coworker.automation import Schedule, ScheduledTask, Scheduler, TaskRun, TaskStore
 from coworker.automation.models import grant_entries, rule_entry, rule_parts
@@ -334,6 +334,56 @@ def test_mint_task_rule_validates(tmp_path, monkeypatch):
     assert manager.task_store.get(task.id).always_allowed_tools == [
         "send_message slack:C1"
     ]
+
+
+def test_mint_task_rule_cannot_resurrect_deleted_task(tmp_path, monkeypatch):
+    from coworker.server.manager import SessionManager
+
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_provider())
+    task = _task()
+    manager.task_store.save(task)
+    run = TaskRun(task_id=task.id)
+    manager.task_store.add_run(run)
+    write_entered = threading.Event()
+    release_write = threading.Event()
+    results = []
+    errors = []
+    original_save = manager.task_store.save
+    mint_thread = None
+
+    def blocked_save(stale_task):
+        if threading.current_thread() is mint_thread:
+            write_entered.set()
+            assert release_write.wait(timeout=5)
+        return original_save(stale_task)
+
+    monkeypatch.setattr(manager.task_store, "save", blocked_save)
+
+    def mint():
+        try:
+            results.append(
+                manager.mint_task_rule(
+                    run.session_id,
+                    "send_message",
+                    {"target": "slack:C1"},
+                    _Meta(),
+                )
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    mint_thread = threading.Thread(target=mint)
+    mint_thread.start()
+    assert write_entered.wait(timeout=5)
+    assert manager.delete_automation(task.id)["ok"] is True
+    release_write.set()
+    mint_thread.join(timeout=5)
+
+    assert not mint_thread.is_alive()
+    assert errors == []
+    assert results == [False]
+    assert manager.task_store.get(task.id) is None
+    assert manager.task_store.runs(task.id, limit=None) == []
 
 
 def test_get_engine_seeds_run_session_rules(tmp_path, monkeypatch):

--- a/tests/test_tool_output_lifecycle.py
+++ b/tests/test_tool_output_lifecycle.py
@@ -1,0 +1,479 @@
+"""Production lifecycle coverage for retained tool outputs."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from coworker.agent import build_engine
+from coworker.agents import chat_agent
+from coworker.automation import Schedule, ScheduledTask
+from coworker.providers import AssistantTurn, ModelCapabilities, ProviderClient
+from coworker.server import SessionManager, create_app
+from coworker.sessions import SessionRecord
+from coworker.tool_outputs import (
+    SessionToolOutputStore,
+    ToolOutputStoreError,
+    session_output_key,
+)
+
+
+class _Provider(ProviderClient):
+    def complete(self, *, model, messages, tools=None, **settings):
+        return AssistantTurn(text="ok", finish_reason="stop")
+
+    def capabilities(self, model):
+        return ModelCapabilities()
+
+
+def _record(session_id: str, workspace: Path) -> SessionRecord:
+    return SessionRecord(
+        session_id=session_id,
+        workspace=str(workspace),
+        model="m",
+        mode="interactive",
+        agent="cowork",
+    )
+
+
+def test_build_engine_wires_explicit_store_and_reserves_retrieval_tool(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "explicit")
+    engine = build_engine(
+        agent=chat_agent(),
+        provider=_Provider(),
+        tool_output_store=store,
+    )
+
+    assert engine.tool_output_store is store
+    assert engine.registry.names()[-1] == "read_tool_output"
+
+    def read_tool_output():
+        return "shadowed"
+
+    with pytest.raises(ValueError, match="reserved or already registered"):
+        build_engine(
+            agent=chat_agent(),
+            provider=_Provider(),
+            extra_tools=[read_tool_output],
+            tool_output_store=store,
+        )
+
+
+def test_build_engine_direct_callers_get_durable_or_ephemeral_store(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr("coworker.agent.state_dir", lambda: tmp_path / "state")
+
+    durable = build_engine(
+        agent=chat_agent(),
+        provider=_Provider(),
+        session_id="durable",
+    )
+    assert durable.tool_output_store.directory == (
+        tmp_path / "state" / "tool-outputs" / session_output_key("durable")
+    )
+    assert durable._ephemeral_output_dir is None
+
+    ephemeral = build_engine(agent=chat_agent(), provider=_Provider())
+    ephemeral_root = Path(ephemeral._ephemeral_output_dir.name)
+    assert ephemeral_root.is_dir()
+    assert ephemeral.tool_output_store.directory.is_relative_to(ephemeral_root)
+    ephemeral._ephemeral_output_dir.cleanup()
+    assert not ephemeral_root.exists()
+
+
+def test_manager_uses_session_store_for_live_and_scheduled_engines(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+
+    live = manager.get_engine("live", workspace=str(workspace), agent="cowork")
+    assert live is not None
+    assert live.tool_output_store.directory == (
+        manager._data_base / "tool-outputs" / session_output_key("live")
+    )
+
+    task = ScheduledTask(
+        title="Daily brief",
+        instructions="Write a brief",
+        schedule=Schedule(kind="cron", cron="0 9 * * *"),
+        workspace=str(workspace),
+        agent="cowork",
+    )
+    scheduled = manager._build_task_engine(task, session_id="__run__scheduled")
+    assert scheduled.tool_output_store.directory == (
+        manager._data_base / "tool-outputs" / session_output_key("__run__scheduled")
+    )
+
+
+def test_delete_session_removes_retained_outputs_even_without_live_engine(tmp_path):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    manager.session_store.save(_record("delete-me", tmp_path))
+    store = manager.tool_output_store("delete-me")
+    store.put("call", "tool", "retained")
+
+    assert manager.delete_session("delete-me")["ok"] is True
+    assert not store.directory.exists()
+
+
+def test_delete_running_session_blocks_stale_save_and_defers_output_cleanup(tmp_path):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    engine = manager.get_engine("running", workspace=str(tmp_path), agent="cowork")
+    assert engine is not None
+    manager.save("running", engine)
+    store = manager.tool_output_store("running")
+    store.put("call", "tool", "retained")
+    manager.mark_running("running")
+
+    assert manager.delete_session("running")["ok"] is True
+    assert store.directory.is_dir()
+
+    engine.messages.append({"role": "assistant", "content": "stale completion"})
+    manager.save("running", engine)
+    assert manager.session_store.exists("running") is False
+    assert (
+        manager.get_engine("running", workspace=str(tmp_path), agent="cowork") is None
+    )
+
+    manager.mark_idle("running")
+    assert not store.directory.exists()
+    manager.save("running", engine)
+    assert manager.session_store.exists("running") is False
+
+
+def test_delete_between_durable_resume_lookup_and_claim_blocks_resume(
+    tmp_path, monkeypatch
+):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    session_id = "durable-resume-race"
+    manager.session_store.save(_record(session_id, tmp_path))
+
+    class ResumableEngine:
+        resumed = False
+
+        async def resume(self):
+            self.resumed = True
+            yield None
+
+    engine = ResumableEngine()
+    manager._engines[session_id] = engine
+    original_get_engine = manager.get_engine
+
+    def get_engine_then_delete(requested_session_id):
+        stale_engine = original_get_engine(requested_session_id)
+        assert manager.delete_session(requested_session_id)["ok"] is True
+        return stale_engine
+
+    monkeypatch.setattr(manager, "get_engine", get_engine_then_delete)
+    item = SimpleNamespace(session_id=session_id, tool_call_id="call")
+
+    asyncio.run(manager._durable_resume(item))
+
+    assert engine.resumed is False
+    assert manager.is_running(session_id) is False
+    assert manager.session_store.exists(session_id) is False
+
+
+def test_delete_and_inflight_save_are_one_lifecycle_transaction(tmp_path, monkeypatch):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    engine = manager.get_engine("racing", workspace=str(tmp_path), agent="cowork")
+    assert engine is not None
+    manager.save("racing", engine)
+
+    save_entered = threading.Event()
+    release_save = threading.Event()
+    delete_started = threading.Event()
+    original_save = manager.session_store.save
+
+    def blocked_save(record):
+        save_entered.set()
+        assert release_save.wait(timeout=5)
+        original_save(record)
+
+    monkeypatch.setattr(manager.session_store, "save", blocked_save)
+    save_thread = threading.Thread(target=manager.save, args=("racing", engine))
+
+    def delete() -> None:
+        delete_started.set()
+        manager.delete_session("racing")
+
+    delete_thread = threading.Thread(target=delete)
+    save_thread.start()
+    assert save_entered.wait(timeout=5)
+    delete_thread.start()
+    assert delete_started.wait(timeout=5)
+    release_save.set()
+    save_thread.join(timeout=5)
+    delete_thread.join(timeout=5)
+
+    assert not save_thread.is_alive()
+    assert not delete_thread.is_alive()
+    assert manager.session_store.exists("racing") is False
+
+
+def test_deleted_session_cannot_be_resurrected_by_root_mutation(tmp_path):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    manager.session_store.save(_record("deleted-root", tmp_path))
+    manager.delete_session("deleted-root")
+
+    result = manager.add_root("deleted-root", str(tmp_path), writable=True)
+
+    assert result["ok"] is False
+    assert manager.get_roots("deleted-root") == []
+    assert manager.session_store.exists("deleted-root") is False
+
+
+def test_deleting_unknown_ids_does_not_accumulate_tombstones(tmp_path):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+
+    for index in range(100):
+        assert manager.delete_session(f"missing-{index}")["ok"] is False
+
+    assert manager._deleted_sessions == set()
+
+
+def test_manager_reuses_session_output_store_for_paged_integrity_cache(tmp_path):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    first = manager.tool_output_store("same")
+    reopened = manager.tool_output_store("same", create=False)
+
+    assert reopened is first
+
+    first.delete_all()
+    recreated = manager.tool_output_store("same")
+    assert recreated is not first
+    assert recreated.put("call", "tool", "works").ref
+
+
+def test_manager_creates_only_one_store_for_concurrent_callers(tmp_path):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    barrier = threading.Barrier(16)
+    stores = []
+
+    def open_store() -> None:
+        barrier.wait(timeout=5)
+        stores.append(manager.tool_output_store("shared"))
+
+    threads = [threading.Thread(target=open_store) for _ in range(16)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len({id(store) for store in stores}) == 1
+
+
+def test_manager_never_reuses_cached_store_through_replaced_symlink(tmp_path):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    store = manager.tool_output_store("replaced")
+    store.delete_all()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    store.directory.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ToolOutputStoreError, match="unsafe"):
+        manager.tool_output_store("replaced")
+
+
+def test_session_delete_tolerates_unsafe_orphan_store_without_following_it(tmp_path):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    manager.session_store.save(_record("unsafe-delete", tmp_path))
+    store = manager.tool_output_store("unsafe-delete")
+    store.delete_all()
+    manager._tool_output_stores.pop("unsafe-delete")
+    outside = tmp_path / "outside-delete"
+    outside.mkdir()
+    store.directory.symlink_to(outside, target_is_directory=True)
+
+    result = manager.delete_session("unsafe-delete")
+
+    assert result["ok"] is True
+    assert outside.is_dir()
+
+
+def test_orphan_gc_preserves_known_and_live_sessions(tmp_path):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    manager.session_store.save(_record("known", tmp_path))
+    manager.tool_output_store("known").put("c", "t", "keep-known")
+
+    live = manager.tool_output_store("live")
+    live.put("c", "t", "keep-live")
+    manager._engines["live"] = object()
+
+    orphan = manager.tool_output_store("orphan")
+    orphan.put("c", "t", "drop")
+    unrelated = manager._data_base / "tool-outputs" / ("g" * 64)
+    unrelated.mkdir()
+
+    old = time.time() - 48 * 60 * 60
+    for path in (live.directory, orphan.directory, unrelated):
+        os.utime(path, (old, old))
+
+    assert manager.collect_tool_output_orphans(grace_seconds=24 * 60 * 60) == 1
+    assert not orphan.directory.exists()
+    assert live.directory.is_dir()
+    assert manager.tool_output_store("known", create=False).directory.is_dir()
+    assert unrelated.is_dir()
+
+
+def test_global_retention_evicts_oldest_inactive_store_to_cap(tmp_path):
+    from coworker.tool_outputs import (
+        ToolOutputPolicy,
+        collect_retained_output_stores,
+    )
+
+    active = SessionToolOutputStore(tmp_path, "active-oldest")
+    active.put("c", "t", "a" * 100)
+    evict = SessionToolOutputStore(tmp_path, "evict-me")
+    evict.put("c", "t", "b" * 100)
+    newest = SessionToolOutputStore(tmp_path, "keep-newest")
+    newest.put("c", "t", "c" * 100)
+    now = time.time()
+    os.utime(active.directory, (now - 300, now - 300))
+    os.utime(evict.directory, (now - 200, now - 200))
+    os.utime(newest.directory, (now - 100, now - 100))
+
+    result = collect_retained_output_stores(
+        tmp_path,
+        known_session_ids={"active-oldest", "evict-me", "keep-newest"},
+        active_session_ids={"active-oldest"},
+        orphan_grace_seconds=24 * 60 * 60,
+        policy=ToolOutputPolicy(
+            max_global_output_bytes=900,
+            max_retention_age_seconds=10_000,
+            min_disk_headroom_bytes=0,
+        ),
+        now=now,
+    )
+
+    assert result.removed_sessions == 1
+    assert active.directory.is_dir()
+    assert not evict.directory.exists()
+    assert newest.directory.is_dir()
+    assert result.remaining_bytes <= 900
+
+
+def test_manager_retention_expires_old_known_store_but_preserves_live(tmp_path):
+    from coworker.tool_outputs import ToolOutputPolicy
+
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    manager.session_store.save(_record("known-old", tmp_path))
+    known = manager.tool_output_store("known-old")
+    known.put("c", "t", "expire")
+    live = manager.tool_output_store("live-old")
+    live.put("c", "t", "preserve")
+    manager._engines["live-old"] = object()
+    now = time.time()
+    for directory in (known.directory, live.directory):
+        os.utime(directory, (now - 200, now - 200))
+
+    removed = manager.collect_tool_output_orphans(
+        grace_seconds=24 * 60 * 60,
+        policy=ToolOutputPolicy(
+            max_global_output_bytes=10_000,
+            max_retention_age_seconds=100,
+            min_disk_headroom_bytes=0,
+        ),
+        now=now,
+    )
+
+    assert removed == 1
+    assert not known.directory.exists()
+    assert live.directory.is_dir()
+
+
+def test_global_retention_never_follows_symlinked_store_paths(tmp_path):
+    from coworker.tool_outputs import (
+        ToolOutputPolicy,
+        collect_retained_output_stores,
+    )
+
+    outside = tmp_path / "outside"
+    outside_store = outside / ("a" * 64)
+    outside_store.mkdir(parents=True)
+    sentinel = outside_store / "sentinel.txt"
+    sentinel.write_text("keep", encoding="utf-8")
+    policy = ToolOutputPolicy(
+        max_global_output_bytes=0,
+        max_retention_age_seconds=0,
+        min_disk_headroom_bytes=0,
+    )
+
+    linked_root = tmp_path / "linked-root"
+    linked_root.mkdir()
+    (linked_root / "tool-outputs").symlink_to(outside, target_is_directory=True)
+    collect_retained_output_stores(linked_root, policy=policy)
+
+    linked_session = tmp_path / "linked-session"
+    output_root = linked_session / "tool-outputs"
+    output_root.mkdir(parents=True)
+    session_link = output_root / ("b" * 64)
+    session_link.symlink_to(outside_store, target_is_directory=True)
+    collect_retained_output_stores(linked_session, policy=policy)
+
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+    assert session_link.is_symlink()
+
+
+def test_tool_output_route_is_bounded_paged_and_session_scoped(tmp_path):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    manager.session_store.save(_record("one", tmp_path))
+    record = manager.tool_output_store("one").put(
+        "call", "tool", "hello durable output"
+    )
+    manager.session_store.load = Mock(
+        side_effect=AssertionError("paging must not parse the transcript")
+    )
+    client = TestClient(create_app(manager))
+
+    page = client.get(
+        f"/v1/sessions/one/tool-outputs/{record.ref}", params={"limit_bytes": 5}
+    )
+    assert page.status_code == 200
+    assert page.json()["content"] == "hello"
+    assert page.json()["complete"] is False
+    assert client.get(f"/v1/sessions/two/tool-outputs/{record.ref}").status_code == 404
+    assert (
+        client.get("/v1/sessions/one/tool-outputs/not-a-reference").status_code == 400
+    )
+    assert (
+        client.get(
+            f"/v1/sessions/one/tool-outputs/{record.ref}",
+            params={"limit_bytes": 8_001},
+        ).status_code
+        == 400
+    )
+
+
+def test_tool_output_route_maps_missing_and_corrupt_records(tmp_path):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    manager.session_store.save(_record("one", tmp_path))
+    store = manager.tool_output_store("one")
+    record = store.put("call", "tool", "hello")
+    client = TestClient(create_app(manager))
+
+    assert (
+        client.get("/v1/sessions/one/tool-outputs/out_" + ("a" * 32)).status_code == 404
+    )
+    (store.directory / f"{record.ref}.json").write_text("{", encoding="utf-8")
+    assert client.get(f"/v1/sessions/one/tool-outputs/{record.ref}").status_code == 409
+
+
+def test_app_runs_orphan_gc_at_startup(tmp_path):
+    manager = SessionManager(data_dir=tmp_path / "data", provider=_Provider())
+    original = manager.collect_tool_output_orphans
+    manager.collect_tool_output_orphans = Mock(wraps=original)
+
+    with TestClient(create_app(manager)):
+        pass
+
+    manager.collect_tool_output_orphans.assert_called_once_with()

--- a/tests/test_tool_outputs.py
+++ b/tests/test_tool_outputs.py
@@ -1,0 +1,405 @@
+"""Public behavior tests for retained oversized tool output."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from coworker.tools.shell import LocalExecutor
+from coworker.tool_outputs import (
+    SessionToolOutputStore,
+    ToolOutputPolicy,
+    ToolOutputStoreError,
+    ToolResultProjector,
+    is_valid_output_ref,
+    read_tool_output_tool,
+    serialize_tool_result,
+)
+
+
+class _RejectWholeStringEncode(str):
+    """Catch regressions that duplicate an entire retained string in memory."""
+
+    def encode(self, *args, **kwargs):
+        raise AssertionError("the complete string must not be encoded at once")
+
+
+def _policy(**overrides: int) -> ToolOutputPolicy:
+    values = {
+        "inline_limit_chars": 100,
+        "preview_chars": 20,
+        "read_default_bytes": 16,
+        "read_max_bytes": 64,
+        "max_single_output_bytes": 1_024,
+        "max_session_output_bytes": 4_096,
+        "min_disk_headroom_bytes": 0,
+    }
+    values.update(overrides)
+    return ToolOutputPolicy(**values)
+
+
+def test_small_result_remains_inline_without_changing_its_value(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "session-1", _policy())
+    value = {"ok": True, "count": 3}
+
+    projected = ToolResultProjector(store).project("call-1", "search", value)
+
+    assert projected.model_value is value
+    assert projected.stored is None
+    assert store.list_references() == set()
+
+
+def test_large_result_is_replaced_by_bounded_preview_and_opaque_reference(tmp_path):
+    policy = _policy(
+        inline_limit_chars=500,
+        preview_chars=40,
+        max_single_output_bytes=4_096,
+        max_session_output_bytes=8_192,
+    )
+    store = SessionToolOutputStore(tmp_path, "customer/session", policy)
+    result = "HEAD" + ("x" * 1_000) + "TAIL"
+
+    projected = ToolResultProjector(store).project(
+        "../../provider-call-id",
+        "crm_search",
+        result,
+    )
+
+    assert projected.stored is not None
+    assert is_valid_output_ref(projected.stored.ref)
+    assert "provider-call-id" not in projected.stored.ref
+    assert store.list_references() == {projected.stored.ref}
+
+    envelope = projected.model_value
+    assert envelope["output_ref"] == projected.stored.ref
+    assert envelope["truncated"] is True
+    assert envelope["original_chars"] == len(result)
+    assert envelope["preview"].startswith("HEAD")
+    assert envelope["preview"].endswith("TAIL")
+    assert "characters omitted" in envelope["preview"]
+    assert len(serialize_tool_result(envelope)) <= policy.inline_limit_chars
+
+
+def test_utf8_output_can_be_read_in_exact_byte_pages(tmp_path):
+    policy = _policy(read_default_bytes=7, read_max_bytes=20)
+    store = SessionToolOutputStore(tmp_path, "session-utf8", policy)
+    text = "é🙂漢字" * 10
+    record = store.put("call-utf8", "search", text)
+
+    with pytest.raises(ValueError, match="UTF-8"):
+        store.read(record.ref, offset_bytes=1, limit_bytes=7)
+
+    pages = []
+    next_offset = 0
+    while next_offset is not None:
+        page = store.read(record.ref, next_offset, limit_bytes=7)
+        pages.append(page["content"])
+        next_offset = page["next_offset_bytes"]
+
+    assert "".join(pages) == text
+    assert page["complete"] is True
+    assert page["total_chars"] == len(text)
+    assert page["total_bytes"] == len(text.encode("utf-8"))
+    assert page["sha256"] == record.sha256
+
+
+def test_per_result_quota_rejects_output_without_publishing_a_reference(tmp_path):
+    policy = _policy(max_single_output_bytes=10)
+    store = SessionToolOutputStore(tmp_path, "session-quota", policy)
+
+    with pytest.raises(ToolOutputStoreError, match="per-result quota"):
+        store.put("call", "search", "x" * 11)
+
+    assert store.list_references() == set()
+
+
+def test_put_encodes_large_strings_in_bounded_chunks(tmp_path):
+    policy = _policy(
+        inline_limit_chars=100,
+        max_single_output_bytes=4_096,
+        max_session_output_bytes=8_192,
+    )
+    store = SessionToolOutputStore(tmp_path, "session-streaming", policy)
+    value = _RejectWholeStringEncode("x" * 1_000)
+
+    record = store.put("call", "search", value)
+
+    assert record.bytes == 1_000
+    assert store.read(record.ref, limit_bytes=64)["content"] == "x" * 64
+
+
+def test_projector_streams_large_structured_results_without_full_serialization(
+    tmp_path, monkeypatch
+):
+    import coworker.tool_outputs as tool_outputs
+
+    policy = _policy(
+        inline_limit_chars=100,
+        max_single_output_bytes=4_096,
+        max_session_output_bytes=8_192,
+    )
+    store = SessionToolOutputStore(tmp_path, "session-structured", policy)
+    original_serialize = tool_outputs.serialize_tool_result
+
+    def reject_full_result(value):
+        if isinstance(value, dict) and "huge_payload" in value:
+            raise AssertionError("large structured results must be streamed")
+        return original_serialize(value)
+
+    monkeypatch.setattr(
+        tool_outputs,
+        "serialize_tool_result",
+        reject_full_result,
+    )
+
+    projected = ToolResultProjector(store).project(
+        "call",
+        "search",
+        {"huge_payload": "x" * 1_000},
+    )
+
+    assert projected.stored is not None
+    assert projected.model_value["output_ref"] == projected.stored.ref
+    pages = []
+    offset = 0
+    while offset is not None:
+        page = store.read(projected.stored.ref, offset, limit_bytes=64)
+        pages.append(page["content"])
+        offset = page["next_offset_bytes"]
+    assert "".join(pages) == original_serialize({"huge_payload": "x" * 1_000})
+
+
+def test_session_quota_counts_content_and_metadata(tmp_path):
+    policy = _policy(
+        max_single_output_bytes=20,
+        max_session_output_bytes=700,
+    )
+    store = SessionToolOutputStore(tmp_path, "session-total-quota", policy)
+    first = store.put("call-1", "search", "x" * 10)
+    second = store.put("call-2", "search", "y" * 10)
+
+    with pytest.raises(ToolOutputStoreError, match="session quota"):
+        store.put("call-3", "search", "z" * 10)
+
+    assert store.list_references() == {first.ref, second.ref}
+
+
+def test_put_rejects_unreadable_oversized_metadata_without_publishing(tmp_path):
+    policy = _policy(
+        max_single_output_bytes=1_024,
+        max_session_output_bytes=256_000,
+    )
+    store = SessionToolOutputStore(tmp_path, "session-metadata-limit", policy)
+
+    with pytest.raises(ToolOutputStoreError, match="metadata"):
+        store.put("call", "x" * 70_000, "retained")
+
+    assert store.list_references() == set()
+
+
+def test_global_quota_is_shared_across_session_stores(tmp_path):
+    policy = _policy(
+        max_single_output_bytes=20,
+        max_session_output_bytes=4_096,
+        max_global_output_bytes=500,
+    )
+    SessionToolOutputStore(tmp_path, "session-global-one", policy).put(
+        "call-1",
+        "search",
+        "x" * 10,
+    )
+    second = SessionToolOutputStore(tmp_path, "session-global-two", policy)
+
+    with pytest.raises(ToolOutputStoreError, match="global quota"):
+        second.put("call-2", "search", "y" * 10)
+
+    assert second.list_references() == set()
+
+
+def test_store_rejects_symlinked_session_directory(tmp_path):
+    from coworker.tool_outputs import session_output_key
+
+    output_root = tmp_path / "tool-outputs"
+    output_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (output_root / session_output_key("session-link")).symlink_to(
+        outside,
+        target_is_directory=True,
+    )
+
+    with pytest.raises(ToolOutputStoreError, match="unsafe"):
+        SessionToolOutputStore(tmp_path, "session-link", _policy())
+
+
+def test_open_existing_store_rejects_symlinked_output_root(tmp_path):
+    from coworker.tool_outputs import session_output_key
+
+    outside = tmp_path / "outside-root"
+    (outside / session_output_key("session-root-link")).mkdir(parents=True)
+    state = tmp_path / "state"
+    state.mkdir()
+    (state / "tool-outputs").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ToolOutputStoreError, match="unsafe"):
+        SessionToolOutputStore(
+            state,
+            "session-root-link",
+            _policy(),
+            create=False,
+        )
+
+
+def test_read_rejects_same_length_content_tampering(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "session-integrity", _policy())
+    record = store.put("call", "search", "hello")
+    content_path = store.directory / f"{record.ref}.txt"
+    content_path.write_text("jello", encoding="utf-8")
+
+    with pytest.raises(ToolOutputStoreError, match="content is corrupt"):
+        store.read(record.ref)
+
+
+@pytest.mark.parametrize("suffix", [".json", ".txt"])
+def test_read_never_follows_symlinked_result_files(tmp_path, suffix):
+    store = SessionToolOutputStore(tmp_path, f"session-link-{suffix}", _policy())
+    record = store.put("call", "search", "hello")
+    managed_path = store.directory / f"{record.ref}{suffix}"
+    outside_path = tmp_path / f"outside{suffix}"
+    outside_path.write_bytes(managed_path.read_bytes())
+    managed_path.unlink()
+    managed_path.symlink_to(outside_path)
+
+    with pytest.raises(ToolOutputStoreError, match="unsafe|unavailable"):
+        store.read(record.ref)
+
+
+def test_reopening_store_reconciles_interrupted_writes(tmp_path):
+    session_id = "session-reconcile"
+    store = SessionToolOutputStore(tmp_path, session_id, _policy())
+    record = store.put("call", "search", "hello")
+    metadata_path = store.directory / f"{record.ref}.json"
+    metadata_path.unlink()
+    pending_path = store.directory / ".pending-interrupted"
+    pending_path.write_text("partial", encoding="utf-8")
+
+    reopened = SessionToolOutputStore(
+        tmp_path,
+        session_id,
+        _policy(),
+        create=False,
+    )
+
+    assert reopened.list_references() == set()
+    assert not (reopened.directory / f"{record.ref}.txt").exists()
+    assert not pending_path.exists()
+
+
+def test_delete_all_removes_the_session_store(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "session-cleanup", _policy())
+    store.put("call", "search", "retained")
+    directory = store.directory
+
+    store.delete_all()
+
+    assert not directory.exists()
+    with pytest.raises(FileNotFoundError):
+        SessionToolOutputStore(
+            tmp_path,
+            "session-cleanup",
+            _policy(),
+            create=False,
+        )
+
+
+def test_read_tool_output_exposes_bounded_pages_and_controlled_errors(tmp_path):
+    store = SessionToolOutputStore(
+        tmp_path,
+        "session-tool",
+        _policy(inline_limit_chars=500),
+    )
+    record = store.put("call", "search", "abcdefghij")
+    read_tool_output = read_tool_output_tool(store)
+
+    page = read_tool_output(record.ref, limit_bytes=5)
+
+    assert page["content"] == "abcde"
+    assert page["next_offset_bytes"] == 5
+    assert page["complete"] is False
+    assert (
+        read_tool_output.__coworker_schema__["function"]["name"] == "read_tool_output"
+    )
+    assert read_tool_output.__aisuite_tool_metadata__.risk_level == "low"
+    assert read_tool_output("not-a-ref")["error_kind"] == "invalid"
+    assert read_tool_output("out_" + ("0" * 32))["error_kind"] == "missing"
+
+
+def test_read_tool_output_result_is_never_stored_recursively(tmp_path):
+    store = SessionToolOutputStore(tmp_path, "session-no-recursion", _policy())
+    projected = ToolResultProjector(store).project(
+        "call",
+        "read_tool_output",
+        {"content": "x" * 500},
+    )
+
+    assert projected.stored is None
+    assert projected.model_value["error_kind"] == "limit"
+    assert store.list_references() == set()
+
+
+def test_preview_discloses_when_the_source_was_already_incomplete(tmp_path):
+    policy = _policy(
+        inline_limit_chars=500,
+        max_single_output_bytes=4_096,
+        max_session_output_bytes=8_192,
+    )
+    store = SessionToolOutputStore(tmp_path, "session-partial", policy)
+    result = {
+        "output": "x" * 1_000,
+        "retained_complete": False,
+        "discarded_bytes": 400,
+    }
+
+    projected = ToolResultProjector(store).project(
+        "call",
+        "run_shell",
+        result,
+    )
+
+    assert projected.stored is not None
+    assert projected.stored.content_complete is False
+    assert projected.model_value["content_complete"] is False
+    assert "not fully recoverable" in projected.model_value["instruction"]
+
+
+def test_projected_shell_tail_discloses_that_original_output_is_incomplete(tmp_path):
+    command = (
+        'foreach ($i in 1..1000) { "line$i" }'
+        if sys.platform == "win32"
+        else "for i in $(seq 1 1000); do echo line$i; done"
+    )
+    executor = LocalExecutor(cwd=tmp_path, max_output_chars=800, default_timeout=10)
+    try:
+        shell_result = executor.run(command)
+    finally:
+        executor.close()
+    assert shell_result["truncated"] is True
+
+    policy = _policy(
+        inline_limit_chars=500,
+        preview_chars=40,
+        max_single_output_bytes=4_096,
+        max_session_output_bytes=8_192,
+    )
+    store = SessionToolOutputStore(tmp_path, "session-shell-tail", policy)
+    projected = ToolResultProjector(store).project(
+        "call-shell",
+        "run_shell",
+        shell_result,
+    )
+
+    assert projected.stored is not None
+    assert projected.stored.content_complete is False
+    assert projected.model_value["content_complete"] is False
+    assert "not fully recoverable" in projected.model_value["instruction"]

--- a/tests/test_tools_permissions.py
+++ b/tests/test_tools_permissions.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 import aisuite as ai
-from coworker.permissions import Decision, Mode, PermissionEngine
+from coworker.permissions import Mode, PermissionEngine
 from coworker.tools import ToolRegistry
 
 
@@ -48,6 +48,16 @@ def test_registry_execute_unknown_tool(tmp_path):
     reg = _registry(tmp_path)
     with pytest.raises(KeyError):
         reg.execute("nope", {})
+
+
+def test_registry_can_reserve_an_internal_tool_name():
+    def internal_tool():
+        return "internal"
+
+    reg = ToolRegistry()
+    reg.register(internal_tool)
+    with pytest.raises(ValueError, match="reserved or already registered"):
+        reg.register(internal_tool, replace=False)
 
 
 # -- PermissionEngine -----------------------------------------------------------

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from coworker.conversations import ConversationStore
 from coworker.providers import (
     AssistantTurn,
     ModelCapabilities,
@@ -75,3 +76,25 @@ async def test_tui_approval_then_write(tmp_path):
 
     assert (tmp_path / "made.py").read_text() == "print(1)\n"
     assert any("done, wrote made.py" in line for line in app.rendered)
+
+
+@pytest.mark.asyncio
+async def test_tui_clear_removes_retained_outputs_and_persists_empty_history(tmp_path):
+    session_store = ConversationStore(tmp_path / "state")
+    app = CoworkerApp(
+        workspace=tmp_path,
+        provider=_ScriptedProvider([]),
+        session_store=session_store,
+        session_id="clear-session",
+    )
+    async with app.run_test():
+        output_store = app.engine.tool_output_store
+        record = output_store.put("call", "tool", "retained")
+        content_path = output_store.directory / f"{record.ref}.txt"
+        app.engine.messages.append({"role": "user", "content": "old history"})
+
+        app._handle_command("/clear")
+
+        assert not content_path.exists()
+        assert app.engine.tool_output_store.list_references() == set()
+        assert session_store.load("clear-session").messages == []

--- a/tests/test_vertex_provider.py
+++ b/tests/test_vertex_provider.py
@@ -67,6 +67,26 @@ def test_raw_ids_route_by_name():
     assert openweight.seen == ["deepseek-ai/deepseek-v4-maas"]
 
 
+def test_family_replay_sidecars_follow_native_provider():
+    from coworker.providers import AnthropicProvider, GeminiProvider, OpenAIProvider
+
+    p = VertexProvider(
+        project="proj",
+        location="us-east5",
+        gemini_client=GeminiProvider(client=object()),
+        claude_client=AnthropicProvider(client=object()),
+        openweight_client=OpenAIProvider(client=object()),
+    )
+
+    assert p.replay_sidecar_keys("gemini/gemini-3.6-flash") == frozenset(
+        {"_gemini"}
+    )
+    assert p.replay_sidecar_keys("claude/claude-sonnet-4-6") == frozenset(
+        {"_anthropic"}
+    )
+    assert p.replay_sidecar_keys("openweight/meta/llama") == frozenset()
+
+
 # -- openweight bearer refresh ---------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Project the durable conversation into a bounded, provider-only context without mutating chat history.
- Keep user turns and tool call/result groups atomic while protecting system instructions, the active turn, and in-turn steering.
- Move large tool results into a durable, paged output store and send compact opaque references back to the model.
- Apply message, token, and optional request-byte budgets before every provider call, including subagents.
- Harden session/automation deletion so in-flight writers cannot resurrect deleted state or retained outputs.

## Why

Long tool-heavy sessions currently resend the full transcript and complete artifact/tool payloads on every model call. A relatively short session can therefore exceed provider message or request-body limits even when the visible user messages are small.

This change separates durable application state from provider context. The complete transcript remains available to the UI and persistence layer; only a measured projection is sent to the model.

## Important behavior

- Default direct-provider behavior has no universal byte ceiling, so existing large image/PDF attachments continue to work.
- Hosted gateways can opt into `ContextBudget.gateway()` (1.5 MiB soft target, 2 MiB minus 64 KiB hard headroom).
- The hard provider message count is 256, with a 220-message soft target.
- Model context windows drive token trimming when a verified model limit is available.
- Historical large file-write arguments are replaced with a byte count, SHA-256 digest, and recovery hint.
- Oversized tool results remain on disk and can be read back by opaque reference with bounded paging.
- Provider-private replay state is retained only for the active provider; foreign sidecars never leak across model switches.
- Direct DeepSeek V4 reasoning state survives tool continuations.

## Reliability and safety

- Atomic file publication, metadata limits, digest verification, symlink rejection, startup reconciliation, and quota/age GC for retained outputs.
- Session and automation lifecycle locks plus tombstones prevent stale saves, run writes, and engine construction after deletion.
- Deferred cleanup keeps outputs available to an in-flight turn, then removes them when that turn becomes idle.
- WebSocket finalization always releases the running-session claim even if the terminal persistence checkpoint fails.

## Validation

- `pytest -q`: **1031 passed, 1 skipped**
- Ruff and `git diff --check`: passed
- Companion integration branch: **1441 passed, 1 skipped**
- Companion GUI Vitest: **25 files / 124 tests passed**
- Companion production-mode TypeScript/Vite build: passed
- Companion Playwright smoke suite: **2 passed**
- Companion gateway frontend suite: **1822 passed, 1 skipped**

The Companion integration retained its existing model/effort selector unchanged and additionally exercised live/scheduled gateway budgets, catalog refreshes, model switching, arbitrary managed aliases, and account-switch races.

## Deliberately out of scope

Automatic conversation compaction/summarization is reserved for a separate PR2. This PR provides deterministic context bounding and retained-output retrieval without introducing summary-generated state.
