### PR TITLE
fix(server): surface engine exceptions in WS turn path instead of swallowing them

### DIFF
--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -1742,6 +1742,12 @@ def create_app(manager: SessionManager) -> FastAPI:
                     )
                     if event.type.value in _CHECKPOINTS:
                         manager.save(session_id, engine)
+            except Exception as exc:
+                # An unexpected raise out of the engine must not be swallowed — the
+                # background-turn path (deliver_to_session) does the same.
+                await manager.broadcast_session(
+                    session_id, {"type": "error", "data": {"error": str(exc)}}
+                )
             finally:
                 manager.mark_idle(session_id)
                 manager.save(session_id, engine)


### PR DESCRIPTION
### Problem

`run_turn` in `coworker/server/app.py` is scheduled with `asyncio.create_task` and has `try/finally` with **no `except`**. Any unexpected exception from `engine.run()` or `engine.retry()` escapes the task, becoming an unretrieved "Task exception was never retrieved" — the GUI receives only a `turn_done` event with no error, leaving the user with a silently dead turn and zero feedback.

### Root cause

The WS user-turn path was missing the guard that the background-turn path (`deliver_to_session` in `manager.py:2886-2893`) already has. Both run an engine turn and broadcast events, but only the background path catches unexpected exceptions and surfaces them as error events.

### Fix

Add an `except Exception` block that broadcasts an `error` event before the `finally`, mirroring the exact pattern from `deliver_to_session`. The GUI already handles `error` events by displaying the message with a Retry button.

```py
try:
    events = engine.retry() if retry else engine.run(content)
    async for event in events:
        ...
except Exception as exc:
    await manager.broadcast_session(
        session_id, {"type": "error", "data": {"error": str(exc)}}
    )
finally:
    manager.mark_idle(session_id)
    manager.save(session_id, engine)
    await manager.broadcast_session(session_id, {"type": "turn_done", "data": {}})
```

### Edge case

If `broadcast_session` inside the `except` itself fails, the exception escapes — same outcome as today (unretrieved task exception, user sees nothing). No regression; the fix improves the common case without worsening the failure case.