### PR TITLE
Coerce ask_user options to strings — object-shaped options blank the desktop window

### DIFF
--- a/coworker/inbox.py
+++ b/coworker/inbox.py
@@ -58,6 +58,44 @@ def args_preview(arguments: Optional[dict], *, limit: int = 240) -> str:
     return out[: limit - 1] + "…" if len(out) > limit else out
 
 
+# ask_user's declared signature is ``options: list[str] | None``, but a model is free to emit
+# whatever it likes — several (MiniMax-M2/M3, and anything imitating Claude Code's
+# AskUserQuestion) return objects: ``[{"content": "…"}]`` or ``[{"label": …, "description": …}]``.
+# Those objects used to reach the GUI verbatim, where each option is rendered as a React child;
+# React throws "Objects are not valid as a React child", and with no error boundary the whole tree
+# unmounts — a blank window on every launch that restores the session. Normalise at the store, the
+# one chokepoint every producer (live socket, unattended mirror) and the persisted file share.
+def coerce_options(options: Any) -> list[str]:
+    if not options:
+        return []
+    if isinstance(options, (str, bytes)) or not isinstance(options, (list, tuple)):
+        options = [options]
+    out: list[str] = []
+    for opt in options:
+        if isinstance(opt, str):
+            out.append(opt)
+        elif isinstance(opt, dict):
+            # Take the first human-readable field; fall back to a compact dump so the choice is
+            # still answerable rather than silently dropped.
+            label = next(
+                (
+                    opt[k]
+                    for k in ("content", "label", "text", "title", "value", "name")
+                    if isinstance(opt.get(k), str) and opt[k].strip()
+                ),
+                None,
+            )
+            if label is None:
+                label = json.dumps(opt, ensure_ascii=False, default=str)
+            desc = opt.get("description")
+            if isinstance(desc, str) and desc.strip() and desc.strip() != label.strip():
+                label = f"{label} — {desc}"
+            out.append(label)
+        else:
+            out.append(str(opt))
+    return out
+
+
 @dataclass
 class InboxItem:
     id: str
@@ -100,6 +138,9 @@ class InboxStore:
         if self.path and self.path.is_file():
             data = json.loads(self.path.read_text(encoding="utf-8"))
             for raw in data.get("items", []):
+                # An inbox.json written before options were coerced can still hold objects;
+                # repair on load so upgrading is enough to un-break an already-poisoned file.
+                raw["options"] = coerce_options(raw.get("options"))
                 item = InboxItem(**raw)
                 self._items[item.id] = item
 
@@ -143,7 +184,7 @@ class InboxStore:
             inbox=inbox,
             visibility=visibility,
             data=dict(data or {}),
-            options=list(options or []),
+            options=coerce_options(options),
             allow_text=bool(allow_text),
             multi=bool(multi),
             tool_call_id=tool_call_id,

--- a/surfaces/gui/src/components/ApprovalCard.test.tsx
+++ b/surfaces/gui/src/components/ApprovalCard.test.tsx
@@ -304,3 +304,52 @@ describe("InboxItemCard — parked save_skill proposals (SKILLS-SPEC §5.2)", ()
     expect(onResolve).toHaveBeenCalledWith("i9", "deny");
   });
 });
+
+describe("InboxItemCard — ask_user options that aren't strings", () => {
+  const question = (options: unknown[]): InboxItem =>
+    ({
+      id: "q1",
+      session_id: "s1",
+      kind: "question",
+      title: "Ship it?",
+      body: "",
+      state: "pending",
+      resolution: null,
+      inbox: "default",
+      created_at: "",
+      resolved_at: null,
+      options,
+      allow_text: true,
+    }) as unknown as InboxItem;
+
+  it("renders object-shaped options instead of taking the app down", () => {
+    const onResolve = vi.fn();
+    // The MiniMax-M3 shape that blanked the window, and Claude Code's, in one card. Rendering an
+    // object as a React child throws; with no boundary above this, that unmounted everything.
+    render(
+      <InboxItemCard
+        item={question([{ content: "Ship it" }, { label: "Wait", description: "hold a day" }])}
+        onResolve={onResolve}
+      />,
+    );
+    expect(screen.getByText("Ship it")).toBeTruthy();
+    expect(screen.getByText("Wait — hold a day")).toBeTruthy();
+    // The resolution is the normalized string, so the answer the agent receives is answerable text.
+    fireEvent.click(screen.getByText("Ship it"));
+    expect(onResolve).toHaveBeenCalledWith("q1", "Ship it");
+  });
+
+  it("multi-select joins the normalized labels", () => {
+    const onResolve = vi.fn();
+    render(
+      <InboxItemCard
+        item={{ ...question([{ content: "EU" }, { content: "US" }]), multi: true }}
+        onResolve={onResolve}
+      />,
+    );
+    fireEvent.click(screen.getByText("EU"));
+    fireEvent.click(screen.getByText("US"));
+    fireEvent.click(screen.getByText("Send (2)"));
+    expect(onResolve).toHaveBeenCalledWith("q1", "EU, US");
+  });
+});

--- a/surfaces/gui/src/components/InboxItemCard.tsx
+++ b/surfaces/gui/src/components/InboxItemCard.tsx
@@ -31,6 +31,28 @@ const OPT_ON = "border-accent bg-accentSoft text-accent font-medium";
 const INPUT =
   "flex-1 min-w-0 rounded-lg bg-paper border border-line px-3 py-2 text-[13px] text-ink placeholder:text-faint outline-none focus:border-lineStrong";
 
+// `options` is typed `string[]`, but the type is a promise the wire can't keep: models routinely
+// answer ask_user with objects ([{content}] from MiniMax-M3, [{label, description}] from anything
+// imitating Claude Code) and only the LOCAL server coerces them (inbox.py). The live
+// question_requested frame and any older/third-party server still deliver the raw shape, and an
+// object rendered as a React child throws — which used to take the whole app down. Mirror the
+// server's field order so both surfaces name a choice the same way.
+function optionLabel(opt: unknown): string {
+  if (typeof opt === "string") return opt;
+  if (opt && typeof opt === "object") {
+    const o = opt as Record<string, unknown>;
+    const key = ["content", "label", "text", "title", "value", "name"].find(
+      (k) => typeof o[k] === "string" && (o[k] as string).trim(),
+    );
+    const label = key ? (o[key] as string) : JSON.stringify(opt);
+    const desc = o.description;
+    return typeof desc === "string" && desc.trim() && desc.trim() !== label.trim()
+      ? `${label} — ${desc}`
+      : label;
+  }
+  return String(opt);
+}
+
 export function InboxItemCard({
   item,
   onResolve,
@@ -44,7 +66,8 @@ export function InboxItemCard({
 }) {
   const [answer, setAnswer] = useState("");
   const [selected, setSelected] = useState<string[]>([]);
-  const options = item.options || [];
+  // Normalized up front so selection, the multi-select join and the resolution all speak strings.
+  const options = ((item.options as unknown[]) || []).map(optionLabel);
   const multi = !!item.multi;
   const allowText = item.allow_text !== false;
 

--- a/surfaces/gui/src/main.test.tsx
+++ b/surfaces/gui/src/main.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Drives the REAL main.tsx: stub #root, make App throw, and assert the boundary paints. React 18
+// unmounts the whole tree on an uncaught render throw, so what this pins is that a bad payload can
+// no longer become a blank window with nothing on screen to report.
+vi.mock("./App", () => ({
+  App: () => {
+    throw new Error("Objects are not valid as a React child (found: object with keys {content})");
+  },
+}));
+vi.mock("./tailwind.css", () => ({}));
+vi.mock("./styles.css", () => ({}));
+
+describe("root error boundary", () => {
+  it("shows the error and a way out instead of a blank window", async () => {
+    const root = document.createElement("div");
+    root.id = "root";
+    document.body.appendChild(root);
+    // React logs the caught error itself; silence it so a passing run stays quiet.
+    const noise = vi.spyOn(console, "error").mockImplementation(() => {});
+    await import("./main");
+    await new Promise((r) => setTimeout(r, 100));
+    noise.mockRestore();
+
+    expect(root.textContent).toContain("OpenWorker hit an error and stopped.");
+    // The message is the actionable part — it's what a user can paste into a bug report.
+    expect(root.textContent).toContain("Objects are not valid as a React child");
+    expect(root.querySelector("button")?.textContent).toBe("Reload");
+  });
+});

--- a/surfaces/gui/src/main.tsx
+++ b/surfaces/gui/src/main.tsx
@@ -17,8 +17,48 @@ document.documentElement.dataset.platform = platformOS();
 window.addEventListener("dragover", (e) => e.preventDefault());
 window.addEventListener("drop", (e) => e.preventDefault());
 
+// React 18 unmounts the entire tree on an uncaught render throw, so without a boundary the window
+// simply goes blank — which is how one malformed ask_user option (an object where a string was
+// promised) turned into an app that wouldn't start, with nothing on screen to say why. The boundary
+// can't repair the state that threw; it exists so the failure is legible and the error text is
+// something the user can report.
+class RootBoundary extends React.Component<{ children: React.ReactNode }, { error: Error | null }> {
+  state = { error: null as Error | null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    // A standalone shell, deliberately not `.app` — that class is the sidebar/content grid.
+    return (
+      <div className="h-screen grid place-items-center p-8 bg-paper text-ink">
+        <div className="max-w-lg rounded-xl2 border border-line bg-panel px-5 py-4">
+          <div className="text-[15px] font-semibold">OpenWorker hit an error and stopped.</div>
+          <div className="text-[13px] text-muted mt-1">
+            The conversation is saved — reloading usually gets you back in.
+          </div>
+          <pre className="mt-3 px-2.5 py-1.5 rounded-lg border border-line bg-paper font-mono text-[11.5px] leading-relaxed text-muted whitespace-pre-wrap break-words max-h-56 overflow-auto">
+            {error.message || String(error)}
+          </pre>
+          <button
+            className="mt-3 px-3 py-1.5 rounded-lg bg-accent text-white text-[12.5px] font-medium hover:brightness-105"
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <RootBoundary>
+      <App />
+    </RootBoundary>
   </React.StrictMode>,
 );

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 from coworker.inbox import (
     KIND_APPROVAL,
@@ -127,3 +128,40 @@ def test_approval_body_includes_tool_args():
 
     req2 = PermissionRequest("rm", {"path": "/x"}, None, "destructive")
     assert _approval_body(req2).startswith("destructive")  # reason leads when present
+
+
+def test_coerce_options_normalizes_model_shapes():
+    from coworker.inbox import coerce_options
+
+    # The declared shape passes through untouched.
+    assert coerce_options(["EU", "US"]) == ["EU", "US"]
+    # MiniMax-M3's shape — the one that blanked the desktop window.
+    assert coerce_options([{"content": "Ship it"}, {"content": "Wait"}]) == [
+        "Ship it",
+        "Wait",
+    ]
+    # Claude Code's AskUserQuestion shape: the description enriches the label, never replaces it.
+    assert coerce_options([{"label": "EU", "description": "Europe"}]) == ["EU — Europe"]
+    # A description that merely repeats the label doesn't get appended twice.
+    assert coerce_options([{"label": "EU", "description": "EU"}]) == ["EU"]
+    # Junk still yields an answerable string rather than an object reaching the GUI.
+    junk = coerce_options([{"weird": 1}])
+    assert len(junk) == 1 and isinstance(junk[0], str) and "weird" in junk[0]
+    # Non-lists, empties and Nones all collapse to "no quick replies".
+    assert coerce_options(None) == [] and coerce_options([]) == []
+    assert coerce_options("EU") == ["EU"]
+    assert coerce_options([1, True]) == ["1", "True"]
+
+
+def test_add_question_and_reload_coerce_options(tmp_path):
+    path = tmp_path / "inbox.json"
+    store = InboxStore(path)
+    item = store.add_question("s1", "Ship it?", options=[{"content": "Yes"}, "No"])
+    assert item.options == ["Yes", "No"]  # coerced at the store, before anything persists
+
+    # An inbox.json written by an older build still holds objects; loading repairs it, so an
+    # upgrade alone un-breaks a file that would otherwise crash the GUI on every launch.
+    poisoned = json.loads(path.read_text(encoding="utf-8"))
+    poisoned["items"][0]["options"] = [{"content": "Yes"}, {"label": "No", "description": "stop"}]
+    path.write_text(json.dumps(poisoned), encoding="utf-8")
+    assert InboxStore(path).get(item.id).options == ["Yes", "No — stop"]


### PR DESCRIPTION
# Fix: `ask_user` options that aren't strings blank the desktop window

## What happens

Launch OpenWorker, it restores the last session, and the window is **completely white**. Nothing renders — no sidebar, no composer. The sidecar is healthy and `~/.config/coworker/logs/openworker-server.log` is a wall of `200 OK`:

```
INFO: 127.0.0.1:51777 - "GET /v1/settings HTTP/1.1" 200 OK
INFO: 127.0.0.1:51778 - "GET /v1/sessions/<id>/messages HTTP/1.1" 200 OK
INFO: 127.0.0.1:51781 - "GET /v1/inbox?session_id=<id>&state=pending HTTP/1.1" 200 OK
...
```

Every request the frontend makes succeeds. There is nothing in the log to find, which is most of why this is hard to diagnose.

## Root cause

`ask_user` declares `options: list[str] | None` (`coworker/tools/ask.py:19`), but a model is free to emit whatever it likes — and several do:

* **MiniMax-M2 / M3** answer with `[{"content": "…"}]`
* Models imitating **Claude Code's `AskUserQuestion`** answer with `[{"label": …, "description": …}]`

Both askers passed the model's value straight through:

```python
# coworker/server/app.py:1549   (attended / live socket)
options=list(args.get("options") or []),
# coworker/server/manager.py:751 (unattended / Inbox)
options=list(args.get("options") or []),
# coworker/inbox.py:146          (store)
options=list(options or []),
```

`list()` copies the outer list only, so the dicts land verbatim in `inbox.json`, in the `question_requested` socket frame, and in `/v1/inbox`.

`InboxItemCard` renders each option **directly as a React child** (`InboxItemCard.tsx:143`):

```tsx
{options.map((opt) => (
  <button key={opt} onClick={() => onResolve(item.id, opt)}>
    {opt}          {/* an object here throws */}
  </button>
))}
```

React throws `Objects are not valid as a React child (found: object with keys {content})`. **There is no error boundary anywhere in the GUI** — no `componentDidCatch`, no `getDerivedStateFromError`, no `window.onerror` — so React 18 unmounts the entire tree and `<div id="root">` is left empty. That is the white screen, literally.

Two things make it worse than a one-off render glitch:

1. **It's sticky.** Once the item is in `inbox.json`, `sessionInbox` is polled on every launch for the active session (`App.tsx:852-861`) regardless of attended/unattended, so the app blanks on *every* subsequent start. The only way out is hand-editing `inbox.json` — with no error on screen telling you that.
2. **It's silent.** The boot splash self-clears after 1500 ms (`App.tsx:499-503`), so the user sees splash → white, and the server log shows a clean startup.

Reproduced end-to-end by mounting the real `<App/>` in jsdom against a mocked sidecar serving a restored session plus one pending inbox item with object-shaped options: `ROOT HTML LENGTH: 0`.

## The fix

**Coerce at the store, not at each call site.** `InboxStore.add` is the one chokepoint the live socket, the unattended mirror and the persisted file all share, and `app.py` emits `item.options` (post-coercion) on the socket — so one change covers all three producers.

* `coworker/inbox.py` — new `coerce_options()`; used by `InboxStore.add`. A dict contributes its first human-readable field (`content` / `label` / `text` / `title` / `value` / `name`), enriched with `description` when that adds something, so the resolution handed back to the agent is answerable text rather than `[object Object]`. Junk still degrades to a compact JSON dump instead of being dropped.
* `InboxStore._load` repairs older files, so **upgrading alone un-breaks an `inbox.json` that already holds objects** — users hitting this today don't have to hand-edit anything.
* `surfaces/gui/src/components/InboxItemCard.tsx` — normalises too, mirroring the server's field order. Defence in depth: the live `question_requested` frame and any older or third-party server can still deliver the raw shape.
* `surfaces/gui/src/main.tsx` — a root error boundary. It can't repair the state that threw; it exists so the next data-shape surprise is a legible error with a Reload button instead of a window with nothing in it. This is the part that turns a class of bug from "unrecoverable and unreportable" into "annoying".

`App.tsx` is deliberately untouched: `InboxItemCard` is the only renderer of `options` (checked every consumer), so normalising there covers the live path without duplicating the logic.

## Tests

* `tests/test_inbox.py` — `coerce_options` across all the shapes (pass-through, MiniMax, Claude Code, self-repeating description, junk dict, non-list, `None`), plus `add_question` coercion and the `_load` self-repair round-trip.
* `surfaces/gui/src/components/ApprovalCard.test.tsx` — `InboxItemCard` renders object-shaped options and resolves with the normalised string; multi-select joins normalised labels.
* `surfaces/gui/src/main.test.tsx` — drives the real `main.tsx` with a throwing `App` and asserts the boundary paints the message and a Reload button.

```
$ python -m pytest tests/test_inbox.py -q
11 passed

$ npx tsc --noEmit          # clean
$ npx vitest run            # 16 files, 85 tests passed
$ npm run build             # ✓ built in 10.13s
```

The full `pytest tests/` run has 14 failures on this branch — all pre-existing and environmental, confirmed identical on a clean tree (`test_bedrock_provider.py`: `ModuleNotFoundError: botocore`; `test_fake_slack.py`: websockets-legacy deprecation timeouts; `test_ui_refresh_e2e.py`).

## Workaround for anyone hitting this before the fix ships

Rewrite the options in `~/.config/coworker/inbox.json` as plain strings and relaunch:

```bash
python3 - <<'EOF'
import json, pathlib
p = pathlib.Path.home() / ".config/coworker/inbox.json"
d = json.loads(p.read_text())
for i in d.get("items", []):
    i["options"] = [
        o if isinstance(o, str) else next(
            (o[k] for k in ("content", "label", "text") if isinstance(o.get(k), str)),
            json.dumps(o, ensure_ascii=False),
        )
        for o in (i.get("options") or [])
    ]
p.write_text(json.dumps(d, ensure_ascii=False, indent=2))
EOF
```

It will come back the next time the model answers `ask_user` with objects, though — the socket path blanks the window live.
