### PR TITLE
fix: detect Ollama vision models from naming conventions

### DIFF
--- a/coworker/providers/capabilities.py
+++ b/coworker/providers/capabilities.py
@@ -24,9 +24,12 @@ def capabilities_for(model: str) -> ModelCapabilities:
 
     # Ollama (local) models vary widely and many fake/mishandle parallel tool calls — assume
     # tools work (we only point at tool-capable models) but stay conservative otherwise.
+    # Vision is detected from common model naming conventions (-vl, vision, llava, etc.).
     if provider == "ollama":
+        _vision_patterns = ("-vl", "vision", "llava", "bakllava", "cogvlm", "minicpm-v")
+        has_vision = any(p in name for p in _vision_patterns)
         return ModelCapabilities(
-            tools=True, vision=False, parallel_tool_calls=False, streaming=True
+            tools=True, vision=has_vision, parallel_tool_calls=False, streaming=True
         )
 
     # Cloud-account providers (custom-added ids; curated ones answered from the matrix).


### PR DESCRIPTION
﻿## Summary

Ollama vision models (e.g. qwen3-vl:8b, llava, bakllava) were unconditionally marked as vision: False in capabilities_for(), causing the agent to replace image attachments with a placeholder text.

## Root cause

coworker/providers/capabilities.py set vision=False for every Ollama model regardless of actual vision capability.

## Fix

Added a heuristic that inspects the model name for common vision-model naming patterns (-vl, vision, llava, bakllava, cogvlm, minicpm-v). Non-vision Ollama models (e.g. qwen2.5-coder) remain unaffected.

Closes #337
