### PR TITLE
docs: add CLAUDE.md files for Claude Code guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# OpenWorker
+
+OpenWorker is an open-source AI coworker desktop app. Python backend (FastAPI) + React/TypeScript frontend (Tauri shell).
+
+## Project structure
+
+- `coworker/` -- Python backend: agent engine, LLM providers, connectors, MCP client, server
+- `surfaces/gui/` -- React/TypeScript desktop app (Vite + Tauri)
+- `stt/` -- Speech-to-text sidecar (Rust)
+- `packaging/` -- Installer builds & dev bootstrap
+- `tests/` -- Backend pytest suite
+- `docs/` -- Design docs and decision logs
+
+## Commands
+
+- Backend: `.venv/bin/openworker-server --cwd <dir> --port 8765`
+- Frontend dev: `cd surfaces/gui && npm run dev`
+- Tests (backend): `.venv/bin/pytest`
+- Tests (frontend): `cd surfaces/gui && npm test`
+- Desktop app: `cd surfaces/gui && npm run tauri dev`
+
+## Code conventions
+
+- Python: type hints everywhere, Google-style docstrings
+- TypeScript/React: functional components, hooks, Tailwind CSS
+- Prefer no comments in code unless explaining non-obvious decisions
+- All user-facing strings in English

--- a/coworker/CLAUDE.md
+++ b/coworker/CLAUDE.md
@@ -1,0 +1,27 @@
+# coworker/ -- Python backend
+
+FastAPI server with agent engine, LLM providers, connectors, and tools.
+
+## Key directories
+
+- `server/` -- FastAPI app, manager, CLI entry point
+- `providers/` -- LLM providers (OpenAI, Anthropic, Gemini, Bedrock, Vertex, Ollama)
+- `connectors/` -- External service integrations (Slack, Telegram, GitHub, email, browser, etc.)
+- `agents/` -- Agent implementations (chat, code, cowork)
+- `tools/` -- Built-in agent tools (shell, files, git, search, web, etc.)
+- `mcp/` -- Model Context Protocol client
+- `memory/` -- SQLite-backed conversation memory
+- `automation/` -- Cron-based scheduled tasks
+- `web/` -- Web fetching and browsing utilities
+- `personas/` -- Persona system (YAML-defined agent profiles)
+- `skills/` -- Agent skill framework
+- `testing/` -- Test utilities (fake Slack server)
+
+## Conventions
+
+- Type hints required on all public APIs
+- Google-style docstrings: `"""Summary. (blank line) Details."""`
+- Async where possible (asyncio)
+- Prefs stored in `prefs.json` via `_prefs` dict in `manager.py`
+- Secrets stored via `SecretStore` (encrypted at rest)
+- New settings follow: `manager.py` getter/setter -> `app.py` route -> `api.ts` frontend API

--- a/surfaces/gui/CLAUDE.md
+++ b/surfaces/gui/CLAUDE.md
@@ -1,0 +1,26 @@
+# surfaces/gui/ -- React/TypeScript desktop app
+
+Vite + React + Tauri + Tailwind CSS.
+
+## Key directories
+
+- `src/components/` -- React components (Composer, Settings, Sidebar, etc.)
+- `src/providers/` -- Model provider setup UI
+- `src/connectors/` -- Connector configuration UI components
+
+## Key files
+
+- `src/App.tsx` -- Main app shell
+- `src/api.ts` -- Backend API client (fetch-based)
+- `src/types.ts` -- TypeScript type definitions
+- `src/styles.css` -- Tailwind + custom CSS
+- `src/theme.ts` -- Theme (light/dark/system) management
+- `src/tauri.ts` -- Tauri-specific native APIs
+
+## Conventions
+
+- Functional components with hooks (no classes)
+- Tailwind CSS for styling (custom classes prefixed in styles.css)
+- Settings/preferences stored server-side via `api.ts` functions
+- Import types from `../types` or `../api` as needed
+- Test files co-located as `*.test.tsx` next to component

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,19 @@
+# tests/ -- Backend test suite
+
+pytest with `asyncio_mode = "auto"`.
+
+## Running tests
+
+```bash
+.venv/bin/pytest                     # all tests
+.venv/bin/pytest tests/test_*.py     # single file
+.venv/bin/pytest -k "pattern"        # filter by name
+```
+
+## Conventions
+
+- Test files named `test_*.py` in `tests/` root
+- Async fixtures are automatically handled (asyncio_mode = auto)
+- Test data and helper functions in `conftest.py`
+- New features should include tests
+- Use `unittest.mock` or pytest fixtures for mocking external services


### PR DESCRIPTION
## Summary

Adds \CLAUDE.md\ files in the root, \coworker/\, \surfaces/gui/\, and \	ests/\ directories to provide guidance for Claude Code / AI coding assistants on codebase structure and development conventions.

### Files added

- \CLAUDE.md\ (root) -- Overall project overview, structure, commands, conventions
- \coworker/CLAUDE.md\ -- Python backend: directory layout, key modules, coding conventions
- \surfaces/gui/CLAUDE.md\ -- React/TypeScript frontend: component structure, styling, conventions
- \	ests/CLAUDE.md\ -- Test suite: how to run, naming conventions, async handling

Closes #200