### PR TITLE
fix(dev): install the bedrock extra in setup_dev_env.sh (#284)

### DIFF
--- a/packaging/setup_dev_env.sh
+++ b/packaging/setup_dev_env.sh
@@ -12,10 +12,13 @@ VENV="$ROOT/.venv"
 
 python3 -m venv "$VENV"
 # The coworker package (server, engine, connectors) + inbound-messaging extras.
+# The bedrock extra (boto3) is included so a from-source env matches CI
+# (.github/workflows/ci.yml installs ".[messaging,dev,bedrock]"); without it
+# tests/test_bedrock_provider.py fails with ModuleNotFoundError: boto3 (#284).
 # aisuite comes in as a regular dependency (git-pinned in pyproject.toml until
 # the next PyPI release).
 "$VENV/bin/pip" install --quiet --upgrade pip
-"$VENV/bin/pip" install --quiet -e "$ROOT[messaging,dev]"
+"$VENV/bin/pip" install --quiet -e "$ROOT[messaging,dev,bedrock]"
 
 "$VENV/bin/python" -c 'import aisuite, coworker' # fail loudly if the wiring broke
 echo "Ready: $VENV"


### PR DESCRIPTION
## Summary

Closes #284.

A fresh from-source setup can't pass the repo's own test suite. Following the README "Run from source" steps:

```bash
bash packaging/setup_dev_env.sh
.venv/bin/pytest
```

fails 7 tests in `tests/test_bedrock_provider.py`, every one a `ModuleNotFoundError: No module named 'boto3'`.

## Cause

`packaging/setup_dev_env.sh` installs `.[messaging,dev]`, but CI installs `.[messaging,dev,bedrock]` (`.github/workflows/ci.yml`). The bedrock test suite imports `boto3` directly (it comes from the `bedrock` extra — `pyproject.toml`: `bedrock = ["boto3>=1.34"]`), so an env built by the bootstrap script is missing a dependency CI has.

## Fix

Add `bedrock` to the extras installed by `setup_dev_env.sh` so a local env matches CI, plus a comment explaining why the extra is there. One-token change to the install line.

```diff
-"$VENV/bin/pip" install --quiet -e "$ROOT[messaging,dev]"
+"$VENV/bin/pip" install --quiet -e "$ROOT[messaging,dev,bedrock]"
```

`bash -n` clean. After the change a fresh env installs `boto3` and the previously-failing `tests/test_bedrock_provider.py` can run, matching CI.
