### PR TITLE
[codex] Secure global MCP configuration writes

### DIFF
--- a/coworker/mcp/config.py
+++ b/coworker/mcp/config.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
-from ..secrets import SecretStore, state_dir
+from ..secrets import SecretStore, state_dir, write_private_text
 
 _HTTP_TYPES = {"http", "https", "sse", "streamable-http", "streamable_http"}
 
@@ -98,11 +98,11 @@ def read_global() -> dict[str, dict[str, Any]]:
 
 
 def _write_global(servers: dict[str, dict[str, Any]]) -> None:
-    path = global_mcp_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(path.name + ".tmp")
-    tmp.write_text(json.dumps({"mcpServers": servers}, indent=2), encoding="utf-8")
-    tmp.replace(path)
+    # MCP configs are commonly pasted with literal API keys in headers/env. Keep the
+    # global, user-owned config private even when a SecretStore has not been created yet.
+    write_private_text(
+        global_mcp_path(), json.dumps({"mcpServers": servers}, indent=2)
+    )
 
 
 def put_global_server(name: str, config: dict[str, Any]) -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -8,13 +8,17 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import stat
+import subprocess
+import sys
 from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
 
 from coworker.mcp import build_callables, load_mcp_servers, tool_name
-from coworker.mcp.config import MCPServerDef
+from coworker.mcp.config import MCPServerDef, global_mcp_path, put_global_server
 from coworker.secrets import SecretStore
 from coworker.server.app import create_app
 from coworker.server.manager import SessionManager
@@ -87,6 +91,30 @@ def test_var_resolution(tmp_path, monkeypatch):
     )
     docs = load_mcp_servers(None, secrets=SecretStore())[0]
     assert docs.headers["Authorization"] == "Bearer sekret"
+
+
+def test_global_mcp_config_is_private(tmp_path, monkeypatch):
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    put_global_server(
+        "docs",
+        {
+            "url": "https://x/mcp",
+            "headers": {"Authorization": "Bearer secret"},
+        },
+    )
+    path = global_mcp_path()
+    assert "Bearer secret" in path.read_text(encoding="utf-8")
+
+    if sys.platform == "win32":
+        out = subprocess.run(
+            ["icacls", str(path)], capture_output=True, text=True
+        ).stdout
+        user = os.environ.get("USERNAME", "")
+        assert user and user in out
+        assert "NT AUTHORITY\\SYSTEM" not in out
+        assert "BUILTIN\\Administrators" not in out
+    else:
+        assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
 
 
 # -- tool wrapping + bridge ----------------------------------------------------


### PR DESCRIPTION
## What changed
- Write the global MCP configuration through the existing private, atomic file helper.
- Add a cross-platform regression test for POSIX mode bits and Windows ACLs.

## Why
The global MCP config accepts literal credentials in `headers` and `env`, but it previously inherited normal directory/file permissions. On a fresh install this could expose pasted credentials to broader local principals.

## Validation
- `uv run pytest tests/test_mcp.py -q --disable-warnings` (8 passed)