### PR TITLE
Add manual and automatic context compaction

### DIFF
--- a/coworker/compaction.py
+++ b/coworker/compaction.py
@@ -1,0 +1,140 @@
+"""Codex-style conversation compaction for the provider-facing history.
+
+The durable transcript remains append-only. A compaction notice records the summary;
+provider projection treats the latest notice as a checkpoint and rebuilds active history
+from recent user messages, that summary, and messages written after the checkpoint.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .attachments import content_to_text
+
+SUMMARIZATION_PROMPT = """\
+You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another LLM that will resume the task.
+
+Include:
+- Current progress and key decisions made
+- Important context, constraints, or user preferences
+- What remains to be done (clear next steps)
+- Any critical data, examples, or references needed to continue
+
+Be concise, structured, and focused on helping the next LLM seamlessly continue the work."""
+
+SUMMARY_PREFIX = """\
+Another language model started to solve this problem and produced a summary of its thinking process. You also have access to the state of the tools that were used by that language model. Use this to build on the work that has already been done and avoid duplicating work. Here is the summary produced by the other language model, use the information in this summary to assist with your own analysis:"""
+
+RECENT_USER_MESSAGE_MAX_TOKENS = 20_000
+AUTO_COMPACT_CONTEXT_PERCENT = 90
+_APPROX_BYTES_PER_TOKEN = 4
+
+
+def approx_token_count(text: str) -> int:
+    """Match Codex's provider-independent estimate: UTF-8 bytes rounded up by four."""
+    size = len(text.encode("utf-8"))
+    return (size + _APPROX_BYTES_PER_TOKEN - 1) // _APPROX_BYTES_PER_TOKEN
+
+
+def _truncate_middle(text: str, max_tokens: int) -> str:
+    max_bytes = max_tokens * _APPROX_BYTES_PER_TOKEN
+    raw = text.encode("utf-8")
+    if len(raw) <= max_bytes:
+        return text
+    left_budget = max_bytes // 2
+    right_budget = max_bytes - left_budget
+    left = raw[:left_budget].decode("utf-8", errors="ignore")
+    right = raw[len(raw) - right_budget :].decode("utf-8", errors="ignore")
+    removed = max(0, len(text) - len(left) - len(right))
+    return f"{left}…{removed} chars truncated…{right}"
+
+
+def recent_user_messages(
+    messages: list[dict[str, Any]],
+    *,
+    max_tokens: int = RECENT_USER_MESSAGE_MAX_TOKENS,
+) -> list[dict[str, str]]:
+    """Return the newest user messages that fit the Codex compaction budget."""
+    selected: list[dict[str, str]] = []
+    remaining = max_tokens
+    for message in reversed(messages):
+        if message.get("role") != "user" or remaining <= 0:
+            continue
+        text = content_to_text(message.get("content"))
+        if not text:
+            continue
+        tokens = approx_token_count(text)
+        if tokens <= remaining:
+            selected.append({"role": "user", "content": text})
+            remaining -= tokens
+        else:
+            selected.append(
+                {"role": "user", "content": _truncate_middle(text, remaining)}
+            )
+            break
+    selected.reverse()
+    return selected
+
+
+def compacted_history(messages: list[dict[str, Any]]) -> list[dict[str, Any]] | None:
+    """Build replacement history from the latest durable compaction checkpoint."""
+    checkpoint = -1
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if (
+            message.get("role") == "notice"
+            and message.get("kind") == "context_compaction"
+        ):
+            checkpoint = index
+            break
+    if checkpoint < 0:
+        return None
+
+    marker = messages[checkpoint]
+    summary = str(marker.get("summary") or f"{SUMMARY_PREFIX}\n(no summary available)")
+    systems = [message for message in messages if message.get("role") == "system"]
+    return [
+        *systems,
+        *recent_user_messages(messages[:checkpoint]),
+        {"role": "user", "content": summary},
+        *messages[checkpoint + 1 :],
+    ]
+
+
+def estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
+    """Estimate replacement-history size with the same four-byte rule Codex uses."""
+    return approx_token_count(
+        json.dumps(messages, ensure_ascii=False, separators=(",", ":"))
+    )
+
+
+def should_auto_compact(
+    messages: list[dict[str, Any]], *, context_window: int | None
+) -> bool:
+    """Use the last provider-reported active usage, but never cross a checkpoint."""
+    if not context_window:
+        return False
+    checkpoint = max(
+        (
+            index
+            for index, message in enumerate(messages)
+            if message.get("role") == "notice"
+            and message.get("kind") == "context_compaction"
+        ),
+        default=-1,
+    )
+    for index in range(len(messages) - 1, checkpoint, -1):
+        message = messages[index]
+        usage = message.get("usage")
+        if message.get("role") != "assistant" or not isinstance(usage, dict):
+            continue
+        active_tokens = sum(
+            max(0, int(usage.get(key) or 0))
+            for key in ("input", "output", "cache_read", "cache_write")
+        )
+        return (
+            active_tokens * 100
+            >= context_window * AUTO_COMPACT_CONTEXT_PERCENT
+        )
+    return False

--- a/coworker/engine.py
+++ b/coworker/engine.py
@@ -174,8 +174,92 @@ class TurnEngine:
         if source is not None:
             data["source"] = source
         yield Event(EventType.TURN_START, data)
+        if self._should_auto_compact():
+            try:
+                yield await self._compact_context(automatic=True)
+            except Exception as exc:
+                friendly = friendly_model_error(self.model, exc)
+                self._append_notice("error", friendly or str(exc))
+                yield Event(
+                    EventType.ERROR,
+                    {
+                        "error": friendly or str(exc),
+                        "error_type": type(exc).__name__,
+                        **({"raw": str(exc)} if friendly else {}),
+                    },
+                )
+                return
         async for event in self._loop():
             yield event
+
+    async def compact(self) -> AsyncIterator[Event]:
+        """Run a standalone manual compaction turn (the `/compact` operation)."""
+        self._cancel.clear()
+        yield Event(EventType.TURN_START, {"input": ""})
+        try:
+            yield await self._compact_context(automatic=False)
+        except Exception as exc:
+            friendly = friendly_model_error(self.model, exc)
+            self._append_notice("error", friendly or str(exc))
+            yield Event(
+                EventType.ERROR,
+                {
+                    "error": friendly or str(exc),
+                    "error_type": type(exc).__name__,
+                    **({"raw": str(exc)} if friendly else {}),
+                },
+            )
+            return
+        yield Event(
+            EventType.TURN_END,
+            {"status": "completed", "iterations": 0},
+        )
+
+    def _should_auto_compact(self) -> bool:
+        from .compaction import should_auto_compact
+        from .providers.matrix import context_window_for
+
+        return should_auto_compact(
+            self.messages,
+            context_window=context_window_for(self.model),
+        )
+
+    async def _compact_context(self, *, automatic: bool) -> Event:
+        from .compaction import (
+            SUMMARIZATION_PROMPT,
+            SUMMARY_PREFIX,
+            compacted_history,
+            estimate_messages_tokens,
+        )
+
+        request = [
+            *self._outbound_messages(),
+            {"role": "user", "content": SUMMARIZATION_PROMPT},
+        ]
+        turn = await asyncio.to_thread(
+            self.provider.complete,
+            model=self.model,
+            messages=request,
+            tools=None,
+            **self.model_settings,
+        )
+        marker = {
+            "role": "notice",
+            "kind": "context_compaction",
+            "automatic": automatic,
+            "summary": f"{SUMMARY_PREFIX}\n{turn.text or '(no summary available)'}",
+            "ts": time.time(),
+        }
+        self.messages.append(marker)
+        replacement = compacted_history(self.messages) or []
+        marker["context_tokens"] = estimate_messages_tokens(replacement)
+        return Event(
+            EventType.CONTEXT_COMPACTED,
+            {
+                "automatic": automatic,
+                "context_tokens": marker["context_tokens"],
+            },
+        )
 
     def switch_model(self, model: str) -> Optional[str]:
         """Rebind the session's model mid-conversation (roadmap item 3). History is
@@ -893,13 +977,16 @@ class TurnEngine:
         # one. Whole `notice` messages (error/interrupted/model-switch markers) are
         # display-only too: dropped entirely.
         _SIDECARS = ("source", "_display", "ts", "reasoning", "usage")
+        from .compaction import compacted_history
+
+        source_messages = compacted_history(self.messages) or self.messages
         out = [
             (
                 {k: v for k, v in msg.items() if k not in _SIDECARS}
                 if any(s in msg for s in _SIDECARS)
                 else msg
             )
-            for msg in self.messages
+            for msg in source_messages
             if msg.get("role") != "notice"
         ]
         # PDF attachments (stored as `file` parts) are adapted to the ACTIVE model right

--- a/coworker/events.py
+++ b/coworker/events.py
@@ -16,6 +16,7 @@ class EventType(str, Enum):
     ASSISTANT_DELTA = "assistant_delta"
     REASONING_DELTA = "reasoning_delta"  # model thinking text (display-only, never replayed)
     ASSISTANT_MESSAGE = "assistant_message"
+    CONTEXT_COMPACTED = "context_compacted"
     TOOL_PROPOSED = "tool_proposed"
     PERMISSION_REQUIRED = "permission_required"
     DIRECTORY_REQUESTED = "directory_requested"  # agent asks the user to grant a folder

--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -215,6 +215,21 @@ def model_context_windows() -> dict[str, int]:
     }
 
 
+def context_window_for(model: str) -> int | None:
+    """Resolve an exact model id or an unambiguous provider-managed alias."""
+    exact = entry_for(model)
+    if exact is not None:
+        return exact.context_window
+    alias = model.split(":", 1)[1] if ":" in model else model
+    matches = {
+        entry.context_window
+        for model_id, entry in MATRIX.items()
+        if entry.context_window
+        and (model_id == alias or model_id.endswith(f":{alias}"))
+    }
+    return next(iter(matches)) if len(matches) == 1 else None
+
+
 def models_for_provider(provider: str) -> list[str]:
     """BARE model ids (prefix stripped) the matrix curates for a provider — feeds the
     Settings pane's suggestions and the composer picker so both stay in lockstep with the

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -1708,13 +1708,21 @@ def create_app(manager: SessionManager) -> FastAPI:
             "directory_requested",
             "plan_proposed",
             "iteration_end",
+            "context_compacted",
         }
 
-        async def run_turn(content, *, retry: bool = False) -> None:
+        async def run_turn(
+            content, *, retry: bool = False, compact: bool = False
+        ) -> None:
             # The receive loop atomically claims this session before scheduling the task.
             # Keeping the claim outside prevents two back-to-back frames from both starting.
             try:
-                events = engine.retry() if retry else engine.run(content)
+                if retry:
+                    events = engine.retry()
+                elif compact:
+                    events = engine.compact()
+                else:
+                    events = engine.run(content)
                 async for event in events:
                     # Broadcast to every socket viewing this session (this socket included — it's a
                     # registered client), so a second view of the same session stays in sync too.
@@ -1740,13 +1748,15 @@ def create_app(manager: SessionManager) -> FastAPI:
             # or flush an in-progress assistant stream in the GUI.
             await ws.send_json({"type": "input_rejected", "data": {"error": reason}})
 
-        async def claim_turn(*, retry: bool = False, content=None) -> None:
+        async def claim_turn(
+            *, retry: bool = False, compact: bool = False, content=None
+        ) -> None:
             if not manager.try_mark_running(session_id):
                 await reject_input(
                     "This session is already running a turn. Wait for it to finish or stop it."
                 )
                 return
-            asyncio.create_task(run_turn(content, retry=retry))
+            asyncio.create_task(run_turn(content, retry=retry, compact=compact))
 
         try:
             while True:
@@ -1805,6 +1815,8 @@ def create_app(manager: SessionManager) -> FastAPI:
                     # Re-run after a provider error (engine guards on the error-notice
                     # tail, so a stray frame is a no-op that still ends with turn_done).
                     await claim_turn(retry=True)
+                elif kind == "compact":
+                    await claim_turn(compact=True)
                 elif kind == "set_mode":
                     try:
                         engine.permissions.mode = Mode(message.get("mode"))
@@ -1900,7 +1912,9 @@ def create_app(manager: SessionManager) -> FastAPI:
                         await reject_input("Invalid model: expected a string.")
                         continue
                     await _apply_model(model)
-                    if text or attachments:
+                    if text == "/compact" and not attachments:
+                        await claim_turn(compact=True)
+                    elif text or attachments:
                         content = build_user_content(text, attachments)
                         await claim_turn(content=content)
                 else:

--- a/coworker/tui/app.py
+++ b/coworker/tui/app.py
@@ -156,6 +156,16 @@ class CoworkerApp(App):
             self._write(f"[red]error:[/red] {exc}")
         self._persist_session()
 
+    @work(exclusive=True)
+    async def run_compact(self) -> None:
+        assert self.engine is not None
+        try:
+            async for event in self.engine.compact():
+                self._render_event(event)
+        except Exception as exc:  # pragma: no cover - surfaced to the user
+            self._write(f"[red]error:[/red] {exc}")
+        self._persist_session()
+
     def _persist_session(self) -> None:
         if self._session_store is None or self.engine is None or not self._session_id:
             return
@@ -190,6 +200,12 @@ class CoworkerApp(App):
             self._write("[red]⏹ interrupted[/red]")
         elif event.type is EventType.ERROR:
             self._write(f"[red]error: {data.get('error')}[/red]")
+        elif event.type is EventType.CONTEXT_COMPACTED:
+            self._write(
+                "[dim]Context automatically compacted[/dim]"
+                if data.get("automatic")
+                else "[dim]Context compacted[/dim]"
+            )
         elif event.type is EventType.TURN_END:
             if data.get("status") == "max_iterations_exceeded":
                 self._write("[red]⚠ stopped: max iterations reached[/red]")
@@ -208,7 +224,8 @@ class CoworkerApp(App):
             self.exit()
         elif name == "/help":
             self._write(
-                "commands: /mode plan|interactive|auto · /model <id> · /clear · /quit"
+                "commands: /mode plan|interactive|auto · /model <id> · "
+                "/compact · /clear · /quit"
             )
         elif name == "/mode" and arg in {"plan", "interactive", "auto"}:
             self.mode = Mode(arg)
@@ -220,6 +237,8 @@ class CoworkerApp(App):
             if self.engine:
                 self.engine.model = arg
             self._write(f"model → {arg}")
+        elif name == "/compact" and arg is None:
+            self.run_compact()
         elif name == "/clear":
             if self.engine:
                 self.engine.messages = []

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -635,6 +635,16 @@ export function App() {
           setReasoningStream("");
           break;
         }
+        case "context_compacted":
+          setUsage((u) => ({
+            ...u,
+            context: Math.max(0, Number(d.context_tokens) || 0),
+          }));
+          setItems((p) => [
+            ...p,
+            { kind: "compaction", automatic: !!d.automatic },
+          ]);
+          break;
         case "tool_proposed":
           if (d.name === "todo_write" && (d.arguments?.todos || d.arguments?.items))
             setTodo(normalizeTodos(d.arguments.todos ?? d.arguments.items));
@@ -843,6 +853,12 @@ export function App() {
   }, [surface, sessionId, browserRefreshKey, markUnattended]);
 
   const send = (text: string, attachments?: Attachment[]) => {
+    if (text.trim() === "/compact" && !attachments?.length) {
+      setRunning(true);
+      sessionRef.current?.compact();
+      followLatest();
+      return;
+    }
     setItems((p) => [...p, { kind: "user", text, attachments, ts: Date.now() / 1000 }]);
     // The visible model rides along with the message (single source of truth per turn).
     sessionRef.current?.userMessage(text, attachments, model);

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -1816,6 +1816,10 @@ export class Session {
     });
   }
 
+  compact() {
+    this.send({ type: "compact" });
+  }
+
   approve(decision: string) {
     this.send({ type: "approval", decision });
   }

--- a/surfaces/gui/src/components/SettingsView.tsx
+++ b/surfaces/gui/src/components/SettingsView.tsx
@@ -583,10 +583,9 @@ function UpdateInline() {
 
 // -- Sidebar density -------------------------------------------------------------
 // -- Token savings (PDF attachments; owner ask, 2026-07-17) ---------------------
-// Attachments replay with EVERY turn, so a big PDF quietly multiplies token spend.
-// Auto-compaction of long histories is a planned follow-up (punchlist §7) — until
-// then this card is the user's dial: attach thresholds + the fallback for models
-// without native PDF support.
+// Attachments replay until the next context checkpoint, so a big PDF can still multiply
+// token spend across several turns. This card remains the user's immediate dial: attach
+// thresholds + the fallback for models without native PDF support.
 function TokenSavingsCard() {
   const [pdf, setPdf] = useState<PdfSettings | null>(null);
 

--- a/surfaces/gui/src/components/Transcript.test.tsx
+++ b/surfaces/gui/src/components/Transcript.test.tsx
@@ -81,6 +81,29 @@ describe("TurnGroup (Transcript §33)", () => {
     expect(container.querySelector("details.stepgroup")).toBeNull();
     expect(screen.getByText("Hello there.")).toBeTruthy();
   });
+
+  it("shows automatic compaction as an action inside the expanded steps", () => {
+    const items: Item[] = [
+      { kind: "user", text: "continue" },
+      { kind: "compaction", automatic: true },
+      { kind: "assistant", text: "Done." },
+    ];
+    const { container } = render(<Transcript items={items} onApprove={vi.fn()} />);
+
+    expect(screen.getByText("1 step")).toBeTruthy();
+    expect(screen.queryByText("Context automatically compacted")).toBeNull();
+    fireEvent.click(container.querySelector("summary.stepgroup-head")!);
+    expect(screen.getByText("Context automatically compacted")).toBeTruthy();
+    expect(screen.getByText("Done.")).toBeTruthy();
+  });
+
+  it("distinguishes a manual compaction action", () => {
+    const items: Item[] = [{ kind: "compaction", automatic: false }];
+    const { container } = render(<Transcript items={items} onApprove={vi.fn()} />);
+
+    fireEvent.click(container.querySelector("summary.stepgroup-head")!);
+    expect(screen.getByText("Context compacted")).toBeTruthy();
+  });
 });
 
 describe("live turns (§33 flicker fix)", () => {

--- a/surfaces/gui/src/components/Transcript.tsx
+++ b/surfaces/gui/src/components/Transcript.tsx
@@ -79,7 +79,8 @@ export function ThinkingBlock({ text, live }: { text: string; live?: boolean }) 
 type ToolItem = Extract<Item, { kind: "tool" }>;
 type ApprovalItem = Extract<Item, { kind: "approval" }>;
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
-type TurnItem = ToolItem | ApprovalItem | AssistantItem;
+type CompactionItem = Extract<Item, { kind: "compaction" }>;
+type TurnItem = ToolItem | ApprovalItem | AssistantItem | CompactionItem;
 
 // TurnGroup (§33, absorbs §7's StepGroup): the whole user-message → final-answer span collapses
 // as ONE disclosure — "N steps" — with the agent's narration (assistant text followed by more
@@ -91,18 +92,21 @@ type TurnItem = ToolItem | ApprovalItem | AssistantItem;
 type TurnRow =
   | { type: "narr"; text: string }
   | { type: "step"; tool: ToolItem; approval?: ApprovalItem }
+  | { type: "compact"; item: CompactionItem }
   | { type: "ask"; approval: ApprovalItem };
 
 function buildRows(items: TurnItem[]): TurnRow[] {
   // First pass: tool rows in order; then pair each resolved approval with the nearest
   // same-name tool that doesn't have one yet (approvals may stream before or after their call).
-  const rows: TurnRow[] = items
-    .filter((it): it is ToolItem | AssistantItem => it.kind !== "approval")
-    // Thinking-only assistant items (no text) carry nothing narratable — skip the row.
-    .filter((it) => it.kind !== "assistant" || it.text)
-    .map((it) =>
-      it.kind === "assistant" ? { type: "narr" as const, text: it.text } : { type: "step" as const, tool: it },
-    );
+  const rows: TurnRow[] = [];
+  for (const item of items) {
+    if (item.kind === "assistant" && item.text)
+      rows.push({ type: "narr", text: item.text });
+    else if (item.kind === "tool")
+      rows.push({ type: "step", tool: item });
+    else if (item.kind === "compaction")
+      rows.push({ type: "compact", item });
+  }
   const approvals = items.filter((it): it is ApprovalItem => it.kind === "approval");
   for (const ap of approvals) {
     const at = items.indexOf(ap);
@@ -279,6 +283,21 @@ function TurnGroup({
                 <LineText line={humanizeAsk(row.approval.name, row.approval.args)} />
                 {approvalChip(row.approval.resolved)}
               </div>
+            ) : row.type === "compact" ? (
+              <div
+                className="flex items-center gap-2 px-2 py-0.5 text-[13px] leading-relaxed text-muted"
+                key={i}
+                data-testid="context-compaction-step"
+              >
+                <span className="w-3.5 flex justify-center text-faint shrink-0">
+                  <Icon name="refresh" size={12} />
+                </span>
+                <span>
+                  {row.item.automatic
+                    ? "Context automatically compacted"
+                    : "Context compacted"}
+                </span>
+              </div>
             ) : (
               <StepRow tool={row.tool} approval={row.approval} key={i} />
             ),
@@ -349,7 +368,12 @@ export function Transcript({ items, running, streamingText, onRetry }: Props) {
     answers.forEach((a) => blocks.push({ item: a, i: -1 }));
   };
   items.forEach((item, i) => {
-    if (item.kind === "tool" || item.kind === "assistant" || (item.kind === "approval" && item.resolved))
+    if (
+      item.kind === "tool" ||
+      item.kind === "assistant" ||
+      item.kind === "compaction" ||
+      (item.kind === "approval" && item.resolved)
+    )
       run.push(item);
     else if (
       // PENDING interactive items render elsewhere (approval/question → composer head) and

--- a/surfaces/gui/src/itemsFromMessages.test.ts
+++ b/surfaces/gui/src/itemsFromMessages.test.ts
@@ -83,6 +83,30 @@ describe("itemsFromMessages model switch", () => {
   });
 });
 
+describe("itemsFromMessages compaction checkpoints", () => {
+  it("replays automatic and manual checkpoints as action items", () => {
+    const items = itemsFromMessages([
+      {
+        role: "notice",
+        kind: "context_compaction",
+        automatic: true,
+        summary: "private model context",
+      },
+      {
+        role: "notice",
+        kind: "context_compaction",
+        automatic: false,
+        summary: "another private model context",
+      },
+    ] as any);
+
+    expect(items).toEqual([
+      { kind: "compaction", automatic: true },
+      { kind: "compaction", automatic: false },
+    ]);
+  });
+});
+
 describe("itemsFromMessages reasoning", () => {
   it("attaches the reasoning sidecar to assistant items; thinking-only messages still render", () => {
     const items = itemsFromMessages([

--- a/surfaces/gui/src/itemsFromMessages.ts
+++ b/surfaces/gui/src/itemsFromMessages.ts
@@ -68,7 +68,9 @@ export function itemsFromMessages(messages: ConversationMessage[]): Item[] {
       // reload exactly like the live view rendered them. An error notice is retriable —
       // the Transcript only offers the button when it's the transcript tail.
       items.push(
-        m.kind === "interrupted"
+        m.kind === "context_compaction"
+          ? { kind: "compaction", automatic: !!m.automatic }
+          : m.kind === "interrupted"
           ? { kind: "notice", tone: "warn", text: "Interrupted." }
           : m.kind === "model_switch"
             ? { kind: "notice", tone: "info", text: m.text || "Model switched" }

--- a/surfaces/gui/src/types.ts
+++ b/surfaces/gui/src/types.ts
@@ -5,6 +5,7 @@ export type EventType =
   | "assistant_delta"
   | "reasoning_delta"
   | "assistant_message"
+  | "context_compacted"
   | "tool_proposed"
   | "permission_required"
   | "directory_requested"
@@ -100,6 +101,7 @@ export type Item =
   // registry — no per-connector special-casing.
   | { kind: "connector"; source: MessageSource }
   | { kind: "assistant"; text: string; ts?: number; reasoning?: string }
+  | { kind: "compaction"; automatic: boolean }
   // `hidden` = results the user's privacy filters removed before the agent saw them
   // (from the tool message's `_display` sidecar; the agent-visible content has no trace).
   // `standingRule` = the task-scoped rule that auto-allowed this call ("tool → target").

--- a/surfaces/gui/src/usage.test.ts
+++ b/surfaces/gui/src/usage.test.ts
@@ -58,6 +58,16 @@ describe("usageFromMessages", () => {
     expect(u.byModel["anthropic:claude-fable-5"].input).toBe(400);
     expect(u.context).toBe(360);
   });
+
+  it("resets active context at a durable compaction checkpoint", () => {
+    const u = usageFromMessages([
+      { role: "assistant", usage: turn({ input: 360_000 }) },
+      { role: "notice", kind: "context_compaction", context_tokens: 1_250 },
+    ] as any);
+
+    expect(u.context).toBe(1_250);
+    expect(u.byModel["anthropic:claude-fable-5"].input).toBe(360_000);
+  });
 });
 
 describe("totalTokens / formatTokens", () => {

--- a/surfaces/gui/src/usage.ts
+++ b/surfaces/gui/src/usage.ts
@@ -50,6 +50,10 @@ export function usageFromMessages(messages: ConversationMessage[]): SessionUsage
   let acc = emptyUsage();
   for (const m of messages || []) {
     if (m.role === "assistant" && m.usage) acc = addTurnUsage(acc, m.usage);
+    else if (m.role === "notice" && m.kind === "context_compaction") {
+      const context = num(m.context_tokens);
+      acc = { ...acc, context };
+    }
   }
   return acc;
 }

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1,0 +1,237 @@
+"""Manual and automatic conversation compaction through the public session API."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from coworker.compaction import (
+    RECENT_USER_MESSAGE_MAX_TOKENS,
+    approx_token_count,
+    recent_user_messages,
+)
+from coworker.providers import (
+    AssistantTurn,
+    ModelCapabilities,
+    ProviderClient,
+)
+from coworker.providers.base import TokenUsage
+from coworker.server import SessionManager, create_app
+
+
+class RecordingProvider(ProviderClient):
+    def __init__(self, turns: list[AssistantTurn]) -> None:
+        self.turns = list(turns)
+        self.requests: list[list[dict]] = []
+
+    def complete(self, *, model, messages, tools=None, **settings):
+        self.requests.append(messages)
+        return self.turns.pop(0)
+
+    def capabilities(self, model):
+        return ModelCapabilities()
+
+
+def _turn(text: str, *, context_tokens: int = 0) -> AssistantTurn:
+    usage = TokenUsage(input=context_tokens) if context_tokens else None
+    return AssistantTurn(text=text, finish_reason="stop", usage=usage)
+
+
+def _drain(ws) -> list[dict]:
+    events = []
+    while True:
+        event = ws.receive_json()
+        events.append(event)
+        if event["type"] == "turn_done":
+            return events
+
+
+def _messages_contain(messages: list[dict], text: str) -> bool:
+    return any(text in str(message.get("content", "")) for message in messages)
+
+
+def _receive_turn_start(ws) -> dict:
+    while True:
+        event = ws.receive_json()
+        assert event["type"] != "input_rejected", event
+        if event["type"] == "turn_start":
+            return event
+
+
+def test_slash_compact_is_an_operation_and_replaces_provider_history(tmp_path):
+    provider = RecordingProvider(
+        [
+            _turn("The launch code is ORCHID."),
+            _turn("Remember the launch code ORCHID and the user's request."),
+            _turn("ORCHID"),
+        ]
+    )
+    manager = SessionManager(workspace=tmp_path, provider=provider)
+    client = TestClient(create_app(manager))
+
+    with client.websocket_connect("/ws/session/__manual") as ws:
+        assert ws.receive_json()["type"] == "ready"
+        ws.send_json({"type": "user_message", "text": "Remember launch code ORCHID."})
+        _drain(ws)
+
+        ws.send_json({"type": "compact"})
+        first_compact_event = _receive_turn_start(ws)
+        compact_events = [first_compact_event, *_drain(ws)]
+
+        assert [e["type"] for e in compact_events] == [
+            "turn_start",
+            "context_compacted",
+            "turn_end",
+            "turn_done",
+        ]
+        assert compact_events[1]["data"]["automatic"] is False
+        assert compact_events[1]["data"]["context_tokens"] > 0
+
+        ws.send_json({"type": "user_message", "text": "What is the launch code?"})
+        _drain(ws)
+
+    assert len(provider.requests) == 3
+    assert _messages_contain(
+        provider.requests[1], "CONTEXT CHECKPOINT COMPACTION"
+    )
+    assert not _messages_contain(provider.requests[2], "The launch code is ORCHID.")
+    assert _messages_contain(
+        provider.requests[2],
+        "Remember the launch code ORCHID and the user's request.",
+    )
+    assert _messages_contain(provider.requests[2], "What is the launch code?")
+
+    saved = manager.session_store.load("__manual")
+    assert saved is not None
+    assert all(m.get("content") != "/compact" for m in saved.messages)
+    marker = next(
+        m
+        for m in saved.messages
+        if m.get("role") == "notice" and m.get("kind") == "context_compaction"
+    )
+    assert marker["automatic"] is False
+    assert marker["summary"].startswith(
+        "Another language model started to solve this problem"
+    )
+
+
+def test_automatic_compaction_runs_before_next_model_sample_at_ninety_percent(
+    tmp_path,
+):
+    provider = RecordingProvider(
+        [
+            _turn("first reply", context_tokens=360_000),
+            _turn("summary with the durable facts"),
+            _turn("second reply", context_tokens=120),
+        ]
+    )
+    manager = SessionManager(workspace=tmp_path, provider=provider)
+    client = TestClient(create_app(manager))
+
+    with client.websocket_connect("/ws/session/__automatic") as ws:
+        assert ws.receive_json()["type"] == "ready"
+        ws.send_json(
+            {
+                "type": "user_message",
+                "text": "first",
+                "model": "companion:gpt-5.5",
+            }
+        )
+        _drain(ws)
+
+        ws.send_json(
+            {
+                "type": "user_message",
+                "text": "second",
+                "model": "companion:gpt-5.5",
+            }
+        )
+        events = _drain(ws)
+
+    assert len(provider.requests) == 3
+    assert _messages_contain(provider.requests[1], "CONTEXT CHECKPOINT COMPACTION")
+    assert _messages_contain(provider.requests[2], "summary with the durable facts")
+    assert _messages_contain(provider.requests[2], "second")
+    compacted = [e for e in events if e["type"] == "context_compacted"]
+    assert len(compacted) == 1
+    assert compacted[0]["data"]["automatic"] is True
+    assert 0 < compacted[0]["data"]["context_tokens"] < 360_000
+
+
+def test_compaction_checkpoint_survives_engine_restart(tmp_path):
+    first_provider = RecordingProvider(
+        [
+            _turn("The deployment region is ap-south-1."),
+            _turn("Keep the deployment region ap-south-1."),
+        ]
+    )
+    first_manager = SessionManager(workspace=tmp_path, provider=first_provider)
+    first_client = TestClient(create_app(first_manager))
+    with first_client.websocket_connect("/ws/session/__restart") as ws:
+        assert ws.receive_json()["type"] == "ready"
+        ws.send_json(
+            {"type": "user_message", "text": "Deployment region is ap-south-1."}
+        )
+        _drain(ws)
+        ws.send_json({"type": "compact"})
+        _drain(ws)
+
+    second_provider = RecordingProvider([_turn("ap-south-1")])
+    second_manager = SessionManager(workspace=tmp_path, provider=second_provider)
+    second_client = TestClient(create_app(second_manager))
+    with second_client.websocket_connect("/ws/session/__restart") as ws:
+        assert ws.receive_json()["type"] == "ready"
+        ws.send_json(
+            {"type": "user_message", "text": "Which deployment region?"}
+        )
+        _drain(ws)
+
+    assert len(second_provider.requests) == 1
+    assert _messages_contain(
+        second_provider.requests[0], "Keep the deployment region ap-south-1."
+    )
+    assert not _messages_contain(
+        second_provider.requests[0], "The deployment region is ap-south-1."
+    )
+
+
+def test_automatic_compaction_waits_below_ninety_percent(tmp_path):
+    provider = RecordingProvider(
+        [
+            _turn("first reply", context_tokens=359_999),
+            _turn("second reply", context_tokens=100),
+        ]
+    )
+    manager = SessionManager(workspace=tmp_path, provider=provider)
+    client = TestClient(create_app(manager))
+    with client.websocket_connect("/ws/session/__below") as ws:
+        assert ws.receive_json()["type"] == "ready"
+        for text in ("first", "second"):
+            ws.send_json(
+                {"type": "user_message", "text": text, "model": "gpt-5.5"}
+            )
+            events = _drain(ws)
+            assert all(e["type"] != "context_compacted" for e in events)
+
+    assert len(provider.requests) == 2
+    assert not any(
+        _messages_contain(request, "CONTEXT CHECKPOINT COMPACTION")
+        for request in provider.requests
+    )
+
+
+def test_recent_user_message_budget_matches_codex_and_keeps_utf8_valid():
+    messages = [
+        {"role": "user", "content": "α" * 45_000},
+        {"role": "assistant", "content": "old reply"},
+        {"role": "user", "content": "latest-" + "🚀" * 5_000},
+    ]
+
+    selected = recent_user_messages(messages)
+
+    assert selected[-1]["content"].startswith("latest-")
+    assert selected[0]["content"].startswith("α")
+    assert "chars truncated" in selected[0]["content"]
+    assert (
+        sum(approx_token_count(m["content"]) for m in selected)
+        <= RECENT_USER_MESSAGE_MAX_TOKENS + 16
+    )

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -22,7 +22,7 @@ from coworker.providers.anthropic_provider import AnthropicProvider
 from coworker.providers.base import TokenUsage
 from coworker.providers.bedrock_provider import _BedrockConverseClient
 from coworker.providers.gemini_provider import GeminiProvider
-from coworker.providers.matrix import model_context_windows
+from coworker.providers.matrix import context_window_for, model_context_windows
 from coworker.providers.openai_provider import OpenAIProvider
 from coworker.tools import ToolRegistry
 
@@ -354,3 +354,9 @@ def test_model_context_windows_covers_verified_entries_only():
     assert windows["anthropic:claude-fable-5"] == 1_000_000
     assert "together:thinkingmachines/Inkling" not in windows  # unverified stays absent
     assert all(isinstance(v, int) and v > 0 for v in windows.values())
+
+
+def test_context_window_resolves_provider_managed_aliases():
+    assert context_window_for("companion:gpt-5.6-sol") == 400_000
+    assert context_window_for("companion:deepseek-v4-flash") == 128_000
+    assert context_window_for("companion:unknown-model") is None

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -75,3 +75,26 @@ async def test_tui_approval_then_write(tmp_path):
 
     assert (tmp_path / "made.py").read_text() == "print(1)\n"
     assert any("done, wrote made.py" in line for line in app.rendered)
+
+
+@pytest.mark.asyncio
+async def test_tui_slash_compact_runs_manual_compaction(tmp_path):
+    app = CoworkerApp(
+        workspace=tmp_path,
+        provider=_ScriptedProvider([_text_turn("summary of the durable facts")]),
+    )
+    async with app.run_test() as pilot:
+        assert app.engine is not None
+        app.engine.messages.extend(
+            [
+                {"role": "user", "content": "remember ORCHID"},
+                {"role": "assistant", "content": "remembered"},
+            ]
+        )
+        await _submit(pilot, "/compact")
+
+        assert any("Context compacted" in line for line in app.rendered)
+        assert any(
+            m.get("kind") == "context_compaction" and m.get("automatic") is False
+            for m in app.engine.messages
+        )


### PR DESCRIPTION
Closes #239.
Related to #249.

## What changed

- Add `/compact` to the desktop app and TUI.
- Compact automatically before the next model request when the reported context reaches 90% of the model window.
- Keep the full chat transcript on disk while sending the model a shorter history built from recent user messages and a checkpoint summary.
- Save the checkpoint so the shorter context survives an app restart.
- Show `Context compacted` or `Context automatically compacted` inside the turn's expanded steps.

## Why

Long sessions resend the same history on every model call. This can make later turns expensive or push a request past the model's context limit.

The checkpoint keeps the current task, decisions, user constraints, and recent user messages. Older model-facing history is replaced by that checkpoint, but the user can still read the complete chat.

## How to test

Manual compaction:

1. Start a chat and give the model a fact to remember.
2. Send `/compact`.
3. Expand the steps under the previous turn. It should show `Context compacted`.
4. Ask for the earlier fact. The model should still know it.
5. Reload the session and ask again.

Automatic compaction:

1. Run `pytest tests/test_compaction.py -q`.
2. The boundary test reports 360,000 tokens against a 400,000-token window.
3. The next user message should emit `context_compacted` before the next ordinary model response.
4. In the app, the expanded step should read `Context automatically compacted`.

## Screenshots

Manual `/compact`, followed by a recall check:

![Manual context compaction and recall](https://raw.githubusercontent.com/lazycoder1/openworker/pr-assets-325-context-compaction/context-compaction-manual.png)

Automatic compaction at the test boundary, followed by a recall check:

![Automatic context compaction and recall](https://raw.githubusercontent.com/lazycoder1/openworker/pr-assets-325-context-compaction/context-compaction-automatic.png)

## Checks

- `pytest -q` — 954 passed, 1 skipped
- `npm test -- --run` — 85 passed
- `npm run build` — passed
- Manual app check — `/compact`, checkpoint display, reload, and recall passed
- Automatic app check — threshold event, checkpoint display, and recall passed

## Reference

This follows the compaction lifecycle already used by Codex. `/compact` is a [dedicated command](https://github.com/openai/codex/blob/9a6668f674d74b35418fa534b3b6285a315d0765/codex-rs/tui/src/slash_command.rs#L40), automatic compaction runs [before the next model sample](https://github.com/openai/codex/blob/9a6668f674d74b35418fa534b3b6285a315d0765/codex-rs/core/src/session/turn.rs#L985-L1014), and both paths use the [same summary flow](https://github.com/openai/codex/blob/9a6668f674d74b35418fa534b3b6285a315d0765/codex-rs/core/src/compact.rs#L111-L166) while [retaining recent user messages](https://github.com/openai/codex/blob/9a6668f674d74b35418fa534b3b6285a315d0765/codex-rs/core/src/compact.rs#L611-L684). OpenWorker stores the checkpoint separately so its visible JSONL transcript stays intact.
