### PR TITLE
fix(gui): guard session WS onmessage JSON.parse against malformed frames

### DIFF
--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -1821,7 +1821,13 @@ export class Session {
   constructor(sessionId: string, workspace: string, agent: string, handlers: Handlers) {
     const q = `?workspace=${encodeURIComponent(workspace)}&agent=${encodeURIComponent(agent)}`;
     this.ws = openWebSocket(`${wsBase()}/ws/session/${sessionId}${q}`);
-    this.ws.onmessage = (e) => handlers.onEvent(JSON.parse(e.data));
+    this.ws.onmessage = (e) => {
+      try {
+        handlers.onEvent(JSON.parse(e.data));
+      } catch {
+        /* malformed frame — ignore */
+      }
+    };
     this.ws.onopen = () => {
       this.flush();
       handlers.onOpen?.();


### PR DESCRIPTION
### Problem

The session WebSocket `onmessage` handler calls `JSON.parse(e.data)` without a `try/catch`. A single malformed frame from the server throws an uncaught exception inside the browser event handler, silently killing the callback — the session stops receiving all events (turns, approvals, tool output) and the UI freezes with no error indication.

### Root cause

The handler at `surfaces/gui/src/api.ts:1824` was written without the guard that the sibling `connectEvents` handler at line 1471 already has. Both handlers do the same thing — receive a WebSocket frame, `JSON.parse` it, pass to a handler — but only one was wrapped.

### Fix

Wrap `JSON.parse` in `try/catch`, mirroring the exact pattern (and comment) already used by `connectEvents`:

```ts
// Before:
this.ws.onmessage = (e) => handlers.onEvent(JSON.parse(e.data));

// After:
this.ws.onmessage = (e) => {
  try {
    handlers.onEvent(JSON.parse(e.data));
  } catch {
    /* malformed frame — ignore */
  }
};
```

### Validation

- The fix is a pure consistency change — the same file, same guard, same comment, same intent
- The sibling `connectEvents` handler has used this pattern since it was written
- No behavioural change for well-formed frames; a malformed frame is now silently dropped instead of killing the handler