### PR TITLE
Add SambaNova as OpenAI-compatible model provider

### DIFF
--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -149,6 +149,19 @@ MATRIX: dict[str, ModelEntry] = {
     "openrouter:meta-llama/llama-4-maverick": ModelEntry(
         "Llama 4 Maverick · via OpenRouter", _AGENTIC, 1_000_000
     ),
+    # SambaNova (added 2026-07-29)
+    "sambanova:MiniMax-M2.7": ModelEntry(
+        "MiniMax-M2.7 · SambaNova", _AGENTIC, 196_608
+    ),
+    "sambanova:DeepSeek-V3.1": ModelEntry(
+        "DeepSeek-V3.1 · SambaNova", _AGENTIC, 131_072
+    ),
+    "sambanova:Meta-Llama-3.3-70B-Instruct": ModelEntry(
+        "Meta-Llama-3.3-70B-Instruct · SambaNova", _AGENTIC, 131_072
+    ),
+    "sambanova:gpt-oss-120b": ModelEntry(
+        "gpt-oss-120b · SambaNova", _AGENTIC, 131_072
+    ),
     # -- cloud accounts (models running in the user's own AWS/GCP) ----------------
     # Bedrock ids carry a family segment (claude/ → native Anthropic path, other/ →
     # Converse) plus AWS's own `-v<n>:<m>` version suffix. Some regions require the

--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -544,6 +544,13 @@ DESCRIPTORS: list[ProviderDescriptor] = [
         recommended_model="z-ai/glm-5.2",
         env_key="OPENROUTER_API_KEY",
     ),
+    _compat(
+        "sambanova",
+        "SambaNova",
+        base_url="https://api.sambanova.ai/v1",
+        recommended_model="MiniMax-M2.7",
+        env_key="SAMBANOVA_API_KEY",
+    ),
     ProviderDescriptor(
         name="ollama",
         title="Ollama (local models)",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -409,7 +409,7 @@ def test_reseller_descriptors_and_matrix_stay_in_lockstep():
     from coworker.providers.matrix import models_for_provider
     from coworker.providers.registry import get_descriptor
 
-    for name in ("together", "fireworks", "openrouter"):
+    for name in ("together", "fireworks", "openrouter", "sambanova"):
         d = get_descriptor(name)
         assert d is not None and d.needs_key
         curated = models_for_provider(name)


### PR DESCRIPTION
## Summary

Adds SambaNova as a first-class OpenAI-compatible model provider, mirroring the existing Together/Fireworks/DeepSeek providers.

### Changes

1. **coworker/providers/registry.py**: Registers SambaNova via the `_compat` helper with:
   - Base URL: `https://api.sambanova.ai/v1`
   - Env key: `SAMBANOVA_API_KEY`
   - Recommended model: `MiniMax-M2.7`

2. **coworker/providers/matrix.py**: Adds 4 curated models:
   - `sambanova:MiniMax-M2.7` — 196,608 token context
   - `sambanova:DeepSeek-V3.1` — 131,072 token context
   - `sambanova:Meta-Llama-3.3-70B-Instruct` — 131,072 token context
   - `sambanova:gpt-oss-120b` — 131,072 token context

3. **tests/test_providers.py**: Adds `sambanova` to `test_reseller_descriptors_and_matrix_stay_in_lockstep`.

### Test results

All 24 provider tests pass. (1 test skipped: `test_compat_recommended_models_are_in_the_suggested_lists` requires the `aisuite` package which is not installed in this environment.)

---

⚠️ This is a Draft PR — not ready for review.