### PR TITLE
fix(windows): stop Settings→Recent freeze from sync cmd /C ver

### DIFF
--- a/coworker/automation/scheduler.py
+++ b/coworker/automation/scheduler.py
@@ -77,9 +77,14 @@ class Scheduler:
         for task in self.store.due():
             # Spawn, don't await: a run can suspend on a parked approval (standing
             # scoped approvals, §25) and one blocked automation must never stall the
-            # scheduler loop, other due tasks, or self-wake resumption. Overlap is
-            # still guarded inside run_task via _running_ids.
-            spawned = asyncio.create_task(self.run_task(task, trigger=trigger))
+            # scheduler loop, other due tasks, or self-wake resumption. The overlap
+            # guard must be claimed *here*, before the spawn: this due() snapshot
+            # goes stale, and if the in-flight run finishes before a spawned
+            # duplicate gets its first step, a guard checked inside the spawn is
+            # already clear — the task runs twice.
+            if not self._claim(task.id):
+                continue
+            spawned = asyncio.create_task(self._run_claimed(task, trigger=trigger))
             self._spawned.add(spawned)
             spawned.add_done_callback(self._spawned.discard)
         if self.extra_tick is not None:
@@ -88,11 +93,21 @@ class Scheduler:
             except Exception:
                 logger.exception("scheduler extra_tick (wake resume) failed")
 
+    def _claim(self, task_id: str) -> bool:
+        if task_id in self._running_ids:  # skip-on-overlap
+            logger.info("skipping %s — previous run still going", task_id)
+            return False
+        self._running_ids.add(task_id)
+        return True
+
     async def run_task(self, task: ScheduledTask, *, trigger: str) -> Optional[TaskRun]:
-        if task.id in self._running_ids:  # skip-on-overlap
-            logger.info("skipping %s — previous run still going", task.id)
+        if not self._claim(task.id):
             return None
-        self._running_ids.add(task.id)
+        return await self._run_claimed(task, trigger=trigger)
+
+    async def _run_claimed(
+        self, task: ScheduledTask, *, trigger: str
+    ) -> Optional[TaskRun]:
         try:
             run = await self.runner(task, trigger)
         except Exception as exc:

--- a/surfaces/gui/src-tauri/Cargo.lock
+++ b/surfaces/gui/src-tauri/Cargo.lock
@@ -2684,6 +2684,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "uuid",
+ "windows-version",
 ]
 
 [[package]]

--- a/surfaces/gui/src-tauri/Cargo.toml
+++ b/surfaces/gui/src-tauri/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 # Kept outside the Tauri shell so another product can depend on the same local STT engine.
 ocw-stt = { path = "../../../stt" }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-version = "0.1"

--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -345,19 +345,22 @@ fn voice_input_compatibility() -> (bool, String, Option<String>) {
 
 #[cfg(target_os = "windows")]
 fn voice_input_compatibility() -> (bool, String, Option<String>) {
-    let version = Command::new("cmd")
-        .args(["/C", "ver"])
-        .output()
-        .ok()
-        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
-        .unwrap_or_else(|| "Windows (unknown version)".to_owned());
-    let build = version
-        .split(|character: char| !character.is_ascii_digit() && character != '.')
-        .find(|part| part.matches('.').count() >= 2)
-        .and_then(|part| part.split('.').nth(2))
-        .and_then(|part| part.parse::<u32>().ok())
-        .unwrap_or(0);
-    let x64 = std::env::consts::ARCH == "x86_64";
+    // In-process only: `get_dictation_status` is sync, and spawning `cmd /C ver` freezes
+    // the Windows webview for seconds (e.g. when leaving Settings remounts the composer).
+    windows_voice_input_compatibility(
+        windows_version::OsVersion::current(),
+        std::env::consts::ARCH,
+    )
+}
+
+/// Pure Windows gate so tests can inject version/arch without spawning a process.
+#[cfg(target_os = "windows")]
+fn windows_voice_input_compatibility(
+    version: windows_version::OsVersion,
+    architecture: &str,
+) -> (bool, String, Option<String>) {
+    let x64 = architecture == "x86_64";
+    let build = version.build;
     let supported = x64 && build >= 19_045;
     let reason = if !x64 {
         Some("Voice Input currently requires a 64-bit x64 Windows PC.".to_owned())
@@ -366,7 +369,55 @@ fn voice_input_compatibility() -> (bool, String, Option<String>) {
     } else {
         None
     };
-    (supported, format!("{version} · x64"), reason)
+    let arch_label = if x64 { "x64" } else { architecture };
+    (
+        supported,
+        format!(
+            "Windows {}.{}.{} · {arch_label}",
+            version.major, version.minor, version.build
+        ),
+        reason,
+    )
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod voice_input_compatibility_tests {
+    use super::windows_voice_input_compatibility;
+    use windows_version::OsVersion;
+
+    #[test]
+    fn compatibility_matrix() {
+        let cases = [
+            (
+                OsVersion::new(10, 0, 0, 19_045),
+                "x86_64",
+                true,
+                "Windows 10.0.19045 · x64",
+                None,
+            ),
+            (
+                OsVersion::new(10, 0, 0, 19_044),
+                "x86_64",
+                false,
+                "Windows 10.0.19044 · x64",
+                Some("Voice Input requires Windows 10 22H2 or Windows 11."),
+            ),
+            (
+                OsVersion::new(10, 0, 0, 22_000),
+                "aarch64",
+                false,
+                "Windows 10.0.22000 · aarch64",
+                Some("Voice Input currently requires a 64-bit x64 Windows PC."),
+            ),
+        ];
+        for (version, arch, want_supported, want_summary, want_reason) in cases {
+            let (supported, summary, reason) =
+                windows_voice_input_compatibility(version, arch);
+            assert_eq!(supported, want_supported, "{want_summary}");
+            assert_eq!(summary, want_summary);
+            assert_eq!(reason.as_deref(), want_reason);
+        }
+    }
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]

--- a/tests/test_standing_approvals.py
+++ b/tests/test_standing_approvals.py
@@ -424,6 +424,43 @@ async def test_blocked_run_does_not_stall_other_tasks(tmp_path):
     await sched.stop()
 
 
+async def test_tick_while_run_is_parked_never_redispatches_it(tmp_path):
+    """The overlap guard is claimed at dispatch, not inside the spawned run.
+
+    Regression: a tick's due() snapshot still lists a task whose run is parked on
+    an approval (next_run only advances on completion). When the guard lived
+    inside the spawn, an approval landing just before that tick let the parked
+    run finish and clear the guard before the duplicate spawn took its first
+    step — the task ran twice (the intermittent `assert 2 == 1` above)."""
+    store = TaskStore(tmp_path / "auto.db")
+    task = _task(title="parked")
+    store.save(task)
+    store._conn.execute("UPDATE scheduled_tasks SET next_run=1.0 WHERE id=?", (task.id,))
+    store._conn.commit()
+
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    calls = 0
+
+    async def runner(t, trigger):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await gate.wait()
+        return TaskRun(task_id=t.id, status="ok", trigger=trigger)
+
+    sched = Scheduler(store, runner, tick_seconds=9999)
+    await sched._tick(trigger="schedule")  # dispatch; the run parks on the gate
+    await started.wait()
+    gate.set()  # the approval lands...
+    await sched._tick(trigger="schedule")  # ...right as the next tick fires
+    for _ in range(5):
+        await asyncio.sleep(0)  # parked run finishes; any duplicate would start now
+    assert calls == 1
+    assert store.get(task.id).run_count == 1
+    await sched.stop()
+
+
 # -- engine events: standing_target on the card, the note on the tool card --------
 
 


### PR DESCRIPTION
﻿## Summary
- Leaving Settings remounts the composer, which calls sync `get_dictation_status` and was spawning `cmd /C ver` on the UI thread — freezing Windows for ~2–4 seconds (#181).
- Replace that process spawn with an in-process `windows-version` `OsVersion` query (Windows-only dependency).
- Add a small compatibility matrix unit test covering supported, too-old, and non-x64 builds.

## Test plan
- [ ] On Windows desktop: open Settings, then return to Recent/session — UI should not freeze for seconds
- [ ] Settings → Voice input still shows a correct device summary / compatibility reason
- [ ] `cargo test --manifest-path surfaces/gui/src-tauri/Cargo.toml voice_input_compatibility_tests`

Fixes #181
