### PR TITLE
Encrypt secrets.json at rest; redact secrets from audit tool results

### DIFF
--- a/coworker/audit.py
+++ b/coworker/audit.py
@@ -73,7 +73,7 @@ class AuditStore:
                     event.get("status") or "",
                     event.get("approval") or "",
                     json.dumps(args, default=str),
-                    _truncate(str(event.get("result_preview") or "")),
+                    _result_preview(tool, event),
                     _truncate(str(event.get("reason") or "")),
                     _truncate(str(resource or "")),
                 ),
@@ -135,6 +135,23 @@ def _sanitize_args(tool: str, args: dict[str, Any]) -> dict[str, Any]:
         else:
             out[key] = _summarize(value)
     return out
+
+
+def _result_preview(tool: str, event: dict[str, Any]) -> str:
+    """Redact known-secret keys out of a raw tool result the same way `_sanitize_args` redacts
+    call arguments, before it's stringified into the audit trail. Callers pass the raw `result`
+    dict (not just a pre-stringified preview) precisely so this can happen — engine.py already
+    includes `result=...` alongside `result_preview=...` in the audit event. Stage events with
+    no raw `result` (e.g. "proposed"/"started") fall back to the caller's plain preview string,
+    which never carries a secret in the first place (it's built before any tool executes)."""
+    if "result" in event:
+        result = event.get("result")
+        if isinstance(result, dict):
+            result = _sanitize_args(tool, result)
+        text = result if isinstance(result, str) else json.dumps(result, default=str)
+    else:
+        text = str(event.get("result_preview") or "")
+    return _truncate(text)
 
 
 def _summarize(value: Any) -> Any:

--- a/coworker/secrets.py
+++ b/coworker/secrets.py
@@ -3,13 +3,21 @@
 Design (from OpenClaw): secrets **never enter the model's context, prompts, or traces**.
 The store holds profiles keyed by `connector[:account]`; values may be literals OR
 `${ENV_VAR}` references resolved at read time from the process env / `~/.config/coworker/.env`.
+(`.env` itself stays plaintext by design — it's a hand-edited file following the universal
+dotenv convention, not something this store manages.)
 
-v1 is a `0600` JSON file behind this interface; the interface is what callers depend on, so
-a Keychain / age-encrypted backend can swap in later without touching them.
+v2: `secrets.json` is Fernet-encrypted at rest. The wrapping key is stored in the OS keychain
+(macOS Keychain / Windows Credential Manager / Linux Secret Service, via `keyring`), scoped per
+state directory. If no keychain backend is available (e.g. headless Linux without a Secret
+Service), the wrapping key falls back to a local `0600` file next to the store — secrets stay
+encrypted either way, just without the extra OS-level protection layer on the fallback path.
+v1 plaintext stores are detected on read, backed up to `<path>.bak`, and migrated in place.
+The public interface (`get`/`put`/`delete`/`status`) is unchanged, so callers never see this.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -17,11 +25,30 @@ import subprocess
 import sys
 import threading
 import time
+import warnings
 from pathlib import Path
 from typing import Any, Optional
 
+from cryptography.fernet import Fernet, InvalidToken
+
+try:
+    import keyring
+    from keyring.errors import KeyringError
+except Exception:  # pragma: no cover - keyring is a hard dep; defend against odd platforms anyway
+    keyring = None  # type: ignore[assignment]
+    KeyringError = Exception  # type: ignore[assignment,misc]
+
 _REF = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 _IS_WINDOWS = sys.platform == "win32"
+_KEYRING_SERVICE = "coworker-secrets"
+_STORE_VERSION = 2
+
+
+class SecretStoreError(RuntimeError):
+    """The on-disk secret store can't be decrypted — wrong/missing wrapping key, or corruption.
+
+    Raised rather than silently discarding the store, because silently returning an empty store
+    here would make `put()` overwrite (and permanently lose) every existing credential."""
 
 
 def state_dir() -> Path:
@@ -103,13 +130,61 @@ def write_private_text(path: str | Path, content: str) -> Path:
     return target
 
 
+def _wrap_key_identity(store_path: Path) -> str:
+    """Keyring username scoped to the store's directory, so distinct state dirs (tests, or a
+    `COWORKER_STATE_DIR` override) never share — or collide with — another store's key."""
+    digest = hashlib.sha256(str(store_path.parent.resolve()).encode("utf-8")).hexdigest()[:16]
+    return f"wrapkey:{digest}"
+
+
+def _get_or_create_wrap_key(store_path: Path) -> bytes:
+    """Fernet key for encrypting the store at `store_path`. Prefers the OS keychain; falls back
+    to a local `0600` key file if no keychain backend is available."""
+    username = _wrap_key_identity(store_path)
+
+    if keyring is not None:
+        try:
+            existing = keyring.get_password(_KEYRING_SERVICE, username)
+            if existing:
+                return existing.encode("ascii")
+            new_key = Fernet.generate_key()
+            keyring.set_password(_KEYRING_SERVICE, username, new_key.decode("ascii"))
+            return new_key
+        except Exception:
+            # Backend absence/failure is an expected condition on some platforms (headless
+            # Linux with no Secret Service, sandboxed CI, ...) — fall through to the file key
+            # rather than treating it as a fatal error.
+            pass
+
+    key_path = store_path.parent / ".secrets.key"
+    if key_path.is_file():
+        return key_path.read_text(encoding="ascii").strip().encode("ascii")
+    warnings.warn(
+        f"coworker: no OS keychain backend available; the secrets-at-rest wrapping key for "
+        f"{store_path} is stored in {key_path} instead of the OS keychain. Secrets remain "
+        "encrypted, just without the extra keychain protection layer.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+    new_key = Fernet.generate_key()
+    write_private_text(key_path, new_key.decode("ascii"))
+    return new_key
+
+
 class SecretStore:
-    """File-backed secret store. Reads resolve `${VAR}` refs; status never leaks values."""
+    """File-backed, encrypted-at-rest secret store. Reads resolve `${VAR}` refs; status never
+    leaks values."""
 
     def __init__(self, path: Optional[str | Path] = None) -> None:
         self.path = Path(path).expanduser() if path else state_dir() / "secrets.json"
         self._dotenv_path = self.path.parent / ".env"
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
+        self._fernet: Optional[Fernet] = None
+
+    def _cipher(self) -> Fernet:
+        if self._fernet is None:
+            self._fernet = Fernet(_get_or_create_wrap_key(self.path))
+        return self._fernet
 
     # -- reads ------------------------------------------------------------------
     def get(self, profile: str) -> Optional[dict[str, Any]]:
@@ -174,20 +249,52 @@ class SecretStore:
 
     # -- internals --------------------------------------------------------------
     def _read(self) -> dict[str, Any]:
-        if not self.path.is_file():
-            return {}
-        try:
-            return json.loads(self.path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            return {}
+        with self._lock:
+            if not self.path.is_file():
+                return {}
+            try:
+                raw = json.loads(self.path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                return {}
+            if not isinstance(raw, dict):
+                return {}
+
+            if raw.get("__version__") == _STORE_VERSION and "data" in raw:
+                try:
+                    plaintext = self._cipher().decrypt(raw["data"].encode("ascii"))
+                except (InvalidToken, ValueError) as exc:
+                    raise SecretStoreError(
+                        f"Failed to decrypt {self.path}: the wrapping key is missing/changed, "
+                        "or the file is corrupted. Existing secrets are inaccessible until this "
+                        "is resolved — check the OS keychain entry (service "
+                        f"'{_KEYRING_SERVICE}') or the {self.path.parent / '.secrets.key'} "
+                        "fallback file before deleting anything."
+                    ) from exc
+                try:
+                    store = json.loads(plaintext)
+                except json.JSONDecodeError as exc:
+                    raise SecretStoreError(f"Decrypted {self.path} is not valid JSON") from exc
+                return store if isinstance(store, dict) else {}
+
+            # Legacy (pre-encryption) plaintext store. Back it up once, then migrate in place —
+            # every subsequent read/write goes through the encrypted format from here on.
+            backup = self.path.with_name(self.path.name + ".bak")
+            if not backup.is_file():
+                backup.write_text(json.dumps(raw, indent=2), encoding="utf-8")
+                _restrict_to_user(backup, is_dir=False)
+            self._write(raw)
+            return raw
 
     def _write(self, store: dict[str, Any]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            _restrict_to_user(self.path.parent, is_dir=True)
-        except OSError:
-            pass
-        tmp = self.path.with_name(self.path.name + ".tmp")
-        tmp.write_text(json.dumps(store, indent=2), encoding="utf-8")
-        _restrict_to_user(tmp, is_dir=False)
-        os.replace(tmp, self.path)
+        with self._lock:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                _restrict_to_user(self.path.parent, is_dir=True)
+            except OSError:
+                pass
+            token = self._cipher().encrypt(json.dumps(store).encode("utf-8"))
+            payload = {"__version__": _STORE_VERSION, "data": token.decode("ascii")}
+            tmp = self.path.with_name(self.path.name + ".tmp")
+            tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            _restrict_to_user(tmp, is_dir=False)
+            os.replace(tmp, self.path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
     "websockets>=13",  # managed Slack relay client transport (relay_client.py)
     "ddgs>=9",  # keyless default web-search provider (DuckDuckGo); Tavily/Brave use httpx
     "croniter>=2",  # cron next-fire math for the automation scheduler
+    "cryptography>=42",  # Fernet encryption for secrets.json at rest (coworker/secrets.py)
+    "keyring>=24",  # OS keychain (macOS/Windows/Secret Service) for the secrets wrapping key
     # PDF attachments for models without native PDF support (pdf_support.py):
     # pypdf = pure-python text extraction; pypdfium2 = page rasterization (BSD pdfium,
     # ships its own libpdfium — NOT PyMuPDF, whose AGPL license can't ride in the DMG).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pytest
 import pytest_asyncio
 
+from coworker import secrets as secrets_module
 from coworker.testing.fake_slack import FakeSlack
 
 
@@ -22,6 +23,27 @@ def _isolated_state_dir(tmp_path, monkeypatch):
     as burst noise in the ocw-connect-telemetry-events table)."""
     monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "coworker-state"))
     monkeypatch.delenv("COWORKER_API_TOKEN", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _fake_keyring(monkeypatch):
+    """EVERY test gets an in-memory fake OS keychain for SecretStore's wrapping key. Without
+    this, SecretStore falls through to the developer's real OS keychain (Keychain-unlock
+    prompts on macOS) or, on CI runners with no Secret Service, to the file-key fallback path —
+    either way tests would be non-hermetic and could leave stray entries in a real keychain.
+    Tests that specifically want to exercise the fallback path monkeypatch
+    `secrets_module.keyring = None` themselves."""
+    store: dict[tuple[str, str], str] = {}
+
+    def _get_password(service: str, username: str) -> str | None:
+        return store.get((service, username))
+
+    def _set_password(service: str, username: str, password: str) -> None:
+        store[(service, username)] = password
+
+    if secrets_module.keyring is not None:
+        monkeypatch.setattr(secrets_module.keyring, "get_password", _get_password)
+        monkeypatch.setattr(secrets_module.keyring, "set_password", _set_password)
 
 
 @pytest_asyncio.fixture

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import os
 import stat
 import subprocess
 import sys
 import time
 
-from coworker.secrets import SecretStore
+import pytest
+
+from coworker import secrets as secrets_module
+from coworker.secrets import SecretStore, SecretStoreError
 
 
 def test_put_get_round_trip(tmp_path):
@@ -85,3 +89,72 @@ def test_delete(tmp_path):
     assert store.delete("x") is True
     assert store.delete("x") is False
     assert store.get("x") is None
+
+
+def test_store_is_encrypted_on_disk(tmp_path):
+    """The whole point of C0-encryption: the raw file must not contain the secret in the
+    clear, and must be wrapped in the versioned envelope, not a bare profile map."""
+    path = tmp_path / "secrets.json"
+    SecretStore(path).put("slack:default", {"type": "token", "bot_token": "xoxb-super-secret"})
+    raw_text = path.read_text(encoding="utf-8")
+    assert "xoxb-super-secret" not in raw_text
+    payload = json.loads(raw_text)
+    assert payload["__version__"] == 2
+    assert "data" in payload and "slack:default" not in payload
+
+
+def test_legacy_plaintext_store_migrates_in_place(tmp_path):
+    """A pre-encryption secrets.json (bare `{profile: data}` JSON, no envelope) must still be
+    readable, and must be transparently upgraded to the encrypted format — with the original
+    bytes preserved in a `.bak` file in case the migration needs to be rolled back."""
+    path = tmp_path / "secrets.json"
+    legacy = {"slack:default": {"type": "token", "bot_token": "xoxb-legacy"}}
+    path.write_text(json.dumps(legacy), encoding="utf-8")
+
+    store = SecretStore(path)
+    assert store.get("slack:default") == {"type": "token", "bot_token": "xoxb-legacy"}
+
+    # Migrated in place: the file on disk is now the encrypted envelope, not the legacy shape.
+    migrated = json.loads(path.read_text(encoding="utf-8"))
+    assert migrated["__version__"] == 2
+    assert "xoxb-legacy" not in path.read_text(encoding="utf-8")
+
+    # Original plaintext preserved for rollback.
+    backup = path.with_name(path.name + ".bak")
+    assert json.loads(backup.read_text(encoding="utf-8")) == legacy
+
+
+def test_decrypt_failure_raises_instead_of_silently_wiping(tmp_path):
+    """If the wrapping key is lost/rotated and the store can't be decrypted, this must raise —
+    not silently return an empty store, which would make a subsequent put() overwrite (and
+    permanently lose) every existing credential."""
+    path = tmp_path / "secrets.json"
+    SecretStore(path).put("x", {"a": 1})
+
+    # Simulate a lost wrapping key: forget the fake keyring entry for this store's identity.
+    username = secrets_module._wrap_key_identity(path)
+    if secrets_module.keyring is not None:
+        secrets_module.keyring.set_password(secrets_module._KEYRING_SERVICE, username, "")
+
+    fresh_store = SecretStore(path)  # new instance -> no cached Fernet key
+    with pytest.raises(SecretStoreError):
+        fresh_store.get("x")
+
+
+def test_keyring_unavailable_falls_back_to_local_key_file(tmp_path, monkeypatch):
+    """Headless environments with no OS keychain backend (e.g. Linux CI with no Secret Service)
+    must still encrypt at rest, via a local 0600 key file instead of the keychain."""
+    monkeypatch.setattr(secrets_module, "keyring", None)
+    path = tmp_path / "secrets.json"
+
+    with pytest.warns(RuntimeWarning, match="no OS keychain backend available"):
+        SecretStore(path).put("slack:default", {"bot_token": "xoxb-fallback"})
+
+    assert "xoxb-fallback" not in path.read_text(encoding="utf-8")
+    key_path = path.parent / ".secrets.key"
+    assert key_path.is_file()
+    if sys.platform != "win32":
+        assert stat.S_IMODE(os.stat(key_path).st_mode) == 0o600
+
+    # A second store instance reusing the same file-backed key can still decrypt.
+    assert SecretStore(path).get("slack:default") == {"bot_token": "xoxb-fallback"}


### PR DESCRIPTION
## Summary
- `coworker/secrets.py`: encrypt `secrets.json` at rest with Fernet, wrapping key stored in the OS keychain (falls back to a local `0600` key file when no keychain backend is available, e.g. headless Linux). Legacy plaintext stores are detected on read, backed up to `.bak`, and migrated in place. Public `SecretStore` interface is unchanged.
- `coworker/audit.py`: redact known-secret keys from raw tool `result` payloads before they're written into the audit trail, using the same sanitizer already applied to call arguments.
- Adds `cryptography` and `keyring` dependencies; adds an autouse fake-keychain fixture so tests stay hermetic (no real OS keychain prompts, no stray keychain entries).

## Test plan
- [x] `pytest tests/test_secrets.py` — round trip, on-disk encryption, legacy migration, decrypt-failure-raises, keychain-unavailable fallback
- [ ] `.venv/bin/pytest` full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)