### PR TITLE
Add SambaNova as OpenAI-compatible provider

### DIFF
--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -109,6 +109,26 @@ MATRIX: dict[str, ModelEntry] = {
     "mistral:mistral-large-latest": ModelEntry(
         "Mistral Large · Mistral", _AGENTIC, 128_000
     ),
+    # -- SambaNova ---------------------------------------------------------------
+    # OpenAI-compatible API (verified against api.sambanova.ai/v1/models 2026-07-30).
+    "sambanova:Meta-Llama-3.3-70B-Instruct": ModelEntry(
+        "Llama 3.3 70B · SambaNova", _AGENTIC, 131_072
+    ),
+    "sambanova:DeepSeek-V3.1": ModelEntry(
+        "DeepSeek V3.1 · SambaNova", _AGENTIC, 131_072
+    ),
+    "sambanova:DeepSeek-V3.2": ModelEntry(
+        "DeepSeek V3.2 · SambaNova", _AGENTIC, 32_768
+    ),
+    "sambanova:MiniMax-M2.7": ModelEntry(
+        "MiniMax M2.7 · SambaNova", _AGENTIC, 196_608
+    ),
+    "sambanova:gemma-4-31B-it": ModelEntry(
+        "Gemma 4 31B · SambaNova", _AGENTIC, 131_072
+    ),
+    "sambanova:gpt-oss-120b": ModelEntry(
+        "GPT-OSS 120B · SambaNova", _AGENTIC, 131_072
+    ),
     # -- resellers (their model namespaces, verbatim) -----------------------------
     "together:thinkingmachines/Inkling": ModelEntry("Inkling · via Together"),
     "together:zai-org/GLM-5.2": ModelEntry("GLM-5.2 · via Together", _AGENTIC, 128_000),

--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -519,6 +519,14 @@ DESCRIPTORS: list[ProviderDescriptor] = [
         env_key="META_API_KEY",
         endpoint_help="Prefilled with the Meta Model API endpoint (public preview, US-only as of 2026-07).",
     ),
+    _compat(
+        "sambanova",
+        "SambaNova",
+        base_url="https://api.sambanova.ai/v1",
+        recommended_model="Meta-Llama-3.3-70B-Instruct",
+        env_key="SAMBANOVA_API_KEY",
+        endpoint_help="Prefilled with SambaNova's official OpenAI-compatible endpoint.",
+    ),
     # Resellers: many labs' models behind one key, using THEIR model namespaces (the curated
     # ids + display labels live in providers/matrix.py). TODO: add Groq here (+ its matrix
     # rows) once the current provider surface is tested — deliberately deferred to bound


### PR DESCRIPTION
## Why
Add SambaNova as a supported model provider in OpenWorker, enabling users to use SambaNova's cloud API for agentic workloads.

## Root cause
SambaNova was not in the provider registry despite having a fully OpenAI-compatible API.

## Fix
- Added SambaNova to  via the existing `_compat()` helper (same pattern as Together AI, Fireworks, OpenRouter, etc.), pointing to `https://api.sambanova.ai/v1`
- Added 6 curated SambaNova models to `matrix.py`: Llama 3.3 70B, DeepSeek V3.1, DeepSeek V3.2, MiniMax M2.7, Gemma 4 31B, and GPT-OSS 120B

## Tests
Verified `sambanova` is registered and all 6 models appear in the matrix:
```
$ uv run python -c "from coworker.providers.registry import provider_names; print('sambanova' in provider_names())"
True
$ uv run python -c "from coworker.providers.matrix import models_for_provider; print(models_for_provider('sambanova'))"
['Meta-Llama-3.3-70B-Instruct', 'DeepSeek-V3.1', 'DeepSeek-V3.2', 'MiniMax-M2.7', 'gemma-4-31B-it', 'gpt-oss-120b']
```

## Confidence
High — follows the exact same pattern as all other OpenAI-compatible providers (Together AI, Fireworks, OpenRouter, etc.) and uses the verified official endpoint from SambaNova's docs.

> Authored by a SambaChat managed agent — draft, awaiting human review.