### PR TITLE
Fix display scaling scroll issue in connector integration

### DIFF
--- a/surfaces/gui/src/components/AuditView.tsx
+++ b/surfaces/gui/src/components/AuditView.tsx
@@ -30,7 +30,7 @@ export function AuditView() {
   }, []);
 
   return (
-    <main className="flex-1 min-w-0 flex bg-paper">
+    <main className="flex-1 min-w-0 min-h-0 flex bg-paper">
       <div className="flex-1 min-w-0 overflow-y-auto hairline-scroll">
         <div className="max-w-4xl mx-auto px-7 py-6">
           <PanelHead

--- a/surfaces/gui/src/components/InboxView.tsx
+++ b/surfaces/gui/src/components/InboxView.tsx
@@ -141,7 +141,7 @@ export function InboxView({
   const routingLabel = routingName ? `#${routingName}` : routing;
 
   return (
-    <main className="flex-1 min-w-0 flex bg-paper">
+    <main className="flex-1 min-w-0 min-h-0 flex bg-paper">
       <div className="flex-1 min-w-0 overflow-y-auto hairline-scroll">
         <div className="max-w-4xl mx-auto px-7 py-6">
           <PanelHead

--- a/surfaces/gui/src/components/IntegrationsView.tsx
+++ b/surfaces/gui/src/components/IntegrationsView.tsx
@@ -33,7 +33,7 @@ export function IntegrationsView() {
   }, []);
 
   return (
-    <main className="flex-1 min-w-0 flex bg-paper">
+    <main className="flex-1 min-w-0 min-h-0 flex bg-paper">
       <nav className="page-subnav w-[208px] shrink-0 border-r border-line bg-panel/40 px-3 py-4">
         <div className="px-2 text-[13.5px] font-semibold mb-3 flex items-center gap-2">
           <Icon name="plug" size={16} /> Connectors

--- a/surfaces/gui/src/components/ScheduledView.tsx
+++ b/surfaces/gui/src/components/ScheduledView.tsx
@@ -42,7 +42,7 @@ function toCron(time: string, freq: string): string {
 // The §28 page shell: full-bleed main, centered ≤4xl column — same as Connectors/Activity/Inbox.
 function Shell({ children }: { children: React.ReactNode }) {
   return (
-    <main className="flex-1 min-w-0 flex bg-paper">
+    <main className="flex-1 min-w-0 min-h-0 flex bg-paper">
       <div className="flex-1 min-w-0 overflow-y-auto hairline-scroll">
         <div className="max-w-4xl mx-auto px-7 py-6">{children}</div>
       </div>

--- a/surfaces/gui/src/components/SettingsView.tsx
+++ b/surfaces/gui/src/components/SettingsView.tsx
@@ -81,7 +81,7 @@ export function SettingsView({
   const [tab, setTab] = useState<SetTab>(wanted);
 
   return (
-    <main className="flex-1 min-w-0 flex bg-paper">
+    <main className="flex-1 min-w-0 min-h-0 flex bg-paper">
       <nav className="page-subnav w-[208px] shrink-0 border-r border-line bg-panel/40 px-3 py-4">
         <div className="px-2 text-[13.5px] font-semibold mb-3 flex items-center gap-2">
           <Icon name="gear" size={16} /> Settings


### PR DESCRIPTION
## Summary
Fixes #321 — connector integration content is cut off at increased display scales with no scrollbar.

## Root cause
The \.app\ grid (\display: grid; overflow: hidden\) contains \<main>\ elements as grid items. These grid items had default \min-height: auto\, causing them to grow beyond the viewport when content was tall (e.g., at non-default display scaling). Since the parent grid has \overflow: hidden\, the overflow was silently clipped with no scrollbar appearing.

Adding \min-h-0\ (\min-height: 0\) allows the grid items to shrink below their intrinsic content height, letting the inner \overflow-y-auto\ div properly constrain and scroll.

## Changes
- \IntegrationsView.tsx\ - add \min-h-0\ to \<main>\
- \SettingsView.tsx\ - same fix (identical layout pattern)
- \ScheduledView.tsx\ - same fix
- \AuditView.tsx\ - same fix
- \InboxView.tsx\ - same fix

## Testing
- Verified scrolling works at default display scaling
- The fix allows the inner scroll container to correctly constrain when display scaling increases content size