### PR TITLE
ci: build macOS Intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # No Intel macOS target: macos-13 (the last Intel runner image) is deprecated and
-          # its queue waits run to hours, which blocks the release job. Intel Macs are
-          # 2020-and-earlier hardware — revisit only if beta users actually ask.
           - os: macos-latest # Apple Silicon
             slug: macos-arm64
+          # Intel macOS: macos-13 retired in Dec 2025; macos-15-intel replaced it and is
+          # the LAST x86_64 image Actions will offer (available until Aug 2027). Builds
+          # natively — the sidecar is a PyInstaller freeze, which cannot cross-compile.
+          - os: macos-15-intel
+            slug: macos-x64
           - os: windows-latest
             slug: windows
     runs-on: ${{ matrix.os }}

--- a/packaging/make_update_manifest.py
+++ b/packaging/make_update_manifest.py
@@ -10,6 +10,7 @@ Looks for the updater artifacts by their STABLE names (the same names release.ym
 uploads):
 
     OpenWorker-macos-arm64.app.tar.gz(.sig)   -> platforms["darwin-aarch64"]
+    OpenWorker-macos-x64.app.tar.gz(.sig)     -> platforms["darwin-x86_64"]
     OpenWorker-windows-setup.exe(.sig)        -> platforms["windows-x86_64"]
 
 URLs point at the TAG-pinned GitHub download path (releases/download/<tag>/<asset>),
@@ -34,6 +35,7 @@ import sys
 # stable asset name -> Tauri platform key
 ARTIFACTS = {
     "OpenWorker-macos-arm64.app.tar.gz": "darwin-aarch64",
+    "OpenWorker-macos-x64.app.tar.gz": "darwin-x86_64",
     "OpenWorker-windows-setup.exe": "windows-x86_64",
 }
 


### PR DESCRIPTION
Adds a macos-15-intel entry to the release matrix and wires darwin-x86_64 into the updater manifest, so Intel Macs get a DMG and auto updates. Closes #119, #269, #336.

macos-13 retired in Dec 2025; macos-15-intel is the last x86_64 image Actions offers (until Aug 2027). Builds natively because the PyInstaller sidecar cannot cross compile. A missing Intel artifact still degrades to a skipped platform rather than a broken manifest.