### PR TITLE
Add Intel Mac (x86_64) build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Desktop release builds — macOS (.dmg, arm64 + Intel) and Windows (.msi + NSIS .exe).
+# Desktop release builds — macOS (.dmg, arm64 + x86_64) and Windows (.msi + NSIS .exe).
 #
 # CI calls the SAME scripts developers run locally (packaging/build_dmg.sh and
 # build_windows.ps1); this file only provisions the toolchain (Node, Rust, a Python venv at
@@ -12,6 +12,7 @@
 # Each installer is uploaded twice: once with its versioned name (archive) and once with a
 # stable name (OpenWorker-macos-arm64.dmg, …) so the website can link to
 #   github.com/<repo>/releases/latest/download/<stable-name>
+# (OpenWorker-macos-arm64.dmg, OpenWorker-macos-x86_64.dmg, OpenWorker-windows-setup.exe, …)
 # and never need updating.
 #
 # macOS signing + notarization: Tauri's bundler handles both during `tauri build` when the
@@ -43,11 +44,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # No Intel macOS target: macos-13 (the last Intel runner image) is deprecated and
-          # its queue waits run to hours, which blocks the release job. Intel Macs are
-          # 2020-and-earlier hardware — revisit only if beta users actually ask.
           - os: macos-latest # Apple Silicon
             slug: macos-arm64
+          - os: macos-13      # Intel (x86_64) — beta users have requested this
+            slug: macos-x86_64
           - os: windows-latest
             slug: windows
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Add macos-13 runner to the release matrix so Intel Mac users can download a native DMG installer alongside the existing arm64 build.

The build_dmg.sh script already auto-detects the host architecture via rustc 1.97.1 (8bab26f4f 2026-07-14)
binary: rustc
commit-hash: 8bab26f4f68e0e26f0bb7960be334d5b520ea452 commit-date: 2026-07-14
host: x86_64-apple-darwin
release: 1.97.1
LLVM version: 22.1.6, so no script changes are needed — the same script produces OpenWorker_<version>_x86_64.dmg on Intel runners.

Replaces the "No Intel macOS target" rationale in release.yml with the actual build target, since beta users have now requested it.