### PR TITLE
fix(macos): declare Calendar/Reminders usage strings so EventKit tools work (#302)

### DIFF
--- a/surfaces/gui/src-tauri/Info.plist
+++ b/surfaces/gui/src-tauri/Info.plist
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!-- Merged into the bundle's Info.plist by Tauri. These usage strings appear inside the macOS
-     permission prompts (Desktop/Documents/Downloads/Photos), so a prompt the user didn't expect
-     at least explains itself — the agent's tool runs are what touch these folders, and only when
-     a task needs them. -->
+     permission prompts (Desktop/Documents/Downloads/Photos/Calendars/Reminders), so a prompt the
+     user didn't expect at least explains itself — the agent's tool runs are what touch these, and
+     only when a task needs them.
+
+     Calendars/Reminders (#302): without these keys macOS' TCC blocks EventKit access OUTRIGHT
+     rather than prompting, so a calendar/reminders MCP tool silently fails. macOS 14 split the
+     key: apps built against the 14+ SDK read the ...FullAccessUsageDescription variant, older
+     systems read the legacy key, so both are declared. Like Photos above (and unlike the mic,
+     a hardened-runtime *device* resource that also needs an entitlement), these personal-
+     information resources are gated by the usage string alone on this non-sandboxed app. -->
 <plist version="1.0">
 <dict>
   <key>NSMicrophoneUsageDescription</key>
@@ -16,5 +23,13 @@
   <string>A task you run may need to read or save files in Downloads. OpenWorker never scans this folder on its own.</string>
   <key>NSPhotoLibraryUsageDescription</key>
   <string>A task you run may need to read an image from your photo library. OpenWorker never scans your photos on its own.</string>
+  <key>NSCalendarsUsageDescription</key>
+  <string>A task you run may need to read or manage events in your calendar, for example a calendar MCP tool. OpenWorker never reads your calendar on its own.</string>
+  <key>NSCalendarsFullAccessUsageDescription</key>
+  <string>A task you run may need to read or manage events in your calendar, for example a calendar MCP tool. OpenWorker never reads your calendar on its own.</string>
+  <key>NSRemindersUsageDescription</key>
+  <string>A task you run may need to read or manage your reminders, for example a reminders MCP tool. OpenWorker never reads your reminders on its own.</string>
+  <key>NSRemindersFullAccessUsageDescription</key>
+  <string>A task you run may need to read or manage your reminders, for example a reminders MCP tool. OpenWorker never reads your reminders on its own.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

Closes #302.

Calendar/reminders MCP tools silently fail on macOS with no permission prompt. The app bundle's `Info.plist` declares usage strings for the microphone, Desktop, Documents, Downloads and Photos, but **not Calendars or Reminders**. macOS' TCC blocks EventKit access **outright** (rather than prompting) when the usage-description key is missing, so the user never gets a chance to grant access and the tool just fails.

## Fix

Add the Calendar and Reminders usage strings to `surfaces/gui/src-tauri/Info.plist` (Tauri merges this file into the bundle's `Info.plist`).

macOS 14 split the calendar/reminders keys, so each is declared in both forms for compatibility:

| Resource | macOS 14+ SDK | Legacy (older systems) |
|---|---|---|
| Calendar | `NSCalendarsFullAccessUsageDescription` | `NSCalendarsUsageDescription` |
| Reminders | `NSRemindersFullAccessUsageDescription` | `NSRemindersUsageDescription` |

An app built against the 14+ SDK reads the `...FullAccess` variant; older systems read the legacy key. Declaring both means the prompt works regardless of which SDK the release is built against or which macOS it runs on. Full-access (not write-only) is used because the calendar tools both read and create/delete events.

## Why no entitlement is needed

The app is **not sandboxed** (`entitlements.plist` has only hardened-runtime keys, no `com.apple.security.app-sandbox`). It already follows the pattern of gating personal-information resources by the usage string alone — `NSPhotoLibraryUsageDescription` is present with no `com.apple.security.personal-information.photos-library` entitlement. Calendars/Reminders are the same class of resource as Photos, so they're handled the same way.

This is deliberately different from the microphone, which needed both a usage string *and* `com.apple.security.device.audio-input` — that's a hardened-runtime **device** resource, a different category from these **personal-information** resources. I've noted this reasoning in the file comment so the distinction is clear to future readers.

## Verification

- `plutil -lint Info.plist` → `OK`
- Each new key reads back via `plutil -extract <key> raw`

A full signed-bundle test would confirm the merged `Info.plist` end to end, but that needs a signed release build; the merge itself is standard Tauri behavior already proven by the existing mic/Photos keys.
