### PR TITLE
fix(macos): restore the hidden window on Dock-icon click (#248)

### DIFF
--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -755,6 +755,16 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building the OpenWorker desktop app")
         .run(|app, event| {
+            // macOS: clicking the Dock icon fires Reopen. Close-to-tray only HIDES the main
+            // window (see on_window_event above), and Tauri does nothing on Reopen by default,
+            // so the app activates (menu bar switches) but no window appears (#248). Reshow it —
+            // same path as the tray "Open" item.
+            #[cfg(target_os = "macos")]
+            {
+                if let RunEvent::Reopen { .. } = &event {
+                    show_main(app);
+                }
+            }
             // Also on Exit: belt-and-suspenders in case a quit path reaches teardown without
             // a preceding ExitRequested (observed with macOS Cmd+Q under the tray setup).
             if matches!(event, RunEvent::ExitRequested { .. } | RunEvent::Exit) {


### PR DESCRIPTION
## Summary

Closes #248.

After the window is dismissed, clicking the Dock icon activates OpenWorker (the menu bar switches) but **no window appears**, and `open -a OpenWorker` doesn't bring it back — only `open -n` (a brand-new instance) does.

## Cause

Close-to-tray **hides** the main window rather than quitting:

```rust
win.on_window_event(move |event| {
    if let WindowEvent::CloseRequested { api, .. } = event {
        let _ = w.hide();
        api.prevent_close();
    }
});
```

But the top-level `RunEvent` handler only dealt with `ExitRequested`/`Exit`. On macOS a Dock-icon click fires `RunEvent::Reopen` (the `applicationShouldHandleReopen` delegate callback), and Tauri does nothing with it by default — so a hidden window is never reshown.

## Fix

Handle `RunEvent::Reopen` by reshowing the main window through the existing `show_main` helper — the exact path the tray **Open** item already uses:

```rust
.run(|app, event| {
    #[cfg(target_os = "macos")]
    {
        if let RunEvent::Reopen { .. } = &event {
            show_main(app);   // unminimize + show + set_focus
        }
    }
    // ...existing Exit handling...
});
```

`Reopen` is macOS-only, so the arm is `#[cfg(target_os = "macos")]`. The `{ .. }` pattern intentionally ignores the `has_visible_windows` field: reshowing/focusing on any reopen is the desired behavior and is a harmless no-op when a window is already up.

## Verification

I confirmed the API against the pinned **tauri 2.11.5** source in the cargo cache:

```rust
// tauri-2.11.5/src/app.rs
#[non_exhaustive]
#[cfg(target_os = "macos")]
Reopen {
    /// Indicates whether the NSApplication object found any visible windows in your application.
    has_visible_windows: bool,
}
```

So the variant is macOS-gated (the `#[cfg]` wrapper is required), it's a non-exhaustive struct variant (the `{ .. }` pattern is correct), and it's emitted exactly for the Dock-icon reopen this issue is about. `show_main(&AppHandle)` is already called identically by the tray menu handler.

I did **not** run a full `cargo build` locally: `generate_context!()` embeds `frontendDist` (`../dist`), so compiling requires a complete `npm run build` + Tauri toolchain pass. The change is a 3-line addition that reuses an existing helper and mirrors the existing `RunEvent` matching in the same closure; happy to adjust if CI surfaces anything.
