### PR TITLE
fix(shell): fold the user's login-shell env into run_shell (#362)

### DIFF
--- a/coworker/tools/shell.py
+++ b/coworker/tools/shell.py
@@ -9,6 +9,11 @@ The shell is OS-native: `/bin/bash` on POSIX, `powershell.exe` (`-Command -` REP
 Windows. Each backend has its own marker/exit-code protocol and interrupt mechanism, but
 the `Executor` contract (and the parsed `{marker} {exit_code} {cwd}` trailer) is identical.
 
+On POSIX the persistent shell is non-interactive and never sources the user's rc files, so
+one login+interactive probe runs at startup to fold the user's real PATH/toolchain
+(pyenv/nvm/sdkman/conda) into its environment (#362); per-command execution stays
+non-interactive. See `_login_shell_env` / `_build_env`.
+
 Safety here is permission-gating (high-risk tool → approval) + per-command timeout +
 best-effort non-interactive enforcement. A timed-out command is interrupted (SIGINT to the
 foreground child on POSIX, Ctrl-Break to the child group on Windows); the shell survives so
@@ -24,6 +29,7 @@ from __future__ import annotations
 
 import os
 import queue
+import re
 import signal
 import subprocess
 import sys
@@ -50,6 +56,89 @@ _NONINTERACTIVE_ENV = {
     "PYTHONUNBUFFERED": "1",
     "PIP_NO_INPUT": "1",
 }
+
+# Login-shell environment probe (#362). A GUI-launched server (and a plain non-interactive
+# /bin/bash) never sources the user's rc files, so pyenv/nvm/sdkman/conda shims configured
+# there are invisible to run_shell — the agent then sees a different toolchain than the user
+# (wrong interpreter, wrong versions, misreported system state). We run the user's login
+# shell ONCE at startup and fold its PATH/vars into the persistent shell's environment. The
+# per-command shell stays non-interactive; only this one-time probe is interactive.
+_ENV_PROBE_START = "__COWORKER_ENV_START__"
+_ENV_PROBE_END = "__COWORKER_ENV_END__"
+_ENV_PROBE_TIMEOUT = 5.0
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _parse_env_dump(text: str) -> dict[str, str]:
+    """Pull `KEY=VALUE` pairs from the fenced region of an `env` dump. Only lines inside the
+    marker fence that look like a shell assignment are kept, so rc-file banners/echoes are
+    ignored and a rare multi-line value contributes just its first line (fine for PATH and
+    the shim vars this exists for)."""
+    env: dict[str, str] = {}
+    capturing = False
+    for line in text.splitlines():
+        if line == _ENV_PROBE_START:
+            capturing = True
+            continue
+        if line == _ENV_PROBE_END:
+            break
+        if not capturing:
+            continue
+        key, sep, value = line.partition("=")
+        if sep and _ENV_NAME_RE.match(key):
+            env[key] = value
+    return env
+
+
+def _login_shell_env(
+    shell: Optional[str] = None, *, timeout: float = _ENV_PROBE_TIMEOUT
+) -> dict[str, str]:
+    """Best-effort snapshot of the user's login+interactive shell environment (#362).
+
+    POSIX only. Returns `{}` on any failure — no `$SHELL`, Windows, spawn error, timeout, or
+    unparseable output — so the caller falls straight back to today's behavior. Running the
+    user's own rc here is the same code that runs in every terminal they open (the server
+    already runs as the user); the safeguards are operational, not a trust boundary: the dump
+    is fenced between markers so rc chatter isn't parsed as vars, stdin is closed so an rc
+    that reads it can't hang, and the probe is timeout-bounded so a slow rc can't wedge
+    startup.
+    """
+    if _IS_WINDOWS:
+        return {}
+    shell = shell or os.environ.get("SHELL")
+    if not shell:
+        return {}
+    # `-l -i` so BOTH login files (.zprofile/.bash_profile) and interactive files
+    # (.zshrc/.bashrc) run — pyenv/nvm/sdkman init lives in one or the other, and which
+    # one differs across bash and zsh.
+    dump = f'printf "%s\\n" "{_ENV_PROBE_START}"; env; printf "%s\\n" "{_ENV_PROBE_END}"'
+    try:
+        proc = subprocess.run(
+            [shell, "-l", "-i", "-c", dump],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    return _parse_env_dump(proc.stdout)
+
+
+def _merge_paths(primary: Optional[str], secondary: Optional[str]) -> Optional[str]:
+    """Concatenate two PATH strings, primary first, dropping duplicates and empty entries.
+    Keeps the user's shim directories ahead of the server's own PATH without discarding
+    server entries (e.g. an activated venv's bin)."""
+    parts: list[str] = []
+    seen: set[str] = set()
+    for chunk in (primary, secondary):
+        if not chunk:
+            continue
+        for entry in chunk.split(os.pathsep):
+            if entry and entry not in seen:
+                seen.add(entry)
+                parts.append(entry)
+    return os.pathsep.join(parts) if parts else None
 
 
 class Executor(ABC):
@@ -143,6 +232,7 @@ class LocalExecutor(Executor):
         shell_path: Optional[str] = None,
         default_timeout: float = _DEFAULT_TIMEOUT,
         max_output_chars: int = 20_000,
+        probe_login_env: bool = True,
     ) -> None:
         self.cwd = str(Path(cwd).expanduser().resolve())
         self.default_timeout = default_timeout
@@ -161,8 +251,32 @@ class LocalExecutor(Executor):
         if shell_path is None:
             shell_path = "powershell.exe" if self._is_windows else "/bin/bash"
         self._shell_path = shell_path
-        self._env = {**os.environ, **_NONINTERACTIVE_ENV, **(env or {})}
+        self._env = self._build_env(env, probe_login_env)
         self._spawn()
+
+    def _build_env(
+        self, extra: Optional[dict[str, str]], probe_login_env: bool
+    ) -> dict[str, str]:
+        """Assemble the persistent shell's environment (#362).
+
+        Layered so each source overrides the ones before it:
+          1. the user's login-shell env (pyenv/nvm/sdkman shims etc.), best-effort;
+          2. this process's own environment — server-set vars are authoritative, so they win
+             on conflicts, EXCEPT PATH, which is merged (user shims first, then server
+             entries) so neither the user's toolchain nor an activated venv is lost;
+          3. the non-interactive defaults;
+          4. any explicit `env` passed by the caller.
+        A failed or disabled probe collapses layer 1 to `{}`, leaving today's behavior.
+        """
+        probed = _login_shell_env() if probe_login_env else {}
+        merged = {**probed, **os.environ}
+        merged_path = _merge_paths(probed.get("PATH"), os.environ.get("PATH"))
+        if merged_path:
+            merged["PATH"] = merged_path
+        merged.update(_NONINTERACTIVE_ENV)
+        if extra:
+            merged.update(extra)
+        return merged
 
     def _spawn(self) -> None:
         """Start (or restart) the shell process and its reader. Reused for self-healing:

--- a/tests/test_shell_login_env.py
+++ b/tests/test_shell_login_env.py
@@ -1,0 +1,161 @@
+"""#362 — the persistent run_shell must see the user's login-shell toolchain.
+
+A GUI-launched server runs the agent's shell as a non-interactive /bin/bash that never
+sources the user's rc files, so pyenv/nvm/sdkman/conda shims are invisible and the agent
+sees a different environment than the user. `LocalExecutor` now runs a one-time
+login+interactive probe at startup and folds the result into the persistent shell's env.
+
+These tests stub the login shell with a small script that injects a known directory onto
+PATH, so they assert the wiring deterministically without depending on whatever shell or
+toolchain the CI machine happens to have.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+
+import pytest
+
+from coworker.tools.shell import (
+    LocalExecutor,
+    _login_shell_env,
+    _merge_paths,
+    _parse_env_dump,
+    _ENV_PROBE_END,
+    _ENV_PROBE_START,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="login-shell env probe is POSIX-only (#362)"
+)
+
+
+def _fake_login_shell(tmp_path, shim_dir: str):
+    """Write an executable that emulates `<shell> -l -i -c <cmd>`: it prepends `shim_dir`
+    to PATH (as an rc file would add pyenv/nvm shims) and then runs the requested command."""
+    script = tmp_path / "fake_login_shell.sh"
+    script.write_text(
+        "#!/bin/bash\n"
+        f'export PATH="{shim_dir}:$PATH"\n'
+        'cmd="${@: -1}"\n'  # last arg is the -c command
+        'exec /bin/bash -c "$cmd"\n'
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return str(script)
+
+
+# -- pure helpers -------------------------------------------------------------------
+
+def test_parse_env_dump_only_reads_inside_the_fence():
+    text = "\n".join(
+        [
+            "welcome to your shell",  # rc banner before the fence — ignored
+            "BEFORE=nope",
+            _ENV_PROBE_START,
+            "PATH=/a:/b",
+            "PYENV_ROOT=/home/u/.pyenv",
+            "not an assignment line",
+            "1BAD=badname",  # invalid env name — ignored
+            _ENV_PROBE_END,
+            "AFTER=nope",  # after the fence — ignored
+        ]
+    )
+    env = _parse_env_dump(text)
+    assert env == {"PATH": "/a:/b", "PYENV_ROOT": "/home/u/.pyenv"}
+    assert "BEFORE" not in env and "AFTER" not in env
+
+
+def test_parse_env_dump_keeps_equals_in_value():
+    text = f"{_ENV_PROBE_START}\nFOO=a=b=c\n{_ENV_PROBE_END}"
+    assert _parse_env_dump(text) == {"FOO": "a=b=c"}
+
+
+def test_parse_env_dump_empty_without_fence():
+    assert _parse_env_dump("PATH=/a\nHOME=/h") == {}
+
+
+def test_merge_paths_user_first_and_dedup():
+    merged = _merge_paths("/shim:/usr/local/bin", "/usr/local/bin:/usr/bin")
+    assert merged == "/shim:/usr/local/bin:/usr/bin"
+
+
+def test_merge_paths_handles_missing_and_empty():
+    assert _merge_paths(None, "/usr/bin") == "/usr/bin"
+    assert _merge_paths("/usr/bin", None) == "/usr/bin"
+    assert _merge_paths(None, None) is None
+    assert _merge_paths("", "") is None
+
+
+# -- the probe ----------------------------------------------------------------------
+
+def test_login_shell_env_captures_rc_supplied_path(tmp_path):
+    shim = str(tmp_path / "pyenv-shims")
+    env = _login_shell_env(_fake_login_shell(tmp_path, shim))
+    assert shim in env.get("PATH", "").split(os.pathsep)
+
+
+def test_login_shell_env_missing_shell_returns_empty():
+    assert _login_shell_env("/nonexistent/definitely/not/a/shell") == {}
+
+
+def test_login_shell_env_none_when_shell_unset(monkeypatch):
+    monkeypatch.delenv("SHELL", raising=False)
+    assert _login_shell_env() == {}
+
+
+def test_login_shell_env_times_out_gracefully(tmp_path):
+    slow = tmp_path / "slow_shell.sh"
+    slow.write_text("#!/bin/bash\nsleep 5\n")
+    slow.chmod(0o755)
+    assert _login_shell_env(str(slow), timeout=0.5) == {}
+
+
+# -- executor wiring ----------------------------------------------------------------
+
+def test_executor_exposes_login_path_to_commands(tmp_path, monkeypatch):
+    shim = str(tmp_path / "shims")
+    monkeypatch.setenv("SHELL", _fake_login_shell(tmp_path, shim))
+    ex = LocalExecutor(cwd=tmp_path, default_timeout=10, probe_login_env=True)
+    try:
+        assert shim in ex._env["PATH"].split(os.pathsep)
+        # and it actually reaches the live persistent shell, not just the env dict
+        out = ex.run("echo $PATH")["output"]
+        assert shim in out
+    finally:
+        ex.close()
+
+
+def test_executor_probe_disabled_leaves_path_untouched(tmp_path, monkeypatch):
+    shim = str(tmp_path / "shims")
+    monkeypatch.setenv("SHELL", _fake_login_shell(tmp_path, shim))
+    ex = LocalExecutor(cwd=tmp_path, default_timeout=10, probe_login_env=False)
+    try:
+        assert shim not in ex._env["PATH"].split(os.pathsep)
+    finally:
+        ex.close()
+
+
+def test_noninteractive_defaults_win_over_probe(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHELL", _fake_login_shell(tmp_path, str(tmp_path / "shims")))
+    ex = LocalExecutor(cwd=tmp_path, default_timeout=10, probe_login_env=True)
+    try:
+        assert ex._env["GIT_TERMINAL_PROMPT"] == "0"
+        assert ex._env["PIP_NO_INPUT"] == "1"
+    finally:
+        ex.close()
+
+
+def test_explicit_env_overrides_probe(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHELL", _fake_login_shell(tmp_path, str(tmp_path / "shims")))
+    ex = LocalExecutor(
+        cwd=tmp_path,
+        default_timeout=10,
+        probe_login_env=True,
+        env={"PATH": "/only/this"},
+    )
+    try:
+        assert ex._env["PATH"] == "/only/this"
+    finally:
+        ex.close()


### PR DESCRIPTION
## Summary

Closes #362.

`run_shell` runs in a persistent, **non-interactive `/bin/bash`** that never sources the user's rc files, and a GUI-launched server's own environment doesn't carry the user's shell setup either. So a toolchain configured in `~/.zshrc` / `~/.bash_profile` (pyenv, nvm, sdkman, conda, direnv, …) is invisible to the agent — it sees a different environment than the user, mistakes macOS's stock `/usr/bin/python3` (3.9) for the pyenv python the user actually uses, and can install into the wrong interpreter or misreport system state.

## Fix

Run the user's **login + interactive** shell once at executor startup, capture its `env`, and fold the result into the persistent shell's environment. This is the issue's option 2 — it recovers the user's real PATH/toolchain without making per-command execution interactive.

Environment layering in `LocalExecutor._build_env` (each layer overrides the previous):

1. the user's login-shell env (the shim vars);
2. this process's own environment — server-set vars stay authoritative and win on conflicts, **except `PATH`**, which is merged (user shims first, then the server's entries) so neither the user's toolchain nor an activated venv's `bin` is dropped;
3. the existing non-interactive defaults (`GIT_TERMINAL_PROMPT=0`, etc.);
4. any explicit `env=` passed by the caller.

The probe (`_login_shell_env`) is deliberately conservative:

- **POSIX-only**; Windows returns `{}` and behavior is byte-for-byte unchanged.
- **Best-effort** — no `$SHELL`, a spawn error, a timeout, or unparseable output all return `{}`, falling straight back to today's behavior.
- **Bounded** — `stdin` is closed so an rc that reads it can't hang, the run is timeout-capped (5s) so a slow rc can't wedge startup, and the `env` dump is fenced between markers so rc banners/echoes aren't parsed as variables.
- **One-time** — it runs at construction and the result is cached in `self._env`; the per-command shell and the self-healing respawn stay non-interactive.
- Controlled by a new `probe_login_env` argument (default `True`).

On trust: running the user's own rc is the same code that runs in every terminal they open, and the server already runs as the user — so this isn't a new trust boundary. The safeguards above are operational (don't hang, don't mis-parse), not a sandbox.

## Tests

New `tests/test_shell_login_env.py` (13 tests). They **stub the login shell** with a small script that injects a known directory onto `PATH` (standing in for pyenv/nvm shims), so the wiring is verified deterministically regardless of the CI machine's own shell or toolchain:

- pure helpers — fence parsing (ignores banners / invalid names / after-fence lines, keeps `=` in values) and PATH merge (user-first, de-duped, handles missing/empty);
- the probe — captures an rc-supplied PATH entry, and returns `{}` for a missing shell, an unset `$SHELL`, and a timeout;
- the executor — the injected dir reaches both `self._env["PATH"]` **and** a live `echo $PATH`; disabling the probe leaves PATH untouched; non-interactive defaults and an explicit `env=` both still win over the probe.

All pass, and the existing `tests/test_shell.py` (10) and `tests/test_skills.py` remain green (29 total across the files that construct `LocalExecutor`).
