### PR TITLE
fix(providers): surface a connected Ollama's pulled models in the picker

### DIFF
--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1788,6 +1788,13 @@ class SessionManager:
             return self._provider_configured(provider)
 
         selectable = [m for m in self._curated_models() if _selectable(m)]
+        # Ollama has no curated matrix — its models are whatever the user has pulled locally.
+        # Surface that live `/api/tags` list directly (gated by the cached liveness probe), else
+        # a connected Ollama's models never appear in the picker and can't be selected or run.
+        if self._ollama_alive():
+            for m in self._ollama_models():
+                if m not in selectable:
+                    selectable.append(m)
         if self.model not in selectable:
             selectable.insert(0, self.model)
         from ..providers.matrix import model_context_windows, model_labels

--- a/tests/test_ollama_model_picker.py
+++ b/tests/test_ollama_model_picker.py
@@ -1,0 +1,43 @@
+"""A connected local Ollama's pulled models must appear in the composer's model picker.
+
+Ollama has no curated matrix — its models are whatever the user pulled locally — so
+``get_settings`` has to surface the live ``/api/tags`` list. Otherwise a connected Ollama
+offers nothing to select or run (the picker only ever shows matrix + user-added models).
+"""
+
+from unittest.mock import patch
+
+from coworker.server.manager import SessionManager
+
+
+def test_live_ollama_models_appear_in_picker(tmp_path):
+    mgr = SessionManager(workspace=tmp_path)
+    live = ["ollama:llama3:latest", "ollama:qwen2.5-coder:32b"]
+    with patch.object(mgr, "_ollama_alive", return_value=True), patch.object(
+        mgr, "_ollama_models", return_value=live
+    ):
+        models = mgr.get_settings()["models"]
+
+    assert "ollama:llama3:latest" in models
+    assert "ollama:qwen2.5-coder:32b" in models
+
+
+def test_ollama_models_hidden_when_server_down(tmp_path):
+    mgr = SessionManager(workspace=tmp_path)
+    with patch.object(mgr, "_ollama_alive", return_value=False), patch.object(
+        mgr, "_ollama_models", return_value=["ollama:llama3:latest"]
+    ):
+        models = mgr.get_settings()["models"]
+
+    assert not any(m.startswith("ollama:") for m in models)
+
+
+def test_live_ollama_model_not_duplicated_when_also_user_added(tmp_path):
+    mgr = SessionManager(workspace=tmp_path)
+    with patch.object(mgr, "_ollama_alive", return_value=True), patch.object(
+        mgr, "_ollama_models", return_value=["ollama:llama3:latest"]
+    ):
+        mgr.add_model("ollama:llama3:latest")  # user also added it by hand
+        models = mgr.get_settings()["models"]
+
+    assert models.count("ollama:llama3:latest") == 1


### PR DESCRIPTION
Closes #386 

The composer's model picker comes from get_settings()["models"], which lists the curated matrix plus user-added ids. Ollama has no matrix entries — its models are whatever the user pulled locally — and the live /api/tags list was only used for the provider's "suggested models" hint, never merged into the picker. So a user who connects Ollama and has models pulled sees nothing selectable and cannot run any Ollama model.

Merge the live _ollama_models() list into the selectable set in get_settings when the cached liveness probe reports Ollama is up, de-duplicated against curated / user-added ids.

Adds regression tests: live models appear, are hidden when the server is down, and are not duplicated when the user has also added one by hand.