### PR TITLE
fix(gui): make right-rail Hide side panel clickable again

### DIFF
--- a/surfaces/gui/e2e/session-shell.spec.ts
+++ b/surfaces/gui/e2e/session-shell.spec.ts
@@ -75,3 +75,27 @@ test("composer is three controls (+ attach · Mode · send); folder and branch c
   await expect(page.locator(".wschip")).toHaveCount(0);
   await expect(page.locator(".wsbranch")).toHaveCount(0);
 });
+
+test("right-rail Hide side panel toggle collapses and restores the inspector (#342)", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByText("Draft the launch note").first().click();
+
+  const hide = page.getByRole("button", { name: "Hide side panel" });
+  await expect(hide).toBeVisible();
+  await expect(page.locator(".right-rail")).toBeVisible();
+  await expect(page.locator(".main")).toHaveClass(/rail-open/);
+
+  // Clicks must reach the button even though the topbar side is a window-drag surface —
+  // the actions cluster stops pointerdown so beginWindowDrag never runs (#342).
+  await hide.click();
+  await expect(page.locator(".right-rail")).toHaveCount(0);
+  await expect(page.locator(".main")).not.toHaveClass(/rail-open/);
+  await expect(page.getByRole("button", { name: "Show side panel" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Show side panel" }).click();
+  await expect(page.locator(".right-rail")).toBeVisible();
+  await expect(page.locator(".main")).toHaveClass(/rail-open/);
+  await expect(page.getByRole("button", { name: "Hide side panel" })).toBeVisible();
+});

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -1373,34 +1373,40 @@ export function App() {
               </span>
             )}
           </div>
-          {/* Right: session-settings icon (§23) + panel toggle. Model/mode/persona chrome is
-              gone — the facts live in the subtitle, the controls in the composer (§22). */}
+          {/* Right: artifacts chip + panel toggle. Model/mode/persona chrome is gone — the
+              facts live in the subtitle, the controls in the composer (§22). Clicks must not
+              start a window drag: stop pointerdown (not mousedown) so beginWindowDrag never
+              runs — onMouseDown alone left the button dead in the desktop app (#342). */}
           <div className="main-topbar-side main-topbar-actions" onPointerDown={beginWindowDrag}>
-            {agent === "cowork" && railHidden && artifactCount > 0 && (
-              <button
-                className="topbar-artifacts-btn"
-                onMouseDown={(e) => e.stopPropagation()}
-                onClick={() => setRailHidden(false)}
-                title="Show files this conversation produced"
-              >
-                <Icon name="file" size={14} />
-                <span>Artifacts</span>
-                <span className="topbar-artifacts-count">{artifactCount}</span>
-              </button>
-            )}
-            {/* §32: the panel toggle is the ONE session-panel entry, for every non-chat persona
-                (the rail now carries Access, so code-family gets it too). */}
-            {agent !== "chat" && (
-              <button
-                className="topbar-icon-btn"
-                onMouseDown={(e) => e.stopPropagation()}
-                onClick={() => setRailHidden((h) => !h)}
-                aria-label={railHidden ? "Show side panel" : "Hide side panel"}
-                title={railHidden ? "Show side panel" : "Hide side panel"}
-              >
-                <Icon name="sidebarRight" size={16} />
-              </button>
-            )}
+            <div
+              className="flex items-center gap-1"
+              data-testid="topbar-rail-actions"
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              {agent === "cowork" && railHidden && artifactCount > 0 && (
+                <button
+                  className="topbar-artifacts-btn"
+                  onClick={() => setRailHidden(false)}
+                  title="Show files this conversation produced"
+                >
+                  <Icon name="file" size={14} />
+                  <span>Artifacts</span>
+                  <span className="topbar-artifacts-count">{artifactCount}</span>
+                </button>
+              )}
+              {/* §32: the panel toggle is the ONE session-panel entry, for every non-chat persona
+                  (the rail now carries Access, so code-family gets it too). */}
+              {agent !== "chat" && (
+                <button
+                  className="topbar-icon-btn"
+                  onClick={() => setRailHidden((h) => !h)}
+                  aria-label={railHidden ? "Show side panel" : "Hide side panel"}
+                  title={railHidden ? "Show side panel" : "Hide side panel"}
+                >
+                  <Icon name="sidebarRight" size={16} />
+                </button>
+              )}
+            </div>
           </div>
         </div>
         <div className={"main-workspace" + (railHidden ? " rail-hidden" : "")}>


### PR DESCRIPTION
- Stop topbar window-drag from swallowing Hide/Show side panel clicks by matching the left cluster: stop `pointerdown` (not only `mousedown`) on the right actions
- Fixes the desktop-app case where the toggle looked static (#342)
- Checks: `npm run e2e -- e2e/session-shell.spec.ts` (4 passed)

![Before/after: Hide side panel toggle](https://raw.githubusercontent.com/akkikumar72/pr-assets/main/openworker/pr-348/rail-hide-before-after.png)