### PR TITLE
feat: configurable Enter key behavior in composer

### DIFF
--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -1378,6 +1378,11 @@ def create_app(manager: SessionManager) -> FastAPI:
             max_mb=b.get("pdf_max_mb"),
         )
 
+    @app.post("/v1/settings/enter-behavior")
+    def settings_set_enter_behavior(body: dict) -> dict[str, Any]:
+        # Composer Enter key: "send" (default) or "newline".
+        return manager.set_enter_behavior((body or {}).get("enter_behavior", ""))
+
     @app.post("/v1/attachments/inspect-pdf")
     def attachments_inspect_pdf(body: dict) -> dict[str, Any]:
         # Attach-time page/size probe for the composer's threshold check. Local only.

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1777,6 +1777,7 @@ class SessionManager:
             # hardcoded POSIX one (Windows -> %APPDATA%\coworker, macOS/Linux -> ~/.config).
             "secrets_path": str(self.secrets.path),
             **self.pdf_settings(),
+            "enter_behavior": self.enter_behavior(),
         }
 
     def _surfaces(self) -> dict[str, bool]:
@@ -1902,6 +1903,20 @@ class SessionManager:
         self._prefs["default_model"] = model
         self._save_prefs()
         return {"ok": True, **self.get_settings()}
+
+    def enter_behavior(self) -> str:
+        """Composer Enter key behavior: ``"send"`` (Enter sends, Shift+Enter newline — default)
+        or ``"newline"`` (Enter newline, Shift+Enter sends)."""
+        return self._prefs.get("enter_behavior", "send")
+
+    def set_enter_behavior(self, value: str) -> dict[str, Any]:
+        """Set + persist the composer Enter key behavior."""
+        v = (value or "").strip()
+        if v not in ("send", "newline"):
+            return {"ok": False, "error": "enter_behavior must be 'send' or 'newline'"}
+        self._prefs["enter_behavior"] = v
+        self._save_prefs()
+        return {"ok": True, "enter_behavior": v}
 
     def set_onboarded(self, value: bool = True) -> dict[str, Any]:
         """Record that first-run setup is complete (so it isn't shown again)."""

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -696,6 +696,8 @@ export interface ModelSettings {
   pdf_fallback?: "text" | "images";
   pdf_max_pages?: number; // default 20, 1–100
   pdf_max_mb?: number; // default 10, 1–10
+  // Composer Enter key behavior: "send" (default) or "newline".
+  enter_behavior?: "send" | "newline";
 }
 
 export interface PdfSettings {
@@ -736,6 +738,18 @@ export async function setSessionsPeek(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ sessions_peek: n }),
+  });
+  return res.json();
+}
+
+/** Persist the composer Enter key behavior ("send" or "newline"). */
+export async function setEnterBehavior(
+  value: "send" | "newline",
+): Promise<{ ok: boolean; enter_behavior?: string; error?: string }> {
+  const res = await fetch(`${httpBase()}/v1/settings/enter-behavior`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ enter_behavior: value }),
   });
   return res.json();
 }

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -89,6 +89,7 @@ export function Composer(props: Props) {
   const [dictationError, setDictationError] = useState<string | null>(null);
   const [recordingSeconds, setRecordingSeconds] = useState(0);
   const [attachNotice, setAttachNotice] = useState<string | null>(null);
+  const [enterBehavior, setEnterBehavior] = useState<"send" | "newline">("send");
   const fileInput = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const noticeTimer = useRef<number | null>(null);
@@ -131,6 +132,13 @@ export function Composer(props: Props) {
     setAttachments([]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.resetKey]);
+
+  // Load the Enter key behavior preference (Settings → Composer).
+  useEffect(() => {
+    getSettings()
+      .then((s) => setEnterBehavior(s.enter_behavior || "send"))
+      .catch(() => {});
+  }, []);
 
   // Dictation is intentionally native-only: the browser/dev build remains a local server client
   // and never turns on the browser microphone or ships audio anywhere.
@@ -268,7 +276,8 @@ export function Composer(props: Props) {
   };
 
   const onKey = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    const sendOnEnter = enterBehavior === "send";
+    if (e.key === "Enter" && (sendOnEnter ? !e.shiftKey : e.shiftKey)) {
       e.preventDefault();
       submit();
     }

--- a/surfaces/gui/src/components/SettingsView.tsx
+++ b/surfaces/gui/src/components/SettingsView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import {
   getSettings,
   getTrustedWorkspaces,
+  setEnterBehavior,
   setOnboarded,
   setPdfSettings,
   setScratchBase,
@@ -425,6 +426,8 @@ function AppearanceSection() {
 
       <SidebarCard />
 
+      <ComposerCard />
+
       <FilesCard />
 
       <TrustedWorkspacesCard />
@@ -463,6 +466,46 @@ function AppearanceSection() {
         <div className={FIELD_HELP}>Replays the first-run setup: model, first automation, tips.</div>
       </div>
     </section>
+  );
+}
+
+// -- Composer Enter key behavior -----------------------------------------------
+function ComposerCard() {
+  const [behavior, setBehavior] = useState<"send" | "newline">("send");
+
+  useEffect(() => {
+    getSettings()
+      .then((s) => setBehavior(s.enter_behavior || "send"))
+      .catch(() => {});
+  }, []);
+
+  const save = async (v: "send" | "newline") => {
+    setBehavior(v);
+    await setEnterBehavior(v);
+  };
+
+  return (
+    <div className={CARD + " p-4 mb-4"}>
+      <div className={FIELD_LABEL}>Composer</div>
+      <div className="seg mt-2.5" role="radiogroup" aria-label="Enter key behavior">
+        <button
+          className={behavior === "send" ? "active" : ""}
+          onClick={() => save("send")}
+        >
+          Send on Enter
+        </button>
+        <button
+          className={behavior === "newline" ? "active" : ""}
+          onClick={() => save("newline")}
+        >
+          Newline on Enter
+        </button>
+      </div>
+      <div className={FIELD_HELP}>
+        Send on Enter (default): Enter sends the message, Shift+Enter adds a new line.
+        Newline on Enter: Enter adds a new line, Shift+Enter sends.
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds a user preference toggle in Settings → General → Composer that lets users choose their preferred Enter key behavior.

### Current behavior
Enter sends the message; Shift+Enter inserts a newline. Hardcoded, no way to change.

### Proposed behavior
New **Composer** card in Settings → General with two modes:

| Mode | Enter | Shift+Enter |
|------|-------|-------------|
| **Send on Enter** (default) | Send message | Newline |
| **Newline on Enter** | Newline | Send message |

### Changes
- **Backend** (\manager.py\): Added \enter_behavior\ getter/setter with persistence in \prefs.json\
- **Backend** (\pp.py\): Added \POST /v1/settings/enter-behavior\ route
- **Frontend** (\pi.ts\): Added \enter_behavior\ to \ModelSettings\ + \setEnterBehavior\ API function
- **Frontend** (\Composer.tsx\): Loads the preference and uses it in the \onKey\ handler — swaps the \!e.shiftKey\ check based on the user's choice
- **Frontend** (\SettingsView.tsx\): Added \ComposerCard\ with a segmented control in the General tab

### Testing
- Settings card loads the current preference from the backend and updates optimistically
- Composer reads the preference on mount and adjusts Enter/Shift+Enter accordingly
- The existing default behavior (Send on Enter) is unchanged

Closes #278