### PR TITLE
Add inline skill chooser with exact-path injection

### DIFF
--- a/coworker/agent.py
+++ b/coworker/agent.py
@@ -30,7 +30,7 @@ from .roots import RootDir, normalize_roots, render_context
 from .providers import ProviderClient, ProviderRouter
 from .overrides import RiskOverrideStore
 from .secrets import SecretStore, state_dir
-from .skills import SkillLoader, skill_catalog_text, skill_tools
+from .skills import SkillLoader, skill_catalog_text, skill_roots, skill_tools
 from .tools import ToolRegistry
 from .tools.ask import ask_user_tool
 from .tools.directories import request_directory_tool
@@ -97,13 +97,6 @@ def _enabled_connector_tools(secrets: SecretStore) -> tuple[set[str], set[str]]:
         if tool.get("enabled")
     }
     return enabled_connectors, enabled_tools
-
-
-def _skill_dirs(workspace: Optional[Path]) -> list[Path]:
-    dirs = [state_dir() / "skills"]
-    if workspace is not None:
-        dirs.append(workspace / ".coworker" / "skills")
-    return dirs
 
 
 def build_engine(
@@ -259,7 +252,7 @@ def build_engine(
         if block:
             instructions = f"{instructions}\n\n{block}"
 
-    skill_loader = SkillLoader(_skill_dirs(ws))
+    skill_loader = SkillLoader(skill_roots(ws))
     registry.register_all(skill_tools(skill_loader))
     catalog = skill_catalog_text(skill_loader)
     if catalog:

--- a/coworker/engine.py
+++ b/coworker/engine.py
@@ -13,6 +13,7 @@ engine says `needs_user`, the engine emits `PERMISSION_REQUIRED` and awaits the 
 from __future__ import annotations
 
 import asyncio
+import html
 import json
 import time
 from dataclasses import dataclass
@@ -43,6 +44,23 @@ class PermissionRequest:
 
 
 Approver = Callable[[PermissionRequest], Awaitable[ApprovalOutcome]]
+
+
+def _render_skill_parts(parts: list[dict[str, str]]) -> str:
+    """Render a path-verified rich prompt for the provider, preserving draft order."""
+    rendered: list[str] = []
+    for part in parts:
+        if part.get("type") == "text":
+            rendered.append(part.get("text", ""))
+        elif part.get("type") == "skill":
+            name = html.escape(part.get("name", ""))
+            path = html.escape(part.get("path", ""))
+            content = part.get("content", "")
+            rendered.append(
+                f"<skill>\n<name>{name}</name>\n<path>{path}</path>\n"
+                f"{content}\n</skill>"
+            )
+    return "".join(rendered)
 
 
 async def _deny_all(_request: PermissionRequest) -> ApprovalOutcome:
@@ -154,12 +172,19 @@ class TurnEngine:
 
     # -- main loop --------------------------------------------------------------
     async def run(
-        self, user_input: "str | list", *, source: Optional[dict[str, Any]] = None
+        self,
+        user_input: "str | list",
+        *,
+        source: Optional[dict[str, Any]] = None,
+        skill_parts: Optional[list[dict[str, str]]] = None,
     ) -> AsyncIterator[Event]:
         # `user_input` is a string, or OpenAI content-parts (text + image_url) for attachments.
         # `source` (a MessageSource dict) is a display-only sidecar for connector messages: it
         # rides on the persisted user message + the TURN_START event, but is stripped before the
         # message reaches a provider (see `_outbound_messages`). `content` stays the framed text.
+        # `skill_parts` is another persisted sidecar: ingress has already resolved every selected
+        # exact path and snapshotted its raw SKILL.md. The provider sees its ordered expansion;
+        # the transcript keeps the compact, readable `content` plus structured chip identity.
         # `ts` (unix seconds, stamped on every appended message) is the same kind of sidecar.
         message: dict[str, Any] = {
             "role": "user",
@@ -168,11 +193,18 @@ class TurnEngine:
         }
         if source is not None:
             message["source"] = source
+        if skill_parts is not None:
+            message["skill_parts"] = skill_parts
         self.messages.append(message)
         self._cancel.clear()
         data: dict[str, Any] = {"input": user_input}
         if source is not None:
             data["source"] = source
+        if skill_parts is not None:
+            data["skill_parts"] = [
+                {key: value for key, value in part.items() if key != "content"}
+                for part in skill_parts
+            ]
         yield Event(EventType.TURN_START, data)
         async for event in self._loop():
             yield event
@@ -880,25 +912,62 @@ class TurnEngine:
     def _outbound_messages(self) -> list[dict[str, Any]]:
         """`self.messages` prepared for the provider. The SOLE provider feed (see `_astream`).
 
-        Every message is stripped of the display-only sidecars — `source`, `_display`, and
-        `ts` — (providers reject unknown keys), unconditionally — whether or not a
-        `<system-context>` block is added. When a context
+        Every message is stripped of the non-provider sidecars — `source`, `_display`, `ts`,
+        and `skill_parts` — (providers reject unknown keys), unconditionally. Before stripping,
+        a user message's verified `skill_parts` become ordered full-body `<skill>` blocks.
+        When a context
         provider yields a non-empty string, an ephemeral `<system-context>` block is appended to the
         last user message. Never mutates `self.messages`, so neither the strip nor the block is
         persisted/replayed.
         """
-        # Strip the display-only sidecars — `source` (connector cards), `_display`
+        # Strip non-provider sidecars — `source` (connector cards), `_display`
         # (e.g. filter-hidden counts), `ts` (append-time timestamps), `reasoning`
-        # (thinking text), and `usage` (token counts) — copying only messages that carry
-        # one. Whole `notice` messages (error/interrupted/model-switch markers) are
-        # display-only too: dropped entirely.
-        _SIDECARS = ("source", "_display", "ts", "reasoning", "usage")
-        out = [
-            (
-                {k: v for k, v in msg.items() if k not in _SIDECARS}
-                if any(s in msg for s in _SIDECARS)
+        # (thinking text), `usage` (token counts), and the expanded-below `skill_parts` —
+        # copying only messages that carry one. Whole `notice` messages
+        # (error/interrupted/model-switch markers) are display-only too: dropped entirely.
+        _SIDECARS = (
+            "source",
+            "_display",
+            "ts",
+            "reasoning",
+            "usage",
+            "skill_parts",
+        )
+
+        def prepare(msg: dict[str, Any]) -> dict[str, Any]:
+            prepared = (
+                {key: value for key, value in msg.items() if key not in _SIDECARS}
+                if any(sidecar in msg for sidecar in _SIDECARS)
                 else msg
             )
+            skill_parts = msg.get("skill_parts")
+            if not isinstance(skill_parts, list):
+                return prepared
+
+            expanded = _render_skill_parts(skill_parts)
+            content = prepared.get("content")
+            if isinstance(content, str):
+                return {**prepared, "content": expanded}
+            if isinstance(content, list):
+                replaced = False
+                content_parts: list[Any] = []
+                for part in content:
+                    if (
+                        not replaced
+                        and isinstance(part, dict)
+                        and part.get("type") == "text"
+                    ):
+                        content_parts.append({**part, "text": expanded})
+                        replaced = True
+                    else:
+                        content_parts.append(part)
+                if not replaced:
+                    content_parts.insert(0, {"type": "text", "text": expanded})
+                return {**prepared, "content": content_parts}
+            return prepared
+
+        out = [
+            prepare(msg)
             for msg in self.messages
             if msg.get("role") != "notice"
         ]

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -63,6 +63,63 @@ def _json_value_size(value: Any) -> int:
     return 8  # numbers, booleans, null, separators
 
 
+def _verified_skill_parts(
+    engine: Any, raw_parts: Any
+) -> tuple[Optional[list[dict[str, str]]], Optional[str]]:
+    """Resolve client skill refs against this session's catalog and snapshot exact files."""
+    if raw_parts is None:
+        return None, None
+    if not isinstance(raw_parts, list) or len(raw_parts) > 64:
+        return None, "Invalid skill parts: expected at most 64 parts."
+
+    verified: list[dict[str, str]] = []
+    for part in raw_parts:
+        if not isinstance(part, dict):
+            return None, "Invalid skill part: expected an object."
+        part_type = part.get("type")
+        if part_type == "text":
+            part_text = part.get("text")
+            if not isinstance(part_text, str):
+                return None, "Invalid skill text part: expected a string."
+            verified.append({"type": "text", "text": part_text})
+            continue
+        if part_type != "skill":
+            return None, "Invalid skill part type: expected text or skill."
+
+        name, path = part.get("name"), part.get("path")
+        if not isinstance(name, str) or not isinstance(path, str):
+            return None, "Invalid skill reference: name and path are required."
+        skill = engine.skill_loader.resolve(name, path)
+        if skill is None:
+            return (
+                None,
+                "Invalid skill reference: path is not in the active workspace catalog.",
+            )
+        verified.append(
+            {
+                "type": "skill",
+                "name": skill.name,
+                "path": skill.path or "",
+                "source": skill.source,
+                "content": skill.raw_content,
+            }
+        )
+
+    part_text_chars = sum(
+        len(part["text"]) for part in verified if part["type"] == "text"
+    )
+    if part_text_chars > _MAX_MESSAGE_TEXT_CHARS:
+        return (
+            None,
+            "Skill prompt text too long "
+            f"({part_text_chars} chars; limit {_MAX_MESSAGE_TEXT_CHARS}).",
+        )
+    return (
+        verified if any(part["type"] == "skill" for part in verified) else None,
+        None,
+    )
+
+
 # Brand colors for the connector badge riding the ✓ (UX-DECISIONS §30). The GUI owns the
 # real logos; this page must render offline with zero assets, so a colored initial stands in.
 _BRAND_COLORS = {
@@ -555,8 +612,15 @@ def create_app(manager: SessionManager) -> FastAPI:
         )
 
     @app.get("/v1/skills")
-    def skills() -> dict[str, Any]:
-        return {"skills": manager.list_skills()}
+    def skills(workspace: Optional[str] = None) -> dict[str, Any]:
+        return {"skills": manager.list_skills(workspace)}
+
+    @app.get("/v1/skills/read")
+    def skill_read(path: str, workspace: Optional[str] = None):
+        skill = manager.read_skill(path, workspace)
+        if skill is None:
+            return JSONResponse({"error": "skill not found"}, status_code=404)
+        return skill
 
     @app.get("/v1/workspaces/recent")
     def recent_workspaces() -> dict[str, Any]:
@@ -1710,11 +1774,17 @@ def create_app(manager: SessionManager) -> FastAPI:
             "iteration_end",
         }
 
-        async def run_turn(content, *, retry: bool = False) -> None:
+        async def run_turn(
+            content, *, retry: bool = False, skill_parts=None
+        ) -> None:
             # The receive loop atomically claims this session before scheduling the task.
             # Keeping the claim outside prevents two back-to-back frames from both starting.
             try:
-                events = engine.retry() if retry else engine.run(content)
+                events = (
+                    engine.retry()
+                    if retry
+                    else engine.run(content, skill_parts=skill_parts)
+                )
                 async for event in events:
                     # Broadcast to every socket viewing this session (this socket included — it's a
                     # registered client), so a second view of the same session stays in sync too.
@@ -1740,13 +1810,17 @@ def create_app(manager: SessionManager) -> FastAPI:
             # or flush an in-progress assistant stream in the GUI.
             await ws.send_json({"type": "input_rejected", "data": {"error": reason}})
 
-        async def claim_turn(*, retry: bool = False, content=None) -> None:
+        async def claim_turn(
+            *, retry: bool = False, content=None, skill_parts=None
+        ) -> None:
             if not manager.try_mark_running(session_id):
                 await reject_input(
                     "This session is already running a turn. Wait for it to finish or stop it."
                 )
                 return
-            asyncio.create_task(run_turn(content, retry=retry))
+            asyncio.create_task(
+                run_turn(content, retry=retry, skill_parts=skill_parts)
+            )
 
         try:
             while True:
@@ -1824,6 +1898,12 @@ def create_app(manager: SessionManager) -> FastAPI:
                         await reject_input("Invalid message text: expected a string.")
                         continue
                     text = raw_text.strip()
+                    selected_skill_parts, parts_error = _verified_skill_parts(
+                        engine, message.get("parts")
+                    )
+                    if parts_error is not None:
+                        await reject_input(parts_error)
+                        continue
                     raw_attachments = message.get("attachments")
                     attachments = [] if raw_attachments is None else raw_attachments
                     # Reject an oversized frame instead of buffering it into a turn. Send a
@@ -1900,9 +1980,11 @@ def create_app(manager: SessionManager) -> FastAPI:
                         await reject_input("Invalid model: expected a string.")
                         continue
                     await _apply_model(model)
-                    if text or attachments:
+                    if text or attachments or selected_skill_parts:
                         content = build_user_content(text, attachments)
-                        await claim_turn(content=content)
+                        await claim_turn(
+                            content=content, skill_parts=selected_skill_parts
+                        )
                 else:
                     await reject_input(f"Unknown WebSocket message type: {kind}.")
         except WebSocketDisconnect:

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -82,7 +82,7 @@ from ..providers import (
 )
 from ..secrets import SecretStore, state_dir
 from ..sessions import SessionRecord
-from ..skills import SkillLoader
+from ..skills import SkillLoader, skill_roots
 
 _SCOPES = {s.value for s in Scope}
 
@@ -3647,9 +3647,26 @@ class SessionManager:
     def list_agents(self) -> list[dict[str, Any]]:
         return _list_agents()
 
-    def list_skills(self) -> list[dict[str, Any]]:
-        loader = SkillLoader([state_dir() / "skills"])
-        return loader.catalog()
+    def skill_loader(self, workspace: Optional[str] = None) -> SkillLoader:
+        resolved = self.resolve_workspace(workspace)
+        return SkillLoader(skill_roots(resolved))
+
+    def list_skills(self, workspace: Optional[str] = None) -> list[dict[str, Any]]:
+        return self.skill_loader(workspace).catalog_all()
+
+    def read_skill(
+        self, path: str, workspace: Optional[str] = None
+    ) -> Optional[dict[str, Any]]:
+        skill = self.skill_loader(workspace).get_path(path)
+        if skill is None:
+            return None
+        return {
+            "name": skill.name,
+            "description": skill.description,
+            "path": skill.path,
+            "source": skill.source,
+            "content": skill.raw_content,
+        }
 
     def list_memory(self) -> list[dict[str, Any]]:
         return [

--- a/coworker/skills/__init__.py
+++ b/coworker/skills/__init__.py
@@ -1,3 +1,17 @@
-from .base import Skill, SkillLoader, skill_catalog_text, skill_tools
+from .base import (
+    Skill,
+    SkillLoader,
+    SkillRoot,
+    skill_catalog_text,
+    skill_roots,
+    skill_tools,
+)
 
-__all__ = ["Skill", "SkillLoader", "skill_catalog_text", "skill_tools"]
+__all__ = [
+    "Skill",
+    "SkillLoader",
+    "SkillRoot",
+    "skill_catalog_text",
+    "skill_roots",
+    "skill_tools",
+]

--- a/coworker/skills/base.py
+++ b/coworker/skills/base.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Optional
 
 import aisuite as ai
+import yaml
 
 
 @dataclass
@@ -21,23 +22,58 @@ class Skill:
     name: str
     description: str
     instructions: str = ""  # full body — loaded on demand
-    path: Optional[str] = None
+    path: Optional[str] = None  # exact, absolute SKILL.md path
+    source: str = "global"
+    raw_content: str = ""
     allowed_tools: list[str] = field(default_factory=list)
+
+    @property
+    def resources_path(self) -> Optional[str]:
+        return str(Path(self.path).parent) if self.path else None
+
+
+@dataclass(frozen=True)
+class SkillRoot:
+    path: Path
+    source: str = "global"
+
+
+def skill_roots(workspace: Optional[str | Path] = None) -> list[SkillRoot]:
+    """Return skill roots in override order: shared, OpenWorker global, project."""
+    from ..secrets import state_dir
+
+    roots = [
+        SkillRoot(Path.home() / ".agents" / "skills", "shared"),
+        SkillRoot(state_dir() / "skills", "global"),
+    ]
+    if workspace is not None:
+        roots.append(
+            SkillRoot(
+                Path(workspace).expanduser().resolve() / ".coworker" / "skills",
+                "project",
+            )
+        )
+    return roots
 
 
 class SkillLoader:
-    def __init__(self, dirs: list[str | Path]) -> None:
+    def __init__(self, dirs: list[str | Path | SkillRoot]) -> None:
         self._skills: dict[str, Skill] = {}
-        for directory in dirs:
-            self._discover(Path(directory))
+        self._skills_by_path: dict[str, Skill] = {}
+        self._all: list[Skill] = []
+        for item in dirs:
+            root = item if isinstance(item, SkillRoot) else SkillRoot(Path(item))
+            self._discover(Path(root.path), root.source)
 
-    def _discover(self, directory: Path) -> None:
+    def _discover(self, directory: Path, source: str) -> None:
         if not directory.is_dir():
             return
         for sub in sorted(directory.iterdir()):
             md = sub / "SKILL.md"
             if md.is_file():
-                skill = _parse_skill(md)
+                skill = _parse_skill(md, source=source)
+                self._all.append(skill)
+                self._skills_by_path[skill.path or ""] = skill
                 self._skills[skill.name] = skill
 
     def names(self) -> list[str]:
@@ -46,14 +82,34 @@ class SkillLoader:
     def get(self, name: str) -> Optional[Skill]:
         return self._skills.get(name)
 
+    def resolve(self, name: str, path: str | Path) -> Optional[Skill]:
+        exact = str(Path(path).expanduser().resolve())
+        skill = self._skills_by_path.get(exact)
+        return skill if skill is not None and skill.name == name else None
+
+    def get_path(self, path: str | Path) -> Optional[Skill]:
+        return self._skills_by_path.get(str(Path(path).expanduser().resolve()))
+
     def catalog(self) -> list[dict]:
         return [
             {"name": s.name, "description": s.description}
             for s in self._skills.values()
         ]
 
+    def catalog_all(self) -> list[dict]:
+        return [
+            {
+                "name": s.name,
+                "description": s.description,
+                "path": s.path,
+                "source": s.source,
+            }
+            for s in self._all
+        ]
 
-def _parse_skill(md: Path) -> Skill:
+
+def _parse_skill(md: Path, *, source: str = "global") -> Skill:
+    md = md.expanduser().resolve()
     text = md.read_text(encoding="utf-8")
     name, description, allowed, body = md.parent.name, "", [], text
     if text.startswith("---"):
@@ -61,22 +117,39 @@ def _parse_skill(md: Path) -> Skill:
         if end != -1:
             frontmatter = text[3:end]
             body = text[end + 4 :].lstrip("\n")
-            for line in frontmatter.splitlines():
-                if ":" not in line:
-                    continue
-                key, value = line.split(":", 1)
-                key, value = key.strip().lower(), value.strip()
-                if key == "name" and value:
-                    name = value
-                elif key == "description":
-                    description = value
-                elif key in ("allowed-tools", "allowed_tools"):
-                    allowed = [t.strip() for t in value.split(",") if t.strip()]
+            try:
+                metadata = yaml.safe_load(frontmatter) or {}
+            except yaml.YAMLError:
+                metadata = {}
+            if isinstance(metadata, dict):
+                parsed_name = metadata.get("name")
+                parsed_description = metadata.get("description")
+                parsed_allowed = metadata.get(
+                    "allowed-tools", metadata.get("allowed_tools", [])
+                )
+                if parsed_name:
+                    name = str(parsed_name)
+                if parsed_description is not None:
+                    description = str(parsed_description)
+                if isinstance(parsed_allowed, str):
+                    allowed = [
+                        tool.strip()
+                        for tool in parsed_allowed.split(",")
+                        if tool.strip()
+                    ]
+                elif isinstance(parsed_allowed, list):
+                    allowed = [
+                        str(tool).strip()
+                        for tool in parsed_allowed
+                        if str(tool).strip()
+                    ]
     return Skill(
         name=name,
         description=description,
         instructions=body.strip(),
-        path=str(md.parent),
+        path=str(md),
+        source=source,
+        raw_content=text,
         allowed_tools=allowed,
     )
 
@@ -102,7 +175,7 @@ def skill_tools(loader: SkillLoader) -> list:
         return {
             "name": skill.name,
             "instructions": skill.instructions,
-            "resources_path": skill.path,
+            "resources_path": skill.resources_path,
         }
 
     return [

--- a/surfaces/gui/e2e/chat.spec.ts
+++ b/surfaces/gui/e2e/chat.spec.ts
@@ -26,7 +26,7 @@ test("send → user bubble → streamed echo reply renders", async ({ page }) =>
   await expect(page.locator(".dd").filter({ hasText: "Claude Opus" })).toBeVisible();
   await expect(page.getByTestId("session-subtitle")).toContainText("Claude Opus 4.8");
   // Composer cleared and re-armed for the next turn.
-  await expect(box).toHaveValue("");
+  await expect(box).toHaveText("");
 });
 
 test("approval: tool request suspends the turn; Allow once resumes it", async ({ page }) => {

--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -65,6 +65,54 @@ const PERSONAS = {
   ],
 };
 
+const SKILLS = [
+  {
+    name: "pdf",
+    description: "Extract, inspect, and summarize PDF documents",
+    path: "/Users/test/.agents/skills/pdf/SKILL.md",
+    source: "shared",
+  },
+  {
+    name: "release-notes",
+    description: "Turn completed work into concise release notes",
+    path: "/Users/test/.config/coworker/skills/release-notes/SKILL.md",
+    source: "global",
+  },
+  {
+    name: "pdf",
+    description: "Project-specific PDF workflow",
+    path: "/Users/test/OpenWorker/launch-note/.coworker/skills/pdf/SKILL.md",
+    source: "project",
+  },
+];
+
+const SKILL_CONTENT: Record<string, string> = {
+  [SKILLS[0].path]: [
+    "---",
+    "name: pdf",
+    "description: Extract, inspect, and summarize PDF documents",
+    "---",
+    "",
+    "Inspect the supplied PDF and ground every claim in its contents.",
+  ].join("\n"),
+  [SKILLS[1].path]: [
+    "---",
+    "name: release-notes",
+    "description: Turn completed work into concise release notes",
+    "---",
+    "",
+    "Write concise release notes for the completed work.",
+  ].join("\n"),
+  [SKILLS[2].path]: [
+    "---",
+    "name: pdf",
+    "description: Project-specific PDF workflow",
+    "---",
+    "",
+    "Use the launch-note project's exact PDF workflow.",
+  ].join("\n"),
+};
+
 // The boot-resume target (most recent updated_at) — existing specs open it by title.
 const PINNED_SESSION = {
   session_id: "pinned-cowork-1",
@@ -711,8 +759,14 @@ export async function mockApi(page: import("@playwright/test").Page) {
         // composer's visible model must ride on every user_message; 2026-07-04 fix).
         // `usage` mirrors the real engine's assistant_message sidecar (OPE-42): fixed
         // counts per turn so the usage-chip specs can assert exact accumulation.
+        const selected = Array.isArray(msg.parts)
+          ? msg.parts.filter((part: any) => part?.type === "skill")
+          : [];
+        const selectedSkills = selected.length
+          ? ` [skills=${selected.map((skill: any) => skill.name).join(",")}]`
+          : "";
         send("assistant_message", {
-          text: `Echo: ${msg.text} [model=${msg.model || "none"}]`,
+          text: `Echo: ${msg.text} [model=${msg.model || "none"}]${selectedSkills}`,
           usage: {
             model: msg.model || "anthropic:claude-opus-4-8",
             input: 1_000,
@@ -826,6 +880,13 @@ export async function mockApi(page: import("@playwright/test").Page) {
 
     if (p.endsWith("/v1/health")) return json(HEALTH);
     if (p.endsWith("/v1/settings")) return json(SETTINGS);
+    if (p.endsWith("/v1/skills/read")) {
+      const path = new URL(req.url()).searchParams.get("path") ?? "";
+      const content = SKILL_CONTENT[path];
+      if (!content) return json({ ok: false, error: "skill not found" }, 404);
+      return json({ ok: true, ...SKILLS.find((skill) => skill.path === path), path, content });
+    }
+    if (p.endsWith("/v1/skills")) return json({ skills: SKILLS });
     if (p.endsWith("/v1/settings/pdf") && m === "POST") {
       Object.assign(SETTINGS, req.postDataJSON());
       return json({

--- a/surfaces/gui/e2e/nav-collapse.spec.ts
+++ b/surfaces/gui/e2e/nav-collapse.spec.ts
@@ -23,6 +23,7 @@ test("collapse hides the sidebar and reclaims the width; reveal button docks it 
 test("⌘B toggles the sidebar collapse", async ({ page }) => {
   await page.goto("/");
   const app = page.locator(".app");
+  await expect(page.locator(".sidebar")).toBeVisible();
   await page.keyboard.press("Meta+b");
   await expect(app).toHaveClass(/nav-collapsed/);
   await page.keyboard.press("Meta+b");

--- a/surfaces/gui/e2e/session-intro.spec.ts
+++ b/surfaces/gui/e2e/session-intro.spec.ts
@@ -32,7 +32,7 @@ test("three rows, no Set-me-up; gated rows show Configure › and expand the rai
   await hs.click();
   await expect(page.getByRole("region", { name: "Session access" })).toBeVisible();
   // No composer prefill happened on the gated click.
-  await expect(page.getByPlaceholder(/Ask the coworker/)).toHaveValue("");
+  await expect(page.getByPlaceholder(/Ask the coworker/)).toHaveText("");
 });
 
 test("ready rows reveal Start → on hover and prefill the composer", async ({ page }) => {
@@ -61,13 +61,13 @@ test("ready rows reveal Start → on hover and prefill the composer", async ({ p
   await expect(hs.locator(".task-card-act")).toHaveCSS("opacity", "1");
 
   await hs.click();
-  await expect(page.getByPlaceholder(/Ask the coworker/)).toHaveValue(/HubSpot leads/);
+  await expect(page.getByPlaceholder(/Ask the coworker/)).toHaveText(/HubSpot leads/);
 
   // Both sources live → the automation row is ready too; its prefill is the recipe stem.
   const gh = page.getByTestId("intro-task-github-slack");
   await expect(gh).toContainText("Start →");
   await gh.click();
-  await expect(page.getByPlaceholder(/Ask the coworker/)).toHaveValue(/weekly progress report/);
+  await expect(page.getByPlaceholder(/Ask the coworker/)).toHaveText(/weekly progress report/);
 });
 
 test("folder task opens the inline add-folder form; adding a folder prefills the composer", async ({
@@ -82,7 +82,7 @@ test("folder task opens the inline add-folder form; adding a folder prefills the
   await path.fill("/Users/me/Reports");
   await page.getByRole("button", { name: "Add", exact: true }).click();
 
-  await expect(page.getByPlaceholder(/Ask the coworker/)).toHaveValue(
+  await expect(page.getByPlaceholder(/Ask the coworker/)).toHaveText(
     /Analyze the files in this folder/,
   );
 });

--- a/surfaces/gui/e2e/skill-chooser.spec.ts
+++ b/surfaces/gui/e2e/skill-chooser.spec.ts
@@ -80,6 +80,11 @@ test("chooser keyboard navigation, Tab selection, atomic deletion, and Escape", 
 
   await composer.fill("/");
   await expect(chooser).toBeVisible();
+  const composerBox = await composer.boundingBox();
+  const chooserBox = await chooser.boundingBox();
+  expect(composerBox).not.toBeNull();
+  expect(chooserBox).not.toBeNull();
+  expect(chooserBox!.y + chooserBox!.height).toBeLessThanOrEqual(composerBox!.y);
   await page.keyboard.press("ArrowDown");
   await expect(
     chooser.getByRole("option", { name: /release-notes/i }),

--- a/surfaces/gui/e2e/skill-chooser.spec.ts
+++ b/surfaces/gui/e2e/skill-chooser.spec.ts
@@ -1,0 +1,128 @@
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+test("inline skill chips preserve exact selections through send and open SKILL.md", async ({ page }) => {
+  await page.goto("/");
+
+  const composer = page.getByPlaceholder(/Ask the coworker/);
+  await composer.fill("Review this /");
+
+  const chooser = page.getByRole("listbox", { name: "Skills" });
+  await expect(chooser).toBeVisible();
+  await expect(
+    chooser
+      .getByRole("option", { name: /pdf/i })
+      .filter({ hasText: "Extract, inspect, and summarize PDF documents" }),
+  ).toBeVisible();
+
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("composer-skill-chip").filter({ hasText: "pdf" })).toBeVisible();
+
+  await composer.pressSequentially(" then /release");
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("composer-skill-chip")).toHaveCount(2);
+
+  await page.getByTestId("composer-skill-chip").filter({ hasText: "pdf" }).click();
+  await expect(page.getByText("SKILL.md", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Inspect the supplied PDF and ground every claim in its contents."),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Send" }).click();
+
+  await expect(page.getByTestId("transcript-skill-chip")).toHaveCount(2);
+  await expect(
+    page.getByText(/\[skills=pdf,release-notes\]$/),
+  ).toBeVisible();
+
+  await page
+    .getByTestId("transcript-skill-chip")
+    .filter({ hasText: "release-notes" })
+    .click();
+  await expect(
+    page.getByText("Write concise release notes for the completed work."),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Hide side panel" }).click();
+  await page
+    .getByTestId("transcript-skill-chip")
+    .filter({ hasText: "pdf" })
+    .click();
+  await expect(
+    page.getByText("Inspect the supplied PDF and ground every claim in its contents."),
+  ).toBeVisible();
+});
+
+test("a slash selection replaces only the token at the caret", async ({ page }) => {
+  await page.goto("/");
+  const composer = page.getByPlaceholder(/Ask the coworker/);
+  await composer.fill("Before / after");
+  for (let i = 0; i < " after".length; i += 1) {
+    await composer.press("ArrowLeft");
+  }
+
+  await expect(page.getByRole("listbox", { name: "Skills" })).toBeVisible();
+  await page.keyboard.press("Enter");
+
+  const chip = page.getByTestId("composer-skill-chip").filter({ hasText: "pdf" });
+  await expect(chip).toBeVisible();
+  const draftText = (await composer.innerText()).replace(/\s+/g, " ");
+  expect(draftText.indexOf("Before")).toBeLessThan(draftText.indexOf("pdf"));
+  expect(draftText.indexOf("pdf")).toBeLessThan(draftText.indexOf("after"));
+});
+
+test("chooser keyboard navigation, Tab selection, atomic deletion, and Escape", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const composer = page.getByPlaceholder(/Ask the coworker/);
+  const chooser = page.getByRole("listbox", { name: "Skills" });
+
+  await composer.fill("/");
+  await expect(chooser).toBeVisible();
+  await page.keyboard.press("ArrowDown");
+  await expect(
+    chooser.getByRole("option", { name: /release-notes/i }),
+  ).toHaveAttribute("aria-selected", "true");
+  await page.keyboard.press("Tab");
+  await expect(
+    page.getByTestId("composer-skill-chip").filter({ hasText: "release-notes" }),
+  ).toBeVisible();
+
+  await composer.press("Backspace");
+  await composer.press("Backspace");
+  await expect(page.getByTestId("composer-skill-chip")).toHaveCount(0);
+
+  await composer.pressSequentially("/");
+  await expect(chooser).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(chooser).toBeHidden();
+});
+
+test("duplicate names remain disambiguated by source and exact path", async ({ page }) => {
+  await page.goto("/");
+  const composer = page.getByPlaceholder(/Ask the coworker/);
+  await composer.fill("/pdf");
+
+  const options = page
+    .getByRole("listbox", { name: "Skills" })
+    .getByRole("option", { name: /pdf/i });
+  await expect(options).toHaveCount(2);
+  await expect(options.nth(0)).toContainText("shared");
+  await expect(options.nth(1)).toContainText("project");
+
+  await options.filter({ hasText: "Project-specific PDF workflow" }).click();
+  const chip = page.getByTestId("composer-skill-chip").filter({ hasText: "pdf" });
+  await expect(chip).toHaveAttribute(
+    "title",
+    /launch-note\/\.coworker\/skills\/pdf\/SKILL\.md/,
+  );
+  await chip.click();
+  await expect(
+    page.getByText("Use the launch-note project's exact PDF workflow."),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByTestId("transcript-skill-chip")).toHaveCount(1);
+  await expect(page.getByText(/\[skills=pdf\]$/)).toBeVisible();
+});

--- a/surfaces/gui/package-lock.json
+++ b/surfaces/gui/package-lock.json
@@ -8,6 +8,8 @@
       "name": "openworker-gui",
       "version": "0.0.0",
       "dependencies": {
+        "@lexical/react": "^0.38.2",
+        "lexical": "^0.38.2",
         "pdfjs-dist": "^4.10.38",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -865,6 +867,59 @@
         "node": ">=12"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.20",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.20.tgz",
+      "integrity": "sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -913,6 +968,281 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lexical/clipboard": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.38.2.tgz",
+      "integrity": "sha512-dDShUplCu8/o6BB9ousr3uFZ9bltR+HtleF/Tl8FXFNPpZ4AXhbLKUoJuucRuIr+zqT7RxEv/3M6pk/HEoE6NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/html": "0.38.2",
+        "@lexical/list": "0.38.2",
+        "@lexical/selection": "0.38.2",
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/code": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.38.2.tgz",
+      "integrity": "sha512-wpqgbmPsfi/+8SYP0zI2kml09fGPRhzO5litR9DIbbSGvcbawMbRNcKLO81DaTbsJRnBJiQvbBBBJAwZKRqgBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2",
+        "prismjs": "^1.30.0"
+      }
+    },
+    "node_modules/@lexical/devtools-core": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.38.2.tgz",
+      "integrity": "sha512-hlN0q7taHNzG47xKynQLCAFEPOL8l6IP79C2M18/FE1+htqNP35q4rWhYhsptGlKo4me4PtiME7mskvr7T4yqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/html": "0.38.2",
+        "@lexical/link": "0.38.2",
+        "@lexical/mark": "0.38.2",
+        "@lexical/table": "0.38.2",
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2"
+      },
+      "peerDependencies": {
+        "react": ">=17.x",
+        "react-dom": ">=17.x"
+      }
+    },
+    "node_modules/@lexical/dragon": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.38.2.tgz",
+      "integrity": "sha512-riOhgo+l4oN50RnLGhcqeUokVlMZRc+NDrxRNs2lyKSUdC4vAhAmAVUHDqYPyb4K4ZSw4ebZ3j8hI2zO4O3BbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/extension": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.38.2.tgz",
+      "integrity": "sha512-qbUNxEVjAC0kxp7hEMTzktj0/51SyJoIJWK6Gm790b4yNBq82fEPkksfuLkRg9VQUteD0RT1Nkjy8pho8nNamw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.38.2",
+        "@preact/signals-core": "^1.11.0",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/hashtag": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.38.2.tgz",
+      "integrity": "sha512-jNI4Pv+plth39bjOeeQegMypkjDmoMWBMZtV0lCynBpkkPFlfMnyL9uzW/IxkZnX8LXWSw5mbWk07nqOUNTCrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/text": "0.38.2",
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/history": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.38.2.tgz",
+      "integrity": "sha512-QWPwoVDMe/oJ0+TFhy78TDi7TWU/8bcDRFUNk1nWgbq7+2m+5MMoj90LmOFwakQHnCVovgba2qj+atZrab1dsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.38.2",
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/html": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.38.2.tgz",
+      "integrity": "sha512-pC5AV+07bmHistRwgG3NJzBMlIzSdxYO6rJU4eBNzyR4becdiLsI4iuv+aY7PhfSv+SCs7QJ9oc4i5caq48Pkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.38.2",
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/link": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.38.2.tgz",
+      "integrity": "sha512-UOKTyYqrdCR9+7GmH6ZVqJTmqYefKGMUHMGljyGks+OjOGZAQs78S1QgcPEqltDy+SSdPSYK7wAo6gjxZfEq9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.38.2",
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/list": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.38.2.tgz",
+      "integrity": "sha512-OQm9TzatlMrDZGxMxbozZEHzMJhKxAbH1TOnOGyFfzpfjbnFK2y8oLeVsfQZfZRmiqQS4Qc/rpFnRP2Ax5dsbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.38.2",
+        "@lexical/selection": "0.38.2",
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/mark": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.38.2.tgz",
+      "integrity": "sha512-U+8KGwc3cP5DxSs15HfkP2YZJDs5wMbWQAwpGqep9bKphgxUgjPViKhdi+PxIt2QEzk7WcoZWUsK1d2ty/vSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/markdown": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.38.2.tgz",
+      "integrity": "sha512-ykQJ9KUpCs1+Ak6ZhQMP6Slai4/CxfLEGg/rSHNVGbcd7OaH/ICtZN5jOmIe9ExfXMWy1o8PyMu+oAM3+AWFgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/code": "0.38.2",
+        "@lexical/link": "0.38.2",
+        "@lexical/list": "0.38.2",
+        "@lexical/rich-text": "0.38.2",
+        "@lexical/text": "0.38.2",
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/offset": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.38.2.tgz",
+      "integrity": "sha512-uDky2palcY+gE6WTv6q2umm2ioTUnVqcaWlEcchP6A310rI08n6rbpmkaLSIh3mT2GJQN2QcN2x0ct5BQmKIpA==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/overflow": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.38.2.tgz",
+      "integrity": "sha512-f6vkTf+YZF0EuKvUK3goh4jrnF+Z0koiNMO+7rhSMLooc5IlD/4XXix4ZLiIktUWq4BhO84b82qtrO+6oPUxtw==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/plain-text": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.38.2.tgz",
+      "integrity": "sha512-xRYNHJJFCbaQgr0uErW8Im2Phv1nWHIT4VSoAlBYqLuVGZBD4p61dqheBwqXWlGGJFk+MY5C5URLiMicgpol7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.38.2",
+        "@lexical/dragon": "0.38.2",
+        "@lexical/selection": "0.38.2",
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/react": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.38.2.tgz",
+      "integrity": "sha512-M3z3MkWyw3Msg4Hojr5TnO4TzL71NVPVNGoavESjdgJbTdv1ezcQqjE4feq+qs7H9jytZeuK8wsEOJfSPmNd8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.16",
+        "@lexical/devtools-core": "0.38.2",
+        "@lexical/dragon": "0.38.2",
+        "@lexical/extension": "0.38.2",
+        "@lexical/hashtag": "0.38.2",
+        "@lexical/history": "0.38.2",
+        "@lexical/link": "0.38.2",
+        "@lexical/list": "0.38.2",
+        "@lexical/mark": "0.38.2",
+        "@lexical/markdown": "0.38.2",
+        "@lexical/overflow": "0.38.2",
+        "@lexical/plain-text": "0.38.2",
+        "@lexical/rich-text": "0.38.2",
+        "@lexical/table": "0.38.2",
+        "@lexical/text": "0.38.2",
+        "@lexical/utils": "0.38.2",
+        "@lexical/yjs": "0.38.2",
+        "lexical": "0.38.2",
+        "react-error-boundary": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.x",
+        "react-dom": ">=17.x"
+      }
+    },
+    "node_modules/@lexical/rich-text": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.38.2.tgz",
+      "integrity": "sha512-eFjeOT7YnDZYpty7Zlwlct0UxUSaYu53uLYG+Prs3NoKzsfEK7e7nYsy/BbQFfk5HoM1pYuYxFR2iIX62+YHGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.38.2",
+        "@lexical/dragon": "0.38.2",
+        "@lexical/selection": "0.38.2",
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/selection": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.38.2.tgz",
+      "integrity": "sha512-eMFiWlBH6bEX9U9sMJ6PXPxVXTrihQfFeiIlWLuTpEIDF2HRz7Uo1KFRC/yN6q0DQaj7d9NZYA6Mei5DoQuz5w==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/table": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.38.2.tgz",
+      "integrity": "sha512-uu0i7yz0nbClmHOO5ZFsinRJE6vQnFz2YPblYHAlNigiBedhqMwSv5bedrzDq8nTTHwych3mC63tcyKIrM+I1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.38.2",
+        "@lexical/extension": "0.38.2",
+        "@lexical/utils": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/text": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.38.2.tgz",
+      "integrity": "sha512-+juZxUugtC4T37aE3P0l4I9tsWbogDUnTI/mgYk4Ht9g+gLJnhQkzSA8chIyfTxbj5i0A8yWrUUSw+/xA7lKUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/utils": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.38.2.tgz",
+      "integrity": "sha512-y+3rw15r4oAWIEXicUdNjfk8018dbKl7dWHqGHVEtqzAYefnEYdfD2FJ5KOTXfeoYfxi8yOW7FvzS4NZDi8Bfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/list": "0.38.2",
+        "@lexical/selection": "0.38.2",
+        "@lexical/table": "0.38.2",
+        "lexical": "0.38.2"
+      }
+    },
+    "node_modules/@lexical/yjs": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.38.2.tgz",
+      "integrity": "sha512-fg6ZHNrVQmy1AAxaTs8HrFbeNTJCaCoEDPi6pqypHQU3QVfqr4nq0L0EcHU/TRlR1CeduEPvZZIjUUxWTZ0u8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/offset": "0.38.2",
+        "@lexical/selection": "0.38.2",
+        "lexical": "0.38.2"
+      },
+      "peerDependencies": {
+        "yjs": ">=13.5.22"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -1217,6 +1547,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3386,6 +3726,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -3467,6 +3818,34 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lexical": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.38.2.tgz",
+      "integrity": "sha512-JJmfsG3c4gwBHzUGffbV7ifMNkKAWMCnYE3xJl87gty7hjyV5f3xq7eqTjP5HFYvO4XpjJvvWO2/djHp5S10tw==",
+      "license": "MIT"
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lilconfig": {
@@ -4871,6 +5250,15 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
@@ -4935,6 +5323,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.2.tgz",
+      "integrity": "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-is": {
@@ -5363,6 +5760,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
@@ -6082,6 +6485,24 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yjs": {
+      "version": "13.6.31",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
+      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/surfaces/gui/package.json
+++ b/surfaces/gui/package.json
@@ -14,6 +14,8 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@lexical/react": "^0.38.2",
+    "lexical": "^0.38.2",
     "pdfjs-dist": "^4.10.38",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -32,6 +32,7 @@ import type {
   ApprovalDecision,
   Attachment,
   Item,
+  PromptPart,
   SessionInfo,
   SessionUsage,
   TodoItem,
@@ -65,6 +66,7 @@ import { ApprovalCard } from "./components/ApprovalCard";
 import { DirectoryRequestCard } from "./components/DirectoryRequestCard";
 import { PlanCard } from "./components/PlanCard";
 import { WorkspaceTrustPrompt } from "./components/WorkspaceTrustPrompt";
+import { OPEN_SKILL_EVENT } from "./skillEvents";
 
 const newId = () =>
   (crypto as any).randomUUID ? crypto.randomUUID().slice(0, 12) : Math.random().toString(36).slice(2, 14);
@@ -237,6 +239,7 @@ export function App() {
   };
   const [browserRefreshKey, setBrowserRefreshKey] = useState(0);
   const [railHidden, setRailHidden] = useState(false);
+  const [skillRailOpen, setSkillRailOpen] = useState(false);
   // Left-nav collapse (⌘B): when collapsed the sidebar leaves the grid so content reclaims the
   // width; hovering the left edge peeks it back as a floating overlay. Persisted per-device.
   const [navCollapsed, setNavCollapsed] = useState<boolean>(() => {
@@ -258,6 +261,7 @@ export function App() {
   // #3: collapse the nav while a full artifact preview is open, restore it on close (unless the
   // user manually toggled meanwhile). The collapse is transient — it never overwrites the pref.
   const onArtifactPreview = useCallback((open: boolean) => {
+    if (!open) setSkillRailOpen(false);
     if (open) {
       if (navBeforePreview.current === null) navBeforePreview.current = navCollapsed;
       setNavPeek(false);
@@ -292,12 +296,20 @@ export function App() {
     setRailHidden(false);
     setAccessKey((k) => k + 1);
   };
-  // §34 (UX-016): clicking an artifact chip in the transcript must land somewhere visible —
-  // RightRail opens the viewer; this just makes sure the rail isn't hidden.
+  // Clicking an artifact or skill chip must land somewhere visible — RightRail opens the
+  // matching viewer; this just makes sure the rail isn't hidden.
   useEffect(() => {
-    const show = () => setRailHidden(false);
-    window.addEventListener("ocw-open-artifact", show);
-    return () => window.removeEventListener("ocw-open-artifact", show);
+    const showArtifact = () => setRailHidden(false);
+    const showSkill = () => {
+      setSkillRailOpen(true);
+      setRailHidden(false);
+    };
+    window.addEventListener("ocw-open-artifact", showArtifact);
+    window.addEventListener(OPEN_SKILL_EVENT, showSkill);
+    return () => {
+      window.removeEventListener("ocw-open-artifact", showArtifact);
+      window.removeEventListener(OPEN_SKILL_EVENT, showSkill);
+    };
   }, []);
   // The command-palette search, openable from the collapsed-sidebar topbar cluster (§22). The
   // expanded sidebar owns its own instance; this one exists so search never disappears with it.
@@ -602,11 +614,22 @@ export function App() {
                 : [...p, { kind: "connector", source: src }];
             });
           } else if (typeof d.input === "string" && d.input) {
+            const parts = Array.isArray(d.skill_parts)
+              ? (d.skill_parts as PromptPart[])
+              : undefined;
             setItems((p) => {
               const last = p[p.length - 1];
               return last && last.kind === "user" && last.text === d.input
                 ? p
-                : [...p, { kind: "user", text: d.input as string, ts: Date.now() / 1000 }];
+                : [
+                    ...p,
+                    {
+                      kind: "user",
+                      text: d.input as string,
+                      ...(parts ? { parts } : {}),
+                      ts: Date.now() / 1000,
+                    },
+                  ];
             });
           }
           break;
@@ -842,10 +865,19 @@ export function App() {
     return () => clearInterval(t);
   }, [surface, sessionId, browserRefreshKey, markUnattended]);
 
-  const send = (text: string, attachments?: Attachment[]) => {
-    setItems((p) => [...p, { kind: "user", text, attachments, ts: Date.now() / 1000 }]);
+  const send = (text: string, attachments?: Attachment[], parts?: PromptPart[]) => {
+    setItems((p) => [
+      ...p,
+      {
+        kind: "user",
+        text,
+        attachments,
+        ...(parts?.some((part) => part.type === "skill") ? { parts } : {}),
+        ts: Date.now() / 1000,
+      },
+    ]);
     // The visible model rides along with the message (single source of truth per turn).
-    sessionRef.current?.userMessage(text, attachments, model);
+    sessionRef.current?.userMessage(text, attachments, model, parts);
     followLatest(); // sending always re-engages stream-following, wherever the user had scrolled
   };
   // Resolving a LIVE prompt also resolves its parked Inbox mirror server-side, but the polled
@@ -1344,7 +1376,7 @@ export function App() {
           onOpenIntegrations={() => setSurface("integrations")}
         />
       ) : (
-      <div className={"main" + (surface === "session" && agent !== "chat" && !railHidden ? " rail-open" : "")}>
+      <div className={"main" + (surface === "session" && (agent !== "chat" || skillRailOpen) && !railHidden ? " rail-open" : "")}>
         <div className="main-topbar">
           {/* Left: the contextual cluster — [sidebar] [+ new session] [search] — rendered ONLY
               while the sidebar is collapsed (§22; the expanded sidebar already owns those
@@ -1421,7 +1453,7 @@ export function App() {
             )}
             {/* §32: the panel toggle is the ONE session-panel entry, for every non-chat persona
                 (the rail now carries Access, so code-family gets it too). */}
-            {agent !== "chat" && (
+            {(agent !== "chat" || skillRailOpen) && (
               <button
                 className="topbar-icon-btn"
                 onMouseDown={(e) => e.stopPropagation()}
@@ -1613,7 +1645,7 @@ export function App() {
             />
                   </div>
           <RightRail
-            active={surface === "session" && agent !== "chat" && !railHidden}
+            active={surface === "session" && (agent !== "chat" || skillRailOpen) && !railHidden}
             sessionId={sessionId}
             refreshKey={browserRefreshKey}
             toolNames={items.filter((i) => i.kind === "tool").map((i: any) => i.name)}

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -1,4 +1,4 @@
-import type { SessionInfo, WsEvent } from "./types";
+import type { PromptPart, SessionInfo, SkillRef, WsEvent } from "./types";
 
 declare const __COWORKER_DEV_TOKEN__: string;
 
@@ -150,6 +150,28 @@ export interface ConversationMessage {
 export async function getSessionMessages(sessionId: string): Promise<ConversationMessage[]> {
   const res = await fetch(`${httpBase()}/v1/sessions/${sessionId}/messages`);
   return (await res.json()).messages ?? [];
+}
+
+export type SkillInfo = SkillRef;
+
+export interface SkillContent extends SkillInfo {
+  content: string;
+}
+
+export async function getSkills(workspace?: string): Promise<SkillInfo[]> {
+  const q = new URLSearchParams();
+  if (workspace) q.set("workspace", workspace);
+  const res = await fetch(`${httpBase()}/v1/skills${q.size ? `?${q.toString()}` : ""}`);
+  return (await res.json()).skills ?? [];
+}
+
+export async function readSkill(path: string, workspace?: string): Promise<SkillContent> {
+  const q = new URLSearchParams({ path });
+  if (workspace) q.set("workspace", workspace);
+  const res = await fetch(`${httpBase()}/v1/skills/read?${q.toString()}`);
+  const body = await res.json();
+  if (!res.ok) throw new Error(body.error || "Skill not found");
+  return body;
 }
 
 export async function renameSession(sessionId: string, title: string): Promise<{ ok: boolean; error?: string }> {
@@ -1807,12 +1829,18 @@ export class Session {
    * exactly what the user sees — immune to set_model races across reconnects (a new cowork
    * session always reconnects once to adopt its scratch dir, which could drop a queued
    * set_model and leave the engine on a stale/resumed model; found 2026-07-04). */
-  userMessage(text: string, attachments?: unknown[], model?: string) {
+  userMessage(
+    text: string,
+    attachments?: unknown[],
+    model?: string,
+    parts?: PromptPart[],
+  ) {
     this.send({
       type: "user_message",
       text,
       ...(model ? { model } : {}),
       ...(attachments?.length ? { attachments } : {}),
+      ...(parts?.some((part) => part.type === "skill") ? { parts } : {}),
     });
   }
 

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -1,11 +1,15 @@
-import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
-import type { Attachment, SessionUsage } from "../types";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import type { Attachment, PromptPart, SessionUsage, SkillRef } from "../types";
 import { isPdfFile, readFile } from "../attach";
-import { getSettings, inspectPdf } from "../api";
+import { getSettings, getSkills, inspectPdf } from "../api";
 import { formatTokens, totalTokens } from "../usage";
 import { Dropdown, type Option } from "./Dropdown";
 import { Icon } from "./Icon";
 import { Toggle } from "./Toggle";
+import {
+  SkillPromptEditor,
+  type SkillPromptEditorHandle,
+} from "./SkillPromptEditor";
 import {
   cancelDictation,
   getDictationLevel,
@@ -59,7 +63,7 @@ interface Props {
   modelReady?: boolean;
   onConnectModel?: () => void;
   onConfigureVoiceInput?: () => void;
-  onSend: (text: string, attachments?: Attachment[]) => void;
+  onSend: (text: string, attachments?: Attachment[], parts?: PromptPart[]) => void;
   onInterrupt: () => void;
   onModeChange: (mode: string) => void;
   onModelChange: (model: string) => void;
@@ -88,6 +92,8 @@ interface Props {
 
 export function Composer(props: Props) {
   const [text, setText] = useState("");
+  const [promptParts, setPromptParts] = useState<PromptPart[]>([]);
+  const [skills, setSkills] = useState<SkillRef[]>([]);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [dragging, setDragging] = useState(false);
   const [attachMenuOpen, setAttachMenuOpen] = useState(false);
@@ -97,7 +103,7 @@ export function Composer(props: Props) {
   const [recordingSeconds, setRecordingSeconds] = useState(0);
   const [attachNotice, setAttachNotice] = useState<string | null>(null);
   const fileInput = useRef<HTMLInputElement | null>(null);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const editorRef = useRef<SkillPromptEditorHandle | null>(null);
   const noticeTimer = useRef<number | null>(null);
 
   // Rejected-attachment notice: visible ~8s, then clears (or on ✕).
@@ -107,15 +113,15 @@ export function Composer(props: Props) {
     noticeTimer.current = window.setTimeout(() => setAttachNotice(null), 8000);
   };
 
-  useLayoutEffect(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    const max = parseFloat(getComputedStyle(el).lineHeight || "22") * 4;
-    const next = Math.min(el.scrollHeight, max);
-    el.style.height = `${Math.max(next, 24)}px`;
-    el.style.overflowY = el.scrollHeight > max ? "auto" : "hidden";
-  }, [text]);
+  useEffect(() => {
+    let active = true;
+    getSkills(props.workspace)
+      .then((catalog) => active && setSkills(catalog))
+      .catch(() => active && setSkills([]));
+    return () => {
+      active = false;
+    };
+  }, [props.workspace]);
 
   // Apply a prefill (text + attachments) pushed from outside, then focus the composer. Applied at
   // most once per nonce (a ref guards against StrictMode/re-render double-fires), and attachments
@@ -125,16 +131,18 @@ export function Composer(props: Props) {
     const p = props.prefill;
     if (!p || p.nonce === appliedNonce.current) return;
     appliedNonce.current = p.nonce;
-    setText(p.text);
+    editorRef.current?.setText(p.text);
     if (p.attachments?.length) setAttachments((cur) => mergeAttachments(cur, p.attachments!));
-    textareaRef.current?.focus();
+    editorRef.current?.focus();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.prefill?.nonce]);
 
   // Clear the draft when the conversation changes, so a half-typed message / picked file doesn't
   // bleed from one session into another.
   useEffect(() => {
+    editorRef.current?.clear();
     setText("");
+    setPromptParts([]);
     setAttachments([]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.resetKey]);
@@ -269,19 +277,14 @@ export function Composer(props: Props) {
       props.onConnectModel?.();
       return;
     }
-    props.onSend(t, attachments);
+    props.onSend(t, attachments, promptParts);
+    editorRef.current?.clear();
     setText("");
+    setPromptParts([]);
     setAttachments([]);
   };
 
-  const onKey = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      submit();
-    }
-  };
-
-  const onPaste = (e: React.ClipboardEvent) => {
+  const onPaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
     const imgs = Array.from(e.clipboardData.items)
       .filter((it) => it.kind === "file" && it.type.startsWith("image/"))
       .map((it) => it.getAsFile())
@@ -301,10 +304,11 @@ export function Composer(props: Props) {
         const transcript = await stopDictation();
         if (transcript === null) throw new Error("Could not transcribe your recording.");
         if (transcript.trim()) {
-          setText((draft) => (draft.trim() ? `${draft.trimEnd()} ${transcript.trim()}` : transcript.trim()));
+          const addition = text.trim() ? ` ${transcript.trim()}` : transcript.trim();
+          editorRef.current?.appendText(addition);
         }
         setDictation(await getDictationStatus());
-        textareaRef.current?.focus();
+        editorRef.current?.focus();
         return;
       }
 
@@ -394,15 +398,16 @@ export function Composer(props: Props) {
           if (e.dataTransfer.files.length) addFiles(e.dataTransfer.files);
         }}
       >
-        <textarea
-          ref={textareaRef}
-          className="w-full block px-3.5 pt-3.5 pb-1.5 text-[14.5px]"
+        <SkillPromptEditor
+          ref={editorRef}
           placeholder={props.placeholder || "Ask the coworker…  (drop or paste files)"}
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          onKeyDown={onKey}
+          skills={skills}
+          onChange={(draft) => {
+            setText(draft.text);
+            setPromptParts(draft.parts);
+          }}
+          onSubmit={submit}
           onPaste={onPaste}
-          rows={1}
         />
 
         {/* Three-control row (§22): + attach · Mode ⌄ …(right)… model (fresh only) · send */}

--- a/surfaces/gui/src/components/Composer.voice.test.tsx
+++ b/surfaces/gui/src/components/Composer.voice.test.tsx
@@ -84,8 +84,8 @@ describe("Composer voice input (§37)", () => {
     });
     fireEvent.click(stop);
     await screen.findByLabelText("Start dictation"); // recording UI wound down
-    const box = screen.getByPlaceholderText(/Ask the coworker/) as HTMLTextAreaElement;
-    expect(box.value).toBe("hello from the mic"); // a DRAFT — nothing auto-sent
+    const box = screen.getByPlaceholderText(/Ask the coworker/);
+    expect(box.textContent).toBe("hello from the mic"); // a DRAFT — nothing auto-sent
     expect(document.querySelector(".voice-wave-bars")).toBeNull();
   });
 

--- a/surfaces/gui/src/components/RightRail.tsx
+++ b/surfaces/gui/src/components/RightRail.tsx
@@ -4,14 +4,17 @@ import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 import {
   getArtifacts,
   readArtifact,
+  readSkill,
   revealArtifact,
   type ArtifactContent,
   type ArtifactInfo,
+  type SkillInfo,
 } from "../api";
 import type { TodoItem } from "../types";
 import { AccessSection } from "./AccessSection";
 import { Icon } from "./Icon";
 import { Markdown, OPEN_ARTIFACT_EVENT } from "./Markdown";
+import { OPEN_SKILL_EVENT } from "../skillEvents";
 
 type Panel = "progress" | "artifacts";
 
@@ -82,6 +85,7 @@ export function RightRail({
   });
   const [artifacts, setArtifacts] = useState<ArtifactInfo[]>([]);
   const [selected, setSelected] = useState<ArtifactInfo | null>(null);
+  const [selectedSkill, setSelectedSkill] = useState<SkillInfo | null>(null);
   const [content, setContent] = useState<ArtifactContent | null>(null);
 
   const refreshArtifacts = () => getArtifacts(sessionId).then(setArtifacts).catch(() => setArtifacts([]));
@@ -95,21 +99,58 @@ export function RightRail({
   // workspace, which the new session can't (and shouldn't) read.
   useEffect(() => {
     setSelected(null);
+    setSelectedSkill(null);
     setContent(null);
   }, [sessionId]);
 
   useEffect(() => {
+    if (selectedSkill) return;
     setContent(null);
     if (!selected) return;
     readArtifact(sessionId, selected.path).then(setContent).catch(() => setContent(null));
-  }, [selected?.path, sessionId]);
+  }, [selected?.path, selectedSkill, sessionId]);
+
+  useEffect(() => {
+    if (!selectedSkill) return;
+    setContent(null);
+    readSkill(selectedSkill.path, workspace)
+      .then((skill) =>
+        setContent({
+          ok: true,
+          path: skill.path,
+          kind: "markdown",
+          content: skill.content,
+        }),
+      )
+      .catch((error) =>
+        setContent({
+          ok: false,
+          path: selectedSkill.path,
+          kind: "markdown",
+          error: error instanceof Error ? error.message : "Skill not found",
+        }),
+      );
+  }, [selectedSkill?.path, workspace]);
 
   // Notify the app when a preview opens/closes (drives the left-nav auto-collapse).
   useEffect(() => {
-    onPreviewChange?.(!!selected);
-  }, [!!selected, onPreviewChange]);
+    onPreviewChange?.(!!selected || !!selectedSkill);
+  }, [!!selected, !!selectedSkill, onPreviewChange]);
 
   const reloadSelected = () => {
+    if (selectedSkill) {
+      setContent(null);
+      return readSkill(selectedSkill.path, workspace)
+        .then((skill) =>
+          setContent({
+            ok: true,
+            path: skill.path,
+            kind: "markdown",
+            content: skill.content,
+          }),
+        )
+        .catch(() => setContent(null));
+    }
     if (!selected) return Promise.resolve();
     setContent(null);
     return readArtifact(sessionId, selected.path).then(setContent).catch(() => setContent(null));
@@ -119,7 +160,6 @@ export function RightRail({
   // Resolve against the loaded list first; on a miss, refresh once (the file may be
   // seconds old), then fall back to a minimal record — readArtifact validates the path.
   useEffect(() => {
-    if (!active) return;
     const minimal = (path: string): ArtifactInfo => ({
       path,
       name: path.split("/").pop() || path,
@@ -132,6 +172,7 @@ export function RightRail({
     const onOpen = (e: Event) => {
       const path = String((e as CustomEvent).detail?.path || "");
       if (!path) return;
+      setSelectedSkill(null);
       const found = match(artifacts, path);
       if (found) {
         setSelected(found);
@@ -146,19 +187,44 @@ export function RightRail({
     };
     window.addEventListener(OPEN_ARTIFACT_EVENT, onOpen);
     return () => window.removeEventListener(OPEN_ARTIFACT_EVENT, onOpen);
-  }, [active, sessionId, artifacts]);
+  }, [sessionId, artifacts]);
+
+  useEffect(() => {
+    const onOpen = (event: Event) => {
+      const detail = (event as CustomEvent<SkillInfo>).detail;
+      if (!detail?.path || !detail?.name) return;
+      setSelected(null);
+      setSelectedSkill(detail);
+    };
+    window.addEventListener(OPEN_SKILL_EVENT, onOpen);
+    return () => window.removeEventListener(OPEN_SKILL_EVENT, onOpen);
+  }, []);
 
   if (!active) return null;
 
   return (
-    <aside className={"right-rail" + (selected ? " artifact-mode" : "")}>
-      {selected ? (
+    <aside className={"right-rail" + (selected || selectedSkill ? " artifact-mode" : "")}>
+      {selected || selectedSkill ? (
         <ArtifactViewer
           sessionId={sessionId}
-          artifact={selected}
+          artifact={
+            selected ||
+            {
+              path: selectedSkill!.path,
+              abs_path: selectedSkill!.path,
+              name: "SKILL.md",
+              kind: "markdown",
+              size: 0,
+              modified_at: 0,
+            }
+          }
+          isSkill={!!selectedSkill}
           content={content}
           onReload={reloadSelected}
-          onBack={() => setSelected(null)}
+          onBack={() => {
+            setSelected(null);
+            setSelectedSkill(null);
+          }}
         />
       ) : (
         <>
@@ -291,12 +357,14 @@ function ArtifactViewer({
   content,
   onReload,
   onBack,
+  isSkill = false,
 }: {
   sessionId: string;
   artifact: ArtifactInfo;
   content: ArtifactContent | null;
   onReload: () => Promise<void>;
   onBack: () => void;
+  isSkill?: boolean;
 }) {
   const [reloadKey, setReloadKey] = useState(0);
   const isHtml = content?.kind === "html" && !content.error;
@@ -306,11 +374,16 @@ function ArtifactViewer({
   return (
     <div className="artifact-viewer">
       <div className="artifact-head">
-        <button className="artifact-icon-btn" onClick={onBack} aria-label="Back to artifacts" title="Back">
+        <button
+          className="artifact-icon-btn"
+          onClick={onBack}
+          aria-label={isSkill ? "Back to skills" : "Back to artifacts"}
+          title="Back"
+        >
           <Icon name="arrowLeft" size={16} />
         </button>
         <div className="artifact-heading">
-          <div className="artifact-title"><span>Artifacts</span><span className="artifact-sep">/</span><span>{artifact.name}</span></div>
+          <div className="artifact-title"><span>{isSkill ? "Skills" : "Artifacts"}</span><span className="artifact-sep">/</span><span>{artifact.name}</span></div>
           <div className="artifact-path">{artifact.path}</div>
         </div>
         <div className="rail-actions">
@@ -327,7 +400,7 @@ function ArtifactViewer({
               <Icon name="refresh" size={16} />
             </button>
           )}
-          {isApp && (
+          {!isSkill && isApp && (
             <button
               className="artifact-icon-btn"
               onClick={() => revealArtifact(sessionId, artifact.path, "open")}
@@ -347,14 +420,16 @@ function ArtifactViewer({
           >
             <Icon name="copy" size={16} />
           </button>
-          <button
-            className="artifact-icon-btn"
-            onClick={() => revealArtifact(sessionId, artifact.path, "reveal")}
-            aria-label="Show in folder"
-            title="Show in folder"
-          >
-            <Icon name="folder" size={16} />
-          </button>
+          {!isSkill && (
+            <button
+              className="artifact-icon-btn"
+              onClick={() => revealArtifact(sessionId, artifact.path, "reveal")}
+              aria-label="Show in folder"
+              title="Show in folder"
+            >
+              <Icon name="folder" size={16} />
+            </button>
+          )}
         </div>
       </div>
       <div className="artifact-preview">

--- a/surfaces/gui/src/components/SkillPromptEditor.tsx
+++ b/surfaces/gui/src/components/SkillPromptEditor.tsx
@@ -304,7 +304,7 @@ function SkillChooser({
     <div
       role="listbox"
       aria-label="Skills"
-      className="absolute z-50 left-2 right-2 top-full mt-1 max-h-72 overflow-auto rounded-xl border border-line bg-panel p-1.5 shadow-2xl"
+      className="absolute z-50 bottom-full left-2 right-2 mb-1 max-h-72 overflow-auto rounded-xl border border-line bg-panel p-1.5 shadow-2xl"
     >
       {matches.map((skill, index) => (
         <button

--- a/surfaces/gui/src/components/SkillPromptEditor.tsx
+++ b/surfaces/gui/src/components/SkillPromptEditor.tsx
@@ -1,0 +1,437 @@
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $getNodeByKey,
+  $isElementNode,
+  $isRangeSelection,
+  $isTextNode,
+  COMMAND_PRIORITY_HIGH,
+  COMMAND_PRIORITY_LOW,
+  DecoratorNode,
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ARROW_UP_COMMAND,
+  KEY_ENTER_COMMAND,
+  KEY_ESCAPE_COMMAND,
+  KEY_TAB_COMMAND,
+  SELECTION_CHANGE_COMMAND,
+  type EditorConfig,
+  type LexicalEditor,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread,
+} from "lexical";
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
+import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
+import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { openSkill } from "../skillEvents";
+import type { PromptPart, SkillRef } from "../types";
+import { Icon } from "./Icon";
+
+type SerializedSkillNode = Spread<
+  { type: "skill"; version: 1; skill: SkillRef },
+  SerializedLexicalNode
+>;
+
+class SkillNode extends DecoratorNode<JSX.Element> {
+  __skill: SkillRef;
+
+  static getType() {
+    return "skill";
+  }
+
+  static clone(node: SkillNode) {
+    return new SkillNode(node.__skill, node.__key);
+  }
+
+  static importJSON(serialized: SerializedSkillNode) {
+    return new SkillNode(serialized.skill);
+  }
+
+  constructor(skill: SkillRef, key?: NodeKey) {
+    super(key);
+    this.__skill = skill;
+  }
+
+  createDOM(_config: EditorConfig) {
+    const span = document.createElement("span");
+    span.className = "inline";
+    return span;
+  }
+
+  updateDOM() {
+    return false;
+  }
+
+  isInline() {
+    return true;
+  }
+
+  getTextContent() {
+    return `/${this.__skill.name}`;
+  }
+
+  exportJSON(): SerializedSkillNode {
+    return { ...super.exportJSON(), type: "skill", version: 1, skill: this.__skill };
+  }
+
+  decorate() {
+    return (
+      <button
+        type="button"
+        contentEditable={false}
+        data-testid="composer-skill-chip"
+        className="mx-0.5 inline-flex items-center gap-1 rounded-md bg-accentSoft px-1.5 py-0.5 text-[13px] font-medium text-accent hover:bg-accentSoft/70"
+        title={`${this.__skill.source || "skill"} · ${this.__skill.path}`}
+        onClick={() => openSkill(this.__skill)}
+      >
+        <Icon name="diamond" size={12} />
+        {this.__skill.name}
+      </button>
+    );
+  }
+}
+
+function $createSkillNode(skill: SkillRef) {
+  return new SkillNode(skill);
+}
+
+function pushText(parts: PromptPart[], text: string) {
+  if (!text) return;
+  const previous = parts[parts.length - 1];
+  if (previous?.type === "text") previous.text += text;
+  else parts.push({ type: "text", text });
+}
+
+function draftFromEditor(): { text: string; parts: PromptPart[] } {
+  const parts: PromptPart[] = [];
+  const visit = (node: LexicalNode) => {
+    if (node instanceof SkillNode) {
+      parts.push({ type: "skill", ...node.__skill });
+      return;
+    }
+    if ($isTextNode(node)) {
+      pushText(parts, node.getTextContent());
+      return;
+    }
+    if ($isElementNode(node)) node.getChildren().forEach(visit);
+    else pushText(parts, node.getTextContent());
+  };
+  const blocks = $getRoot().getChildren();
+  blocks.forEach((block, index) => {
+    if (index) pushText(parts, "\n");
+    visit(block);
+  });
+  return {
+    parts,
+    text: parts
+      .map((part) => (part.type === "text" ? part.text : `/${part.name}`))
+      .join(""),
+  };
+}
+
+type ActiveSlash = {
+  key: NodeKey;
+  start: number;
+  end: number;
+  query: string;
+};
+
+function activeSlash(): ActiveSlash | null {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return null;
+  const node = selection.anchor.getNode();
+  if (!$isTextNode(node)) return null;
+  const end = selection.anchor.offset;
+  const before = node.getTextContent().slice(0, end);
+  const match = before.match(/(?:^|\s)\/([^\s/]*)$/);
+  if (!match) return null;
+  const query = match[1] || "";
+  return { key: node.getKey(), start: end - query.length - 1, end, query };
+}
+
+function EditorCapture({ onReady }: { onReady: (editor: LexicalEditor) => void }) {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => onReady(editor), [editor, onReady]);
+  return null;
+}
+
+function SkillChooser({
+  skills,
+  onSubmit,
+}: {
+  skills: SkillRef[];
+  onSubmit: () => void;
+}) {
+  const [editor] = useLexicalComposerContext();
+  const [slash, setSlash] = useState<ActiveSlash | null>(null);
+  const [selected, setSelected] = useState(0);
+  const slashRef = useRef<ActiveSlash | null>(null);
+  const selectedRef = useRef(0);
+
+  const matches = useMemo(() => {
+    if (!slash) return [];
+    const query = slash.query.toLowerCase();
+    return skills
+      .filter((skill) =>
+        `${skill.name} ${skill.description || ""} ${skill.source || ""}`
+          .toLowerCase()
+          .includes(query),
+      )
+      .slice(0, 8);
+  }, [skills, slash]);
+  const matchesRef = useRef<SkillRef[]>([]);
+  useEffect(() => {
+    matchesRef.current = matches;
+    if (selected >= matches.length) {
+      selectedRef.current = 0;
+      setSelected(0);
+    }
+  }, [matches, selected]);
+  useEffect(() => {
+    slashRef.current = slash;
+  }, [slash]);
+
+  const choose = (skill: SkillRef) => {
+    const target = slashRef.current;
+    if (!target) return;
+    editor.update(() => {
+      const node = $getNodeByKey(target.key);
+      const selection = $getSelection();
+      if (!$isTextNode(node) || !$isRangeSelection(selection)) return;
+      selection.setTextNodeRange(node, target.start, node, target.end);
+      selection.removeText();
+      selection.insertNodes([$createSkillNode(skill), $createTextNode(" ")]);
+    });
+    setSlash(null);
+    editor.focus();
+  };
+
+  useEffect(
+    () => {
+      const updateSlash = () => {
+        const next = activeSlash();
+        setSlash(next);
+        if (!next) {
+          selectedRef.current = 0;
+          setSelected(0);
+        }
+      };
+      const unregisterUpdate = editor.registerUpdateListener(({ editorState }) => {
+        editorState.read(() => {
+          updateSlash();
+        });
+      });
+      const unregisterSelection = editor.registerCommand(
+        SELECTION_CHANGE_COMMAND,
+        () => {
+          updateSlash();
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      );
+      return () => {
+        unregisterUpdate();
+        unregisterSelection();
+      };
+    },
+    [editor],
+  );
+
+  useEffect(() => {
+    const move = (delta: number) => {
+      const count = matchesRef.current.length;
+      if (!slashRef.current || !count) return false;
+      selectedRef.current = (selectedRef.current + delta + count) % count;
+      setSelected(selectedRef.current);
+      return true;
+    };
+    const selectCurrent = () => {
+      const skill = matchesRef.current[selectedRef.current];
+      if (!slashRef.current || !skill) return false;
+      choose(skill);
+      return true;
+    };
+    return [
+      editor.registerCommand(KEY_ARROW_DOWN_COMMAND, () => move(1), COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(KEY_ARROW_UP_COMMAND, () => move(-1), COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(KEY_TAB_COMMAND, () => selectCurrent(), COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(
+        KEY_ESCAPE_COMMAND,
+        () => {
+          if (!slashRef.current) return false;
+          setSlash(null);
+          return true;
+        },
+        COMMAND_PRIORITY_HIGH,
+      ),
+      editor.registerCommand(
+        KEY_ENTER_COMMAND,
+        (event) => {
+          if (selectCurrent()) {
+            event?.preventDefault();
+            return true;
+          }
+          if (event?.shiftKey) return false;
+          event?.preventDefault();
+          onSubmit();
+          return true;
+        },
+        COMMAND_PRIORITY_HIGH,
+      ),
+    ].reduce((dispose, unregister) => () => {
+      dispose();
+      unregister();
+    });
+  }, [editor, onSubmit]);
+
+  if (!slash || !matches.length) return null;
+  return (
+    <div
+      role="listbox"
+      aria-label="Skills"
+      className="absolute z-50 left-2 right-2 top-full mt-1 max-h-72 overflow-auto rounded-xl border border-line bg-panel p-1.5 shadow-2xl"
+    >
+      {matches.map((skill, index) => (
+        <button
+          type="button"
+          role="option"
+          aria-selected={index === selected}
+          key={`${skill.path}:${index}`}
+          className={
+            "flex w-full items-start gap-2 rounded-lg px-2.5 py-2 text-left " +
+            (index === selected ? "bg-paper text-ink" : "text-muted hover:bg-paper")
+          }
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => choose(skill)}
+        >
+          <Icon name="diamond" size={14} className="mt-0.5 shrink-0 text-accent" />
+          <span className="min-w-0">
+            <span className="block text-[13px] font-medium text-ink">{skill.name}</span>
+            <span className="block truncate text-[11.5px]">{skill.description}</span>
+            <span className="block truncate text-[10.5px] text-faint">
+              {skill.source} · {skill.path}
+            </span>
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export interface SkillPromptEditorHandle {
+  clear: () => void;
+  focus: () => void;
+  setText: (text: string) => void;
+  appendText: (text: string) => void;
+}
+
+interface Props {
+  initialText?: string;
+  placeholder: string;
+  skills: SkillRef[];
+  onChange: (draft: { text: string; parts: PromptPart[] }) => void;
+  onSubmit: () => void;
+  onPaste?: (event: React.ClipboardEvent<HTMLDivElement>) => void;
+}
+
+export const SkillPromptEditor = forwardRef<SkillPromptEditorHandle, Props>(
+  function SkillPromptEditor({ initialText = "", placeholder, skills, onChange, onSubmit, onPaste }, ref) {
+    const [editor, setEditor] = useState<LexicalEditor | null>(null);
+    useImperativeHandle(
+      ref,
+      () => ({
+        clear: () =>
+          editor?.update(() => {
+            const root = $getRoot();
+            root.clear();
+            root.append($createParagraphNode());
+          }),
+        focus: () => editor?.focus(),
+        setText: (text) =>
+          editor?.update(() => {
+            const root = $getRoot();
+            root.clear();
+            root.append($createParagraphNode().append($createTextNode(text)));
+          }),
+        appendText: (text) =>
+          editor?.update(() => {
+            const root = $getRoot();
+            if (!root.getFirstChild()) root.append($createParagraphNode());
+            root.selectEnd();
+            const selection = $getSelection();
+            if ($isRangeSelection(selection)) selection.insertText(text);
+          }),
+      }),
+      [editor],
+    );
+    const config = useMemo(
+      () => ({
+        namespace: "openworker-skill-composer",
+        nodes: [SkillNode],
+        onError: (error: Error) => {
+          throw error;
+        },
+        editorState: () => {
+          const root = $getRoot();
+          root.clear();
+          root.append($createParagraphNode().append($createTextNode(initialText)));
+        },
+        theme: {
+          paragraph: "m-0",
+        },
+      }),
+      // Remounting handles a changed reset/prefill value; this callback is initial state only.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [],
+    );
+
+    return (
+      <LexicalComposer initialConfig={config}>
+        <div className="relative">
+          <PlainTextPlugin
+            contentEditable={
+              <ContentEditable
+                ref={(element) => {
+                  // Preserve the long-standing automation/accessibility locator while using
+                  // a rich contenteditable surface (placeholder is valid as a DOM attribute
+                  // even though React's generic HTML typings omit it here).
+                  element?.setAttribute("placeholder", placeholder);
+                }}
+                aria-label="Message"
+                className="min-h-10 max-h-[5.75rem] w-full overflow-y-auto px-3.5 pb-1.5 pt-3.5 text-[14.5px] leading-[22px] outline-none"
+                onPaste={onPaste}
+              />
+            }
+            placeholder={
+              <div className="pointer-events-none absolute left-3.5 top-3.5 text-[14.5px] text-faint">
+                {placeholder}
+              </div>
+            }
+            ErrorBoundary={LexicalErrorBoundary}
+          />
+          <OnChangePlugin
+            onChange={(state) => state.read(() => onChange(draftFromEditor()))}
+          />
+          <HistoryPlugin />
+          <EditorCapture onReady={setEditor} />
+          <SkillChooser skills={skills} onSubmit={onSubmit} />
+        </div>
+      </LexicalComposer>
+    );
+  },
+);

--- a/surfaces/gui/src/components/Transcript.tsx
+++ b/surfaces/gui/src/components/Transcript.tsx
@@ -1,10 +1,42 @@
 import { useState } from "react";
-import type { ApprovalDecision, Item } from "../types";
+import type { ApprovalDecision, Item, PromptPart } from "../types";
 import { shortArgs } from "./ApprovalCard";
 import { humanizeAsk, humanizeTool, type HumanLine } from "../humanize";
 import { Markdown } from "./Markdown";
 import { ConnectorMessageCard } from "./ConnectorMessageCard";
 import { Icon } from "./Icon";
+import { openSkill } from "../skillEvents";
+
+function UserPrompt({
+  parts,
+  fallback,
+}: {
+  parts?: PromptPart[];
+  fallback: string;
+}) {
+  if (!parts?.some((part) => part.type === "skill")) return <>{fallback}</>;
+  return (
+    <>
+      {parts.map((part, index) =>
+        part.type === "text" ? (
+          <span key={index}>{part.text}</span>
+        ) : (
+          <button
+            key={`${part.path}:${index}`}
+            type="button"
+            data-testid="transcript-skill-chip"
+            className="mx-0.5 inline-flex items-center gap-1 rounded-md bg-white/20 px-1.5 py-0.5 text-[13px] font-medium text-onSolid hover:bg-white/30"
+            title={`${part.source || "skill"} · ${part.path}`}
+            onClick={() => openSkill(part)}
+          >
+            <Icon name="diamond" size={12} />
+            {part.name}
+          </button>
+        ),
+      )}
+    </>
+  );
+}
 
 // Hover affordances for a message bubble (FB-005): copy the raw text + the message's time.
 // Lives in a ZERO-HEIGHT strip under the bubble (absolute, inside the transcript's 20px gap)
@@ -398,7 +430,7 @@ export function Transcript({ items, running, streamingText, onRetry }: Props) {
                       )}
                     </div>
                   )}
-                  {item.text}
+                  <UserPrompt parts={item.parts} fallback={item.text} />
                 </div>
                 <BubbleMeta text={item.text} ts={item.ts} align="right" />
               </div>

--- a/surfaces/gui/src/itemsFromMessages.test.ts
+++ b/surfaces/gui/src/itemsFromMessages.test.ts
@@ -49,6 +49,41 @@ describe("itemsFromMessages timestamps", () => {
   });
 });
 
+describe("itemsFromMessages skill parts", () => {
+  it("restores ordered exact-path chips without exposing injected skill content", () => {
+    const items = itemsFromMessages([
+      {
+        role: "user",
+        content: "Review with /review, then summarize.",
+        skill_parts: [
+          { type: "text", text: "Review with " },
+          {
+            type: "skill",
+            name: "review",
+            path: "/repo/.coworker/skills/review/SKILL.md",
+            content: "private injected body",
+          },
+          { type: "text", text: ", then summarize." },
+        ],
+      },
+    ] as any);
+
+    expect(items[0]).toEqual({
+      kind: "user",
+      text: "Review with /review, then summarize.",
+      parts: [
+        { type: "text", text: "Review with " },
+        {
+          type: "skill",
+          name: "review",
+          path: "/repo/.coworker/skills/review/SKILL.md",
+        },
+        { type: "text", text: ", then summarize." },
+      ],
+    });
+  });
+});
+
 describe("itemsFromMessages notices", () => {
   it("replays persisted error/interrupted markers; only errors are retriable", () => {
     const items = itemsFromMessages([

--- a/surfaces/gui/src/itemsFromMessages.ts
+++ b/surfaces/gui/src/itemsFromMessages.ts
@@ -6,7 +6,7 @@
 // generalizes to any connector via the registry — no Slack special-casing here.
 
 import type { ConversationMessage } from "./api";
-import type { Attachment, Item } from "./types";
+import type { Attachment, Item, PromptPart } from "./types";
 
 export function itemsFromMessages(messages: ConversationMessage[]): Item[] {
   const items: Item[] = [];
@@ -33,6 +33,27 @@ export function itemsFromMessages(messages: ConversationMessage[]): Item[] {
         continue;
       }
       const user = userItemFromContent(m.content);
+      if (Array.isArray(m.skill_parts)) {
+        const restored: PromptPart[] = [];
+        for (const part of m.skill_parts) {
+          if (part?.type === "text" && typeof part.text === "string") {
+            restored.push({ type: "text", text: part.text });
+          }
+          else if (
+            part?.type === "skill" &&
+            typeof part.name === "string" &&
+            typeof part.path === "string"
+          ) {
+            restored.push({
+              type: "skill",
+              name: part.name,
+              path: part.path,
+              ...(typeof part.source === "string" ? { source: part.source } : {}),
+            });
+          }
+        }
+        user.parts = restored;
+      }
       // `ts` (unix seconds) is the server's canonical-message stamp; older sessions have none.
       if (typeof m.ts === "number") user.ts = m.ts;
       if (user.text || user.attachments?.length) items.push(user);

--- a/surfaces/gui/src/skillEvents.ts
+++ b/surfaces/gui/src/skillEvents.ts
@@ -1,0 +1,7 @@
+import type { SkillRef } from "./types";
+
+export const OPEN_SKILL_EVENT = "ocw-open-skill";
+
+export function openSkill(skill: SkillRef) {
+  window.dispatchEvent(new CustomEvent(OPEN_SKILL_EVENT, { detail: skill }));
+}

--- a/surfaces/gui/src/types.ts
+++ b/surfaces/gui/src/types.ts
@@ -90,11 +90,22 @@ export interface Attachment {
   text?: string; // text files
 }
 
+export interface SkillRef {
+  name: string;
+  description?: string;
+  path: string;
+  source?: "project" | "global" | "shared" | string;
+}
+
+export type PromptPart =
+  | { type: "text"; text: string }
+  | ({ type: "skill" } & SkillRef);
+
 // Transcript items
 // `ts` = unix seconds (the server's canonical-message stamp; live items stamp locally).
 // Optional: sessions saved before the server stamped timestamps have none.
 export type Item =
-  | { kind: "user"; text: string; attachments?: Attachment[]; ts?: number }
+  | { kind: "user"; text: string; attachments?: Attachment[]; parts?: PromptPart[]; ts?: number }
   // A connector-delivered inbound message (Slack/Salesforce/…), rendered as a structured card
   // (ConnectorMessageCard) instead of a plain user bubble. Generalizes to any connector via the
   // registry — no per-connector special-casing.

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -38,9 +38,11 @@ class ScriptedProvider(ProviderClient):
         self._turns = list(turns)
         self._loop = loop
         self.calls = 0
+        self.last_messages = None
 
     def complete(self, *, model, messages, tools=None, **settings):
         self.calls += 1
+        self.last_messages = messages
         return self._turns[0] if self._loop else self._turns.pop(0)
 
     def capabilities(self, model):
@@ -70,6 +72,16 @@ def _collect(engine, user_input):
     return asyncio.run(_run())
 
 
+def _collect_with_skill_parts(engine, user_input, skill_parts):
+    async def _run():
+        return [
+            ev
+            async for ev in engine.run(user_input, skill_parts=skill_parts)
+        ]
+
+    return asyncio.run(_run())
+
+
 def _types(events):
     return [ev.type for ev in events]
 
@@ -87,6 +99,45 @@ def test_no_tool_turn(tmp_path):
     ]
     assert events[1].data["text"] == "all done"
     assert events[-1].data["status"] == "completed"
+
+
+def test_selected_skills_expand_in_order_without_leaking_transport_sidecars(
+    tmp_path,
+):
+    skill_path = str(tmp_path / ".coworker" / "skills" / "review" / "SKILL.md")
+    skill_parts = [
+        {"type": "text", "text": "Review this with "},
+        {
+            "type": "skill",
+            "name": "review",
+            "path": skill_path,
+            "content": "---\nname: review\n---\n\nInspect every claim.",
+        },
+        {"type": "text", "text": ", then answer briefly."},
+    ]
+    visible = "Review this with /review, then answer briefly."
+    engine, provider = _engine(tmp_path, [_text_turn("ok")])
+
+    events = _collect_with_skill_parts(engine, visible, skill_parts)
+
+    persisted = next(message for message in engine.messages if message["role"] == "user")
+    assert persisted["content"] == visible
+    assert persisted["skill_parts"] == skill_parts
+
+    outbound = next(
+        message for message in provider.last_messages if message["role"] == "user"
+    )
+    assert "skill_parts" not in outbound
+    content = outbound["content"]
+    assert content.startswith("Review this with <skill>\n")
+    assert f"<path>{skill_path}</path>" in content
+    assert "Inspect every claim." in content
+    assert content.endswith("</skill>, then answer briefly.")
+    assert events[0].data["skill_parts"][1] == {
+        "type": "skill",
+        "name": "review",
+        "path": skill_path,
+    }
 
 
 def test_tool_turn_order_and_execution(tmp_path):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,8 +20,12 @@ class ScriptedProvider(ProviderClient):
 
     def __init__(self, turns):
         self._turns = list(turns)
+        self.last_messages = None
+        self.message_calls = []
 
     def complete(self, *, model, messages, tools=None, **settings):
+        self.last_messages = messages
+        self.message_calls.append(messages)
         return self._turns.pop(0)
 
     def capabilities(self, model):
@@ -72,6 +76,42 @@ def test_agents_and_memory_rest(tmp_path):
         m["content"] == "prefer pathlib"
         for m in client.get("/v1/memory").json()["memory"]
     )
+
+
+def test_skills_catalog_and_read_are_workspace_aware_and_path_verified(tmp_path):
+    skill_file = tmp_path / ".coworker" / "skills" / "review" / "SKILL.md"
+    skill_file.parent.mkdir(parents=True)
+    skill_file.write_text(
+        "---\nname: review\ndescription: Review carefully\n---\n\nCheck every claim.",
+        encoding="utf-8",
+    )
+    client = _client(tmp_path, [])
+
+    catalog = client.get("/v1/skills", params={"workspace": str(tmp_path)}).json()
+    selected = next(
+        skill
+        for skill in catalog["skills"]
+        if skill["name"] == "review" and skill["source"] == "project"
+    )
+    assert selected == {
+        "name": "review",
+        "description": "Review carefully",
+        "path": str(skill_file.resolve()),
+        "source": "project",
+    }
+
+    read = client.get(
+        "/v1/skills/read",
+        params={"workspace": str(tmp_path), "path": selected["path"]},
+    )
+    assert read.status_code == 200
+    assert "Check every claim." in read.json()["content"]
+
+    forged = client.get(
+        "/v1/skills/read",
+        params={"workspace": str(tmp_path), "path": str(tmp_path / "secret.txt")},
+    )
+    assert forged.status_code == 404
 
 
 def test_disable_persona_archives_its_sessions(tmp_path):
@@ -323,6 +363,78 @@ def test_ws_simple_turn(tmp_path):
         assert "turn_end" in types
 
 
+def test_ws_accepts_skill_only_prompt_and_rejects_un_cataloged_paths(tmp_path):
+    skill_file = tmp_path / ".coworker" / "skills" / "review" / "SKILL.md"
+    skill_file.parent.mkdir(parents=True)
+    raw_skill = (
+        "---\nname: review\ndescription: Review carefully\n---\n\nCheck every claim."
+    )
+    skill_file.write_text(raw_skill, encoding="utf-8")
+    provider = ScriptedProvider([_text("reviewed")])
+    manager = SessionManager(workspace=tmp_path, provider=provider)
+    client = TestClient(create_app(manager))
+
+    with client.websocket_connect("/ws/session/skill-turn") as ws:
+        assert ws.receive_json()["type"] == "ready"
+        ws.send_json(
+            {
+                "type": "user_message",
+                "text": "",
+                "parts": [
+                    {
+                        "type": "skill",
+                        "name": "review",
+                        "path": str(tmp_path / "secret.txt"),
+                    }
+                ],
+            }
+        )
+        rejected = ws.receive_json()
+        assert rejected["type"] == "input_rejected"
+        assert "skill" in rejected["data"]["error"].lower()
+
+        ws.send_json(
+            {
+                "type": "user_message",
+                "text": "/review",
+                "parts": [
+                    {
+                        "type": "skill",
+                        "name": "review",
+                        "path": str(skill_file.resolve()),
+                    }
+                ],
+            }
+        )
+        assert "turn_done" in _drain(ws)
+
+    user_message = next(
+        message
+        for message in manager._engines["skill-turn"].messages
+        if message["role"] == "user"
+    )
+    assert user_message["content"] == "/review"
+    assert user_message["skill_parts"] == [
+        {
+            "type": "skill",
+            "name": "review",
+            "path": str(skill_file.resolve()),
+            "source": "project",
+            "content": raw_skill,
+        }
+    ]
+    provider_user = next(
+        message
+        for messages in provider.message_calls
+        for message in messages
+        if message["role"] == "user" and "<name>review</name>" in message["content"]
+    )
+    assert "<name>review</name>" in provider_user["content"]
+    assert f"<path>{skill_file.resolve()}</path>" in provider_user["content"]
+    assert "Check every claim." in provider_user["content"]
+    assert "skill_parts" not in provider_user
+
+
 def test_ws_rejects_oversized_message(tmp_path):
     from coworker.server import app as app_mod
     from coworker.attachments import MAX_ATTACHMENTS
@@ -366,6 +478,12 @@ def test_ws_rejects_malformed_payloads_without_killing_socket(tmp_path):
             [],
             {"type": "user_message", "text": ["not", "text"]},
             {"type": "user_message", "text": "x", "attachments": {}},
+            {"type": "user_message", "text": "x", "parts": {}},
+            {
+                "type": "user_message",
+                "text": "x",
+                "parts": [{"type": "text", "text": ["not", "text"]}],
+            },
             {
                 "type": "user_message",
                 "text": "x",

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from coworker.agent import build_engine
 from coworker.agents import AgentContext, chat_agent, code_agent, get_agent
 from coworker.providers import ModelCapabilities
-from coworker.skills import SkillLoader, skill_catalog_text, skill_tools
+from coworker.skills import SkillLoader, SkillRoot, skill_catalog_text, skill_tools
 from coworker.tools import ToolRegistry
 from coworker.tools.shell import LocalExecutor
 from coworker.tools.todo import TodoList
@@ -78,6 +78,65 @@ def test_skill_loader_catalog_and_load(tmp_path):
     loaded = reg.execute("load_skill", {"name": "pdf"})
     assert "pdfplumber" in loaded["instructions"]
     assert reg.execute("load_skill", {"name": "missing"})["error"]
+
+
+def test_skill_loader_catalogs_duplicate_names_by_exact_file_path(tmp_path):
+    shared = tmp_path / "shared"
+    project = tmp_path / "project"
+    _make_skill(shared, "review", "shared review", "Use the shared checklist.")
+    _make_skill(project, "review", "project review", "Use the project checklist.")
+
+    loader = SkillLoader(
+        [
+            SkillRoot(shared, "shared"),
+            SkillRoot(project, "project"),
+        ]
+    )
+
+    assert loader.catalog_all() == [
+        {
+            "name": "review",
+            "description": "shared review",
+            "path": str((shared / "review" / "SKILL.md").resolve()),
+            "source": "shared",
+        },
+        {
+            "name": "review",
+            "description": "project review",
+            "path": str((project / "review" / "SKILL.md").resolve()),
+            "source": "project",
+        },
+    ]
+    selected = loader.resolve(
+        "review", str(project / "review" / "SKILL.md")
+    )
+    assert selected is not None
+    assert selected.instructions == "Use the project checklist."
+    assert loader.resolve("review", str(tmp_path / "forged" / "SKILL.md")) is None
+
+
+def test_skill_loader_parses_multiline_descriptions_and_tool_lists(tmp_path):
+    skill_file = tmp_path / "skills" / "research" / "SKILL.md"
+    skill_file.parent.mkdir(parents=True)
+    skill_file.write_text(
+        "---\n"
+        "name: research\n"
+        "description: |\n"
+        "  Search primary sources.\n"
+        "  Cite every claim.\n"
+        "allowed-tools:\n"
+        "  - web_search\n"
+        "  - read_file\n"
+        "---\n\n"
+        "Follow the evidence.",
+        encoding="utf-8",
+    )
+
+    skill = SkillLoader([tmp_path / "skills"]).get("research")
+
+    assert skill is not None
+    assert skill.description == "Search primary sources.\nCite every claim.\n"
+    assert skill.allowed_tools == ["web_search", "read_file"]
 
 
 # -- engine assembly per agent --------------------------------------------------


### PR DESCRIPTION
## What this does

Typing `/` in the message box opens a searchable list of skills that are already installed for the user or the current project. Choosing one inserts a skill chip into the message.

You can:

- add more than one skill to a message
- put skills before, after, or between normal text
- send a skill without any extra text
- use the keyboard to search and select skills
- click a skill chip to open the exact `SKILL.md` file

## How messages work

OpenWorker looks for skills in `~/.agents/skills`, the OpenWorker global skills directory, and `<workspace>/.coworker/skills`.

Each chip keeps the full path to its `SKILL.md`. When the message is sent, the server checks that the selected path still belongs to the current skill list, saves the selection with the message, and adds the skill file to the model context in the same order as the surrounding text. Two skills with the same name remain separate because their paths are different.

The existing `load_skill(name)` tool still works as before.

## Screenshots

### `/` opens the installed skill list above the message box

<img width="1280" height="720" alt="skill-chooser-installed-catalog" src="https://github.com/user-attachments/assets/b0ceb9f0-af08-4282-a0a4-32d66cad917a" />

### Skills can sit anywhere in the message

<img width="1280" height="720" alt="skill-chooser-inline-skills" src="https://github.com/user-attachments/assets/c3b85893-5277-4070-8865-1c8d22fdbee6" />

### Clicking a skill opens its `SKILL.md`

<img width="1280" height="720" alt="skill-chooser-skill-viewer" src="https://github.com/user-attachments/assets/69b795de-0930-40f5-b4cf-d7693d4a736d" />

## Testing

- `pytest -q` — 952 passed, 1 skipped
- `npm test` — 82 passed
- `npm run build` — passed
- `npx playwright test` — 160 passed
- tested against the real local server; it found 90 installed skills, including `grill-me` and `guard`

The live test caught the skill list opening below the message box. The list now opens above it, with a browser test that checks the placement.

## Related issue

Addresses the Skills part of #68. This PR does not change the MCP documentation requested in that issue.
