### PR TITLE
fix(compaction, secrets): attachment token estimate, O(n) boundary search, atomic secret writes

### DIFF
--- a/coworker/compaction.py
+++ b/coworker/compaction.py
@@ -40,21 +40,54 @@ _SPAN_BUDGET_CHARS = 400_000
 _USER_MESSAGE_CLIP = 600
 _USER_MESSAGES_MAX = 40
 _TRIM_FRACTION = 0.10
+# Flat token estimates for non-text content parts, whose base64 length is unrelated to what
+# the provider bills. Order-of-magnitude figures for a full-resolution image / a short PDF —
+# the point is not to be exact but to stop a data URL from dominating the whole signal.
+_IMAGE_PART_TOKENS = 1_500
+_FILE_PART_TOKENS = 3_000
 
 
 # -- token math ---------------------------------------------------------------
 
 
+def _serialized_len(value: Any) -> int:
+    try:
+        return len(json.dumps(value, default=str))
+    except (TypeError, ValueError):
+        return len(str(value))
+
+
+def _message_chars(msg: Any) -> int:
+    """Serialized size of one message, with attachment parts charged at their real
+    token cost rather than their base64 length.
+
+    Images and PDFs ride in `content` as `data:` URLs (attachments.py caps them at 12 M
+    and 15 M characters). chars/4 reads a 1.5 MB screenshot as ~375 k tokens when a vision
+    model charges it closer to 1.5 k — enough, on its own, to sit permanently above
+    `cap_tokens` and re-trigger compaction on every iteration of the turn loop.
+    """
+    if not isinstance(msg, dict):
+        return _serialized_len(msg)
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return _serialized_len(msg)
+    chars = _serialized_len({k: v for k, v in msg.items() if k != "content"})
+    for part in content:
+        kind = part.get("type") if isinstance(part, dict) else None
+        if kind == "image_url":
+            chars += _IMAGE_PART_TOKENS * 4
+        elif kind == "file":
+            chars += _FILE_PART_TOKENS * 4
+        else:
+            chars += _serialized_len(part)
+    return chars
+
+
 def estimate_tokens(messages: list[dict[str, Any]]) -> int:
     """chars/4 over the serialized messages — the fallback signal for providers that
-    never report usage (documented in the metering code)."""
-    total = 0
-    for msg in messages:
-        try:
-            total += len(json.dumps(msg, default=str))
-        except (TypeError, ValueError):
-            total += len(str(msg))
-    return total // 4
+    never report usage (documented in the metering code). Attachment parts are charged a
+    flat per-part estimate; see `_message_chars`."""
+    return sum(_message_chars(msg) for msg in messages) // 4
 
 
 def trigger_tokens(
@@ -152,9 +185,17 @@ def pick_boundary(messages: list[dict[str, Any]], *, keep_tokens: int) -> Option
     start = 1 if messages and messages[0].get("role") == "system" else 0
     users, assistants = _turn_starts(messages, start=start)
 
+    # suffix[i] = serialized chars of messages[i:], built in one backward pass. Measuring
+    # each candidate with `estimate_tokens(messages[i:])` instead re-serializes the whole
+    # tail per candidate — O(n²), and ~1 s of blocking CPU on a 1 200-message session,
+    # paid on the turn loop every time the trigger fires.
+    suffix = [0] * (len(messages) + 1)
+    for i in range(len(messages) - 1, -1, -1):
+        suffix[i] = suffix[i + 1] + _message_chars(messages[i])
+
     def _fit(candidates: list[int]) -> Optional[int]:
         for i in candidates:  # earliest-first: keep as much verbatim as fits
-            if estimate_tokens(messages[i:]) <= keep_tokens:
+            if suffix[i] // 4 <= keep_tokens:
                 return i
         return None
 
@@ -167,7 +208,10 @@ def pick_boundary(messages: list[dict[str, Any]], *, keep_tokens: int) -> Option
         if boundary is None:
             boundary = inside[-1] if inside else users[-1]
     if boundary is None:
-        boundary = _fit(assistants) or (assistants[-1] if assistants else None)
+        fitted = _fit(assistants)
+        # `or` here would discard a legitimate index 0 (a history with no system message
+        # that opens on an assistant turn); it is filtered by the `<= start` check below.
+        boundary = fitted if fitted is not None else (assistants[-1] if assistants else None)
     # A boundary at (or before) the first real message summarizes nothing — skip.
     if boundary is None or boundary <= start:
         return None

--- a/coworker/secrets.py
+++ b/coworker/secrets.py
@@ -15,6 +15,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -22,6 +23,10 @@ from typing import Any, Optional
 
 _REF = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 _IS_WINDOWS = sys.platform == "win32"
+
+
+class SecretStoreCorrupt(RuntimeError):
+    """The store file exists but cannot be parsed — raised instead of overwriting it."""
 
 
 def state_dir() -> Path:
@@ -91,16 +96,44 @@ def _restrict_to_user(path: Path, *, is_dir: bool) -> None:
 def write_private_text(path: str | Path, content: str) -> Path:
     """Atomically write a user-only text file using the SecretStore's OS protections."""
     target = Path(path).expanduser()
+    _write_private_atomic(target, content)
+    return target
+
+
+def _write_private_atomic(target: Path, content: str) -> None:
+    """Write `content` to `target` atomically, never exposing it at the process umask.
+
+    Three things `Path.write_text` + `os.replace` did not do:
+
+    * **Mode.** `write_text` creates the temp at the umask (0644 on a stock install) and
+      only narrows it afterwards, so the plaintext tokens are world-readable for the
+      length of the write. `mkstemp` creates at 0600 before a byte is written.
+    * **Durability.** Without an fsync, a crash between write and rename can promote a
+      truncated temp. That truncated file is exactly what makes `_read` unparseable, which
+      used to cost the user every other credential in the store (see `_read`).
+    * **A unique name.** The fixed `<name>.tmp` is shared by every process pointed at the
+      same store — the server and the `openworker-connectors` CLI, say — so two concurrent
+      writes could interleave into one temp and rename the mix into place.
+    """
     target.parent.mkdir(parents=True, exist_ok=True)
     try:
         _restrict_to_user(target.parent, is_dir=True)
     except OSError:
         pass
-    tmp = target.with_name(target.name + ".tmp")
-    tmp.write_text(content, encoding="utf-8")
-    _restrict_to_user(tmp, is_dir=False)
-    os.replace(tmp, target)
-    return target
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(target.parent), prefix=target.name + ".", suffix=".tmp"
+    )
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        _restrict_to_user(tmp, is_dir=False)  # no-op on POSIX; sets the ACL on Windows
+        os.replace(tmp, target)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 class SecretStore:
@@ -159,13 +192,13 @@ class SecretStore:
     # -- writes -----------------------------------------------------------------
     def put(self, profile: str, data: dict[str, Any]) -> None:
         with self._lock:
-            store = self._read()
+            store = self._read(strict=True)
             store[profile] = data
             self._write(store)
 
     def delete(self, profile: str) -> bool:
         with self._lock:
-            store = self._read()
+            store = self._read(strict=True)
             if profile not in store:
                 return False
             del store[profile]
@@ -173,21 +206,39 @@ class SecretStore:
             return True
 
     # -- internals --------------------------------------------------------------
-    def _read(self) -> dict[str, Any]:
+    def _read(self, *, strict: bool = False) -> dict[str, Any]:
+        """The parsed store, or `{}` when it is absent or unreadable.
+
+        `strict=True` (the read-modify-write paths) raises `SecretStoreCorrupt` instead of
+        returning `{}` for a file that exists but does not parse. Swallowing that on the
+        write path meant a single truncated `secrets.json` — a crash mid-write, a full
+        disk — turned the next `put()` into a one-key store, silently discarding every
+        other connector credential the user had authorized.
+        """
         if not self.path.is_file():
             return {}
         try:
-            return json.loads(self.path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+            raw = self.path.read_text(encoding="utf-8")
+        except OSError as exc:
+            if strict:
+                raise SecretStoreCorrupt(f"cannot read {self.path}: {exc}") from exc
             return {}
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            if strict:
+                raise SecretStoreCorrupt(
+                    f"{self.path} exists but is not valid JSON ({exc}). Refusing to "
+                    "overwrite it — move it aside to start a fresh store."
+                ) from exc
+            return {}
+        if not isinstance(data, dict):
+            if strict:
+                raise SecretStoreCorrupt(
+                    f"{self.path} does not contain a JSON object. Refusing to overwrite it."
+                )
+            return {}
+        return data
 
     def _write(self, store: dict[str, Any]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            _restrict_to_user(self.path.parent, is_dir=True)
-        except OSError:
-            pass
-        tmp = self.path.with_name(self.path.name + ".tmp")
-        tmp.write_text(json.dumps(store, indent=2), encoding="utf-8")
-        _restrict_to_user(tmp, is_dir=False)
-        os.replace(tmp, self.path)
+        _write_private_atomic(self.path, json.dumps(store, indent=2))

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -2,6 +2,7 @@
 extraction, summarizer seam, trim fallback, outbound view. No engine involved."""
 
 import json
+import time
 
 import pytest
 
@@ -344,3 +345,75 @@ def test_user_messages_capped_across_repeated_compactions():
     assert restored is not None
     assert restored.user_messages_dropped == state.user_messages_dropped
     assert restored.user_messages == state.user_messages
+
+
+# -- attachments --------------------------------------------------------------
+
+
+def _image_turn(chars: int = 1_500_000) -> dict:
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "what's in this screenshot?"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64," + "A" * chars},
+            },
+        ],
+    }
+
+
+def test_image_part_is_not_charged_its_base64_length():
+    """A data-URL image must not dominate the signal: chars/4 read a 1.5 MB screenshot as
+    ~375k tokens, so a single attachment sat permanently above cap_tokens and re-triggered
+    compaction on every iteration of the turn loop."""
+    msgs = [{"role": "system", "content": "s"}, _image_turn()]
+    est = estimate_tokens(msgs)
+    assert est < 5_000
+    assert not should_compact(est, 200_000)
+
+
+def test_pdf_part_is_not_charged_its_base64_length():
+    msgs = [
+        {"role": "system", "content": "s"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "summarize this"},
+                {
+                    "type": "file",
+                    "file": {
+                        "filename": "report.pdf",
+                        "file_data": "data:application/pdf;base64," + "B" * 2_000_000,
+                    },
+                },
+            ],
+        },
+    ]
+    assert estimate_tokens(msgs) < 10_000
+
+
+def test_text_only_estimate_is_unchanged_by_part_handling():
+    """Text-only histories must measure exactly as before — the whole trigger threshold is
+    calibrated against that number."""
+    msgs = convo(turns=6)
+    assert estimate_tokens(msgs) == sum(len(json.dumps(m, default=str)) for m in msgs) // 4
+
+
+def test_boundary_search_is_linear_in_history_length():
+    """Measuring each candidate with estimate_tokens(messages[i:]) re-serialized the whole
+    tail per candidate — ~1 s of blocking CPU on a 1 200-message session, on the turn loop."""
+    msgs = [{"role": "system", "content": "s"}]
+    for i in range(300):
+        a = assistant("done " + "z" * 300, tool_calls=[("read_file", {"path": "a.py"})])
+        msgs += [
+            user(f"task {i} " + "x" * 400),
+            a,
+            tool(a["tool_calls"][0]["id"], {"exit_code": 0, "out": "y" * 4000}),
+        ]
+    started = time.perf_counter()
+    boundary = pick_boundary(msgs, keep_tokens=40_000)
+    elapsed = time.perf_counter() - started
+    assert boundary is not None
+    assert estimate_tokens(msgs[boundary:]) <= 40_000
+    assert elapsed < 0.25  # linear lands ~7 ms here; the quadratic version took ~950 ms

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -6,6 +6,7 @@ import time
 
 import pytest
 
+from coworker import compaction
 from coworker.compaction import (
     CompactionState,
     DEFAULT_CAP_TOKENS,
@@ -350,11 +351,11 @@ def test_user_messages_capped_across_repeated_compactions():
 # -- attachments --------------------------------------------------------------
 
 
-def _image_turn(chars: int = 1_500_000) -> dict:
+def _image_turn(chars: int = 1_500_000, text: str = "what's in this screenshot?") -> dict:
     return {
         "role": "user",
         "content": [
-            {"type": "text", "text": "what's in this screenshot?"},
+            {"type": "text", "text": text},
             {
                 "type": "image_url",
                 "image_url": {"url": "data:image/png;base64," + "A" * chars},
@@ -363,34 +364,72 @@ def _image_turn(chars: int = 1_500_000) -> dict:
     }
 
 
+def _pdf_turn(chars: int = 2_000_000) -> dict:
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "summarize this"},
+            {
+                "type": "file",
+                "file": {
+                    "filename": "report.pdf",
+                    "file_data": "data:application/pdf;base64," + "B" * chars,
+                },
+            },
+        ],
+    }
+
+
 def test_image_part_is_not_charged_its_base64_length():
     """A data-URL image must not dominate the signal: chars/4 read a 1.5 MB screenshot as
     ~375k tokens, so a single attachment sat permanently above cap_tokens and re-triggered
-    compaction on every iteration of the turn loop."""
+    compaction on every iteration of the turn loop.
+
+    Bracketed on both sides. The upper bound is the defect being fixed; the lower bound
+    guards the inverse defect, an attachment charged ~nothing, which would keep a history
+    that really is over the cap permanently under it. A one-sided `< 5_000` certifies an
+    estimate that collapsed to 26 just as readily as the correct ~1.5k.
+    """
     msgs = [{"role": "system", "content": "s"}, _image_turn()]
     est = estimate_tokens(msgs)
-    assert est < 5_000
+    assert 1_000 < est < 5_000
     assert not should_compact(est, 200_000)
 
 
 def test_pdf_part_is_not_charged_its_base64_length():
-    msgs = [
-        {"role": "system", "content": "s"},
-        {
-            "role": "user",
-            "content": [
-                {"type": "text", "text": "summarize this"},
-                {
-                    "type": "file",
-                    "file": {
-                        "filename": "report.pdf",
-                        "file_data": "data:application/pdf;base64," + "B" * 2_000_000,
-                    },
-                },
-            ],
-        },
-    ]
-    assert estimate_tokens(msgs) < 10_000
+    msgs = [{"role": "system", "content": "s"}, _pdf_turn()]
+    est = estimate_tokens(msgs)
+    assert 2_000 < est < 10_000  # bracketed both sides; see the image test
+
+
+def test_attachment_estimate_does_not_track_data_url_length():
+    """The property the fix establishes is *independence* from base64 length, so assert it
+    differentially rather than at one sampled size. The range spans what attachments.py
+    actually admits (MAX_IMAGE_CHARS 12 M, MAX_PDF_CHARS 15 M) — a bound checked only at
+    1.5 MB says nothing about the sizes the GUI's own picker allows through.
+    """
+    images = {estimate_tokens([_image_turn(n)]) for n in (100_000, 1_500_000, 12_000_000)}
+    assert len(images) == 1, f"image estimate varied with data-URL length: {sorted(images)}"
+    pdfs = {estimate_tokens([_pdf_turn(n)]) for n in (100_000, 2_000_000, 15_000_000)}
+    assert len(pdfs) == 1, f"file estimate varied with data-URL length: {sorted(pdfs)}"
+
+
+def test_text_alongside_an_attachment_is_still_counted():
+    """Only `image_url` and `file` parts get the flat charge; every other part falls to the
+    `else` branch and must still be measured. A long pasted prompt next to a screenshot is
+    the ordinary case, and charging it zero is the same under-count in a different place.
+    """
+    small = estimate_tokens([_image_turn(text="hi")])
+    large = estimate_tokens([_image_turn(text="x" * 40_000)])
+    assert large - small >= 9_000  # 40k chars / 4, less serialization slack
+
+
+def test_message_keys_outside_content_are_still_counted():
+    """`_message_chars` measures the non-content keys separately once it takes the list
+    branch. `tool_call_id`, `name` and friends are real tokens on the wire."""
+    base = {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+    tagged = {**base, "name": "z" * 4_000}
+    assert estimate_tokens([tagged]) - estimate_tokens([base]) >= 900
 
 
 def test_text_only_estimate_is_unchanged_by_part_handling():
@@ -400,20 +439,97 @@ def test_text_only_estimate_is_unchanged_by_part_handling():
     assert estimate_tokens(msgs) == sum(len(json.dumps(m, default=str)) for m in msgs) // 4
 
 
-def test_boundary_search_is_linear_in_history_length():
-    """Measuring each candidate with estimate_tokens(messages[i:]) re-serialized the whole
-    tail per candidate — ~1 s of blocking CPU on a 1 200-message session, on the turn loop."""
+def _long_history(turns: int = 300) -> list[dict]:
     msgs = [{"role": "system", "content": "s"}]
-    for i in range(300):
+    for i in range(turns):
         a = assistant("done " + "z" * 300, tool_calls=[("read_file", {"path": "a.py"})])
         msgs += [
             user(f"task {i} " + "x" * 400),
             a,
             tool(a["tool_calls"][0]["id"], {"exit_code": 0, "out": "y" * 4000}),
         ]
+    return msgs
+
+
+def test_boundary_search_measures_each_message_a_bounded_number_of_times(monkeypatch):
+    """The complexity claim, asserted without a clock.
+
+    Measuring each candidate with `estimate_tokens(messages[i:])` re-serialized the whole
+    tail per candidate — ~1 s of blocking CPU on a 1 200-message session, on the turn loop.
+    Counting the per-message measurements separates O(n) from O(n²) exactly, on any
+    machine and under any CI load, where a wall-clock bound only does so probabilistically.
+    """
+    msgs = _long_history()
+    calls = 0
+    real = compaction._message_chars
+
+    def counting(msg):
+        nonlocal calls
+        calls += 1
+        return real(msg)
+
+    monkeypatch.setattr(compaction, "_message_chars", counting)
+    boundary = pick_boundary(msgs, keep_tokens=40_000)
+    assert boundary is not None
+    assert calls <= 3 * len(msgs)  # one backward pass; quadratic ran ~150x this
+
+
+def test_boundary_search_is_linear_in_history_length():
+    """Wall-clock companion to the call-count test above: catches a regression that keeps
+    the call count linear but makes each call expensive."""
+    msgs = _long_history()
     started = time.perf_counter()
     boundary = pick_boundary(msgs, keep_tokens=40_000)
     elapsed = time.perf_counter() - started
     assert boundary is not None
     assert estimate_tokens(msgs[boundary:]) <= 40_000
-    assert elapsed < 0.25  # linear lands ~7 ms here; the quadratic version took ~950 ms
+    assert elapsed < 0.25  # linear lands ~5 ms here; the quadratic version took ~700 ms
+
+
+def test_falls_back_to_the_last_assistant_when_no_candidate_fits():
+    """The `assistants[-1]` fallback, on the one path that reaches it: a history with no
+    user turns at all (the `if users:` block short-circuits every other route there).
+
+    Pins which end of the list the fallback takes. `assistants[0]` would cut at the very
+    front and summarize the whole history; the intent is the opposite — keep as little as
+    possible when even the newest turn will not fit.
+    """
+    msgs = [{"role": "system", "content": "s"}]
+    for i in range(6):
+        a = assistant("step " + "y" * 3000, tool_calls=[("run_shell", {"command": f"c{i}"})])
+        msgs += [a, tool(a["tool_calls"][0]["id"], {"exit_code": 0, "out": "z" * 3000})]
+    _, assistants = compaction._turn_starts(msgs, start=1)
+    assert len(assistants) > 2  # otherwise [-1] and [-2] coincide and the check is inert
+    boundary = pick_boundary(msgs, keep_tokens=10)  # nothing fits in 10 tokens
+    assert boundary == assistants[-1]
+    assert msgs[boundary]["role"] == "assistant"
+
+
+def test_history_that_wholly_fits_is_not_compacted():
+    """`_fit` returning a legitimate index 0 means the entire history fits inside
+    keep_tokens, so there is nothing to summarize. The `or` this replaced coerced that 0 to
+    the `assistants[-1]` fallback and compacted a history of a few dozen tokens.
+    """
+    msgs = [{"role": "assistant", "content": f"a{i}"} for i in range(3)]
+    assert estimate_tokens(msgs) < 100
+    assert pick_boundary(msgs, keep_tokens=10_000) is None
+
+
+# -- what these checks do NOT cover -------------------------------------------
+#
+# * **The absolute accuracy of the flat estimates.** 1_500 / 3_000 are bracketed to an
+#   order of magnitude, not anchored to a provider's published image-token formula. A
+#   systematically wrong-but-plausible constant (say 600, or 4_000) passes everything here.
+#   Anchoring to the documented formula for the vision models actually in use would turn
+#   this from a range check into a real oracle.
+# * **Multiple attachments in one message.** Every case above carries a single image or
+#   file; N-attachment accumulation is unexercised.
+# * **Providers that report real usage.** estimate_tokens is the fallback signal only, so
+#   none of this constrains behaviour on providers that meter properly.
+# * **Boundary quality, as opposed to boundary cost.** The complexity checks assert the
+#   search is linear and that the kept tail fits; they do not assert the boundary chosen is
+#   the *best* one, and the earliest-first preference is covered only by the pre-existing
+#   test_boundary_prefers_earliest_user_turn_that_fits.
+# * **The exact-threshold boundary.** Nothing pins `suffix[i] // 4 <= keep_tokens` at
+#   equality, so an off-by-one to `<` survives; every case here sits clear of the threshold.
+#   Known from a mutation pass rather than assumed.

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -8,7 +8,9 @@ import subprocess
 import sys
 import time
 
-from coworker.secrets import SecretStore
+import pytest
+
+from coworker.secrets import SecretStore, SecretStoreCorrupt
 
 
 def test_put_get_round_trip(tmp_path):
@@ -85,3 +87,53 @@ def test_delete(tmp_path):
     assert store.delete("x") is True
     assert store.delete("x") is False
     assert store.get("x") is None
+
+
+def test_temp_file_is_never_world_readable_mid_write(tmp_path, monkeypatch):
+    """The plaintext must never touch disk at the process umask. write_text created the temp
+    at 0644 and narrowed it only afterwards, leaving a readable window."""
+    if sys.platform == "win32":
+        return  # mode bits are meaningless here; the ACL is asserted above
+    seen: list[int] = []
+    real_fdopen = os.fdopen
+
+    def spy(fd, *args, **kwargs):
+        seen.append(stat.S_IMODE(os.fstat(fd).st_mode))
+        return real_fdopen(fd, *args, **kwargs)
+
+    monkeypatch.setattr(os, "fdopen", spy)
+    monkeypatch.setattr(os, "umask", lambda mask: 0o000, raising=False)
+    SecretStore(tmp_path / "secrets.json").put("slack:default", {"bot_token": "xoxb-1"})
+    assert seen and all(mode == 0o600 for mode in seen)
+
+
+def test_no_stray_temp_files_left_behind(tmp_path):
+    store = SecretStore(tmp_path / "secrets.json")
+    store.put("a", {"v": 1})
+    store.put("b", {"v": 2})
+    assert [p.name for p in tmp_path.iterdir()] == ["secrets.json"]
+
+
+def test_corrupt_store_is_not_silently_overwritten(tmp_path):
+    """A truncated secrets.json used to parse as {}, so the next put() wrote a one-key store
+    and discarded every other connector credential."""
+    path = tmp_path / "secrets.json"
+    store = SecretStore(path)
+    store.put("slack:default", {"bot_token": "xoxb-1"})
+    store.put("github:default", {"token": "ghp-1"})
+
+    path.write_text('{"slack:default": {"bot_to', encoding="utf-8")  # truncated write
+
+    with pytest.raises(SecretStoreCorrupt):
+        store.put("notion:default", {"token": "secret-1"})
+    with pytest.raises(SecretStoreCorrupt):
+        store.delete("slack:default")
+    assert path.read_text(encoding="utf-8") == '{"slack:default": {"bot_to'
+
+
+def test_reads_still_degrade_gracefully_on_a_corrupt_store(tmp_path):
+    path = tmp_path / "secrets.json"
+    path.write_text("{not json", encoding="utf-8")
+    store = SecretStore(path)
+    assert store.get("anything") is None
+    assert store.status() == []

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -91,7 +91,14 @@ def test_delete(tmp_path):
 
 def test_temp_file_is_never_world_readable_mid_write(tmp_path, monkeypatch):
     """The plaintext must never touch disk at the process umask. write_text created the temp
-    at 0644 and narrowed it only afterwards, leaving a readable window."""
+    at 0644 and narrowed it only afterwards, leaving a readable window.
+
+    The spy fires on the descriptor before any byte is written, so this fails two ways: the
+    write path stops going through an fd we can inspect, or the fd is created permissively.
+    Deliberately does NOT patch os.umask — nothing in secrets.py calls it, so a patch there
+    would read as though the permissive-umask case were covered when it is not. The real
+    guard is that mkstemp's mode does not depend on the umask at all.
+    """
     if sys.platform == "win32":
         return  # mode bits are meaningless here; the ACL is asserted above
     seen: list[int] = []
@@ -102,7 +109,6 @@ def test_temp_file_is_never_world_readable_mid_write(tmp_path, monkeypatch):
         return real_fdopen(fd, *args, **kwargs)
 
     monkeypatch.setattr(os, "fdopen", spy)
-    monkeypatch.setattr(os, "umask", lambda mask: 0o000, raising=False)
     SecretStore(tmp_path / "secrets.json").put("slack:default", {"bot_token": "xoxb-1"})
     assert seen and all(mode == 0o600 for mode in seen)
 
@@ -112,6 +118,79 @@ def test_no_stray_temp_files_left_behind(tmp_path):
     store.put("a", {"v": 1})
     store.put("b", {"v": 2})
     assert [p.name for p in tmp_path.iterdir()] == ["secrets.json"]
+
+
+def test_no_temp_file_left_behind_when_the_write_fails(tmp_path, monkeypatch):
+    """The success path cleans up via os.replace; the failure path needs the handler. A
+    store directory slowly filling with world-readable `.tmp` fragments is the same
+    disclosure the mode fix closes, arriving by a different route."""
+    store = SecretStore(tmp_path / "secrets.json")
+    store.put("a", {"v": 1})
+    real_replace = os.replace
+
+    def boom(src, dst, *args, **kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError):
+        store.put("b", {"v": 2})
+    monkeypatch.setattr(os, "replace", real_replace)
+    assert [p.name for p in tmp_path.iterdir()] == ["secrets.json"]
+
+
+def test_each_write_uses_a_distinct_temp_path(tmp_path, monkeypatch):
+    """The fixed `<name>.tmp` was shared by every process pointed at the same store — the
+    server and the openworker-connectors CLI, say — so two concurrent writes could
+    interleave into one temp and rename the mixture into place.
+
+    Observes the paths actually handed to os.replace rather than spying on mkstemp, so it
+    holds for any implementation that reaches uniqueness some other way.
+    """
+    seen: list[str] = []
+    real_replace = os.replace
+
+    def spy(src, dst, *args, **kwargs):
+        seen.append(str(src))
+        return real_replace(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(os, "replace", spy)
+    store = SecretStore(tmp_path / "secrets.json")
+    for key in ("a", "b", "c"):
+        store.put(key, {"v": key})
+    assert len(seen) == 3
+    assert len(set(seen)) == 3, f"temp path reused across writes: {seen}"
+
+
+def test_store_is_fsynced_before_the_rename(tmp_path, monkeypatch):
+    """Without an fsync a crash between write and rename can promote a truncated temp, and
+    that truncated file is exactly what makes _read unparseable.
+
+    A mechanism check, not a durability proof — it confirms fsync is called on the store's
+    own descriptor before the rename, which is as far as a test can go without a crash
+    harness. See the coverage-limits note at the bottom of this module.
+    """
+    order: list[str] = []
+    real_fsync, real_replace = os.fsync, os.replace
+    monkeypatch.setattr(os, "fsync", lambda fd: (order.append("fsync"), real_fsync(fd))[1])
+    monkeypatch.setattr(
+        os, "replace", lambda s, d, *a, **k: (order.append("replace"), real_replace(s, d))[1]
+    )
+    SecretStore(tmp_path / "secrets.json").put("a", {"v": 1})
+    assert order == ["fsync", "replace"]
+
+
+def test_store_directory_is_created_and_restricted(tmp_path):
+    """The store's parent is created on demand — the first write on a fresh machine lands in
+    a directory that does not exist yet — and is restricted to the user, since a 0755 parent
+    lets anyone list which connectors are configured even when the file itself is 0600.
+    """
+    path = tmp_path / "state" / "coworker" / "secrets.json"
+    store = SecretStore(path)
+    store.put("slack:default", {"bot_token": "xoxb-1"})
+    assert store.get("slack:default") == {"bot_token": "xoxb-1"}
+    if sys.platform != "win32":
+        assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
 
 def test_corrupt_store_is_not_silently_overwritten(tmp_path):
@@ -131,9 +210,40 @@ def test_corrupt_store_is_not_silently_overwritten(tmp_path):
     assert path.read_text(encoding="utf-8") == '{"slack:default": {"bot_to'
 
 
+def test_non_object_store_is_not_silently_overwritten(tmp_path):
+    """Valid JSON that is not an object — `[]`, `null`, a bare string — parses fine and then
+    fails the isinstance check. It reaches the same discard-every-credential outcome as a
+    truncated file, so the strict path has to refuse it too."""
+    for payload in ("[]", "null", '"a string"'):
+        path = tmp_path / f"secrets-{len(payload)}.json"
+        path.write_text(payload, encoding="utf-8")
+        store = SecretStore(path)
+        with pytest.raises(SecretStoreCorrupt):
+            store.put("notion:default", {"token": "secret-1"})
+        assert path.read_text(encoding="utf-8") == payload
+
+
 def test_reads_still_degrade_gracefully_on_a_corrupt_store(tmp_path):
     path = tmp_path / "secrets.json"
     path.write_text("{not json", encoding="utf-8")
     store = SecretStore(path)
     assert store.get("anything") is None
     assert store.status() == []
+
+
+# -- what these checks do NOT cover -------------------------------------------
+#
+# Stated rather than left implicit: a green run is silent about the thing it did not look
+# at in exactly the tone it uses for the thing it approved.
+#
+# * **Durability across a real crash.** test_store_is_fsynced_before_the_rename asserts the
+#   call order, not that the bytes survive power loss. Proving that needs a crash harness
+#   (or a filesystem fault injector); nothing here exercises it.
+# * **Genuine write concurrency.** test_each_write_uses_a_distinct_temp_path establishes
+#   that sequential writes do not collide on a name. Two processes racing on the same store
+#   are not simulated, and the cross-process case has no lock — self._lock is per-instance.
+# * **Windows ACLs.** The mode assertions are skipped on win32; _restrict_to_user's ACL
+#   behaviour there is covered only by the pre-existing platform test.
+# * **Partial-line truncation that still parses.** A store truncated at a point that happens
+#   to yield valid JSON is indistinguishable from a smaller store, and no checksum exists to
+#   tell them apart.


### PR DESCRIPTION

<!-- Open at: https://github.com/andrewyng/openworker/compare/main...oaustegard:openworker:fix/compaction-attachment-tokens-and-secret-store-atomicity?expand=1 -->

Hello — I'm **Muninn**, a Claude-based assistant. [@oaustegard](https://github.com/oaustegard) asked me to read OpenWorker and see whether I could contribute something useful; this PR is my work, opened under his account, and he's reviewed it. I'm flagging the authorship up front because you should weigh it when you decide how much of your time this is worth.

So let me lead with the part that should make it cheap to evaluate: **every claim below has a test that fails on `main` and passes here.** I ran the full backend suite (1,092 passed, 1 skipped) and I benchmarked the two performance claims rather than asserting them.

First, though, the honest context: the README says you work from an internal roadmap and may decline PRs that deviate from it. These are three defect fixes, not features, so I hope they sit inside it — but if the shape is wrong, say so and I'll close it without argument. There are no screenshots because nothing here is visual; timings and test results stand in.

---

### 1. `estimate_tokens` charges attachments their base64 length

Attachments ride in message content as `data:` URLs (`attachments.py` caps them at 12 MB for images, 15 MB for PDFs). `estimate_tokens` is `len(json.dumps(msg)) // 4`, so a **1.5 MB screenshot measures 375,052 tokens** — against a 160,000 trigger. A vision model charges that image closer to 1,500.

This matters because `_compaction_due()` falls back to the estimator whenever the provider hasn't reported usage, which includes the first turn of every session *and* every turn after a compaction (`_last_context_tokens` is reset to `None` at `engine.py:524`). So attaching one screenshot fires compaction before the model is ever called, and then again on every iteration of the tool loop — a summarizer round-trip each time, indefinitely. The retained tail still contains the image, so it never settles.

Fix: charge `image_url` and `file` parts a flat per-part estimate. Text-only histories measure byte-identically — there's a test pinning that, since the whole trigger threshold is calibrated against the old number.

Measured: 375,052 → 1,530 tokens; `should_compact` flips `True` → `False`.

**The one judgment call in this PR:** `_IMAGE_PART_TOKENS = 1_500` / `_FILE_PART_TOKENS = 3_000` are my numbers, chosen to be order-of-magnitude right rather than exact. `providers/matrix.py` already knows per-model facts and might be the better home for these. Happy to move them or take your figures.

### 2. `pick_boundary` is O(n²) on the turn loop

`_fit` called `estimate_tokens(messages[i:])` per candidate, re-serializing the entire tail each time. On a 1,201-message session that is **950 ms of blocking CPU**, paid every time the trigger fires — and issue 1 makes it fire constantly.

One backward pass of suffix sums gives the identical boundary (index 1073 both ways) in **6.7 ms**. The regression test asserts `< 0.25 s`; unpatched it measures 1.28 s.

Also fixed while here: `boundary = _fit(assistants) or (...)` discards a legitimate index `0` — reachable for a history with no system message opening on an assistant turn. Currently masked by the `<= start` check, but it's a live trap for anyone editing that block.

### 3. The secret store has a permission window and a credential-loss path

`Path.write_text` creates the temp at the process umask — **0644 on a stock install** — and narrows it to 0600 only *after* the plaintext connector tokens are on disk. Three related problems in the same few lines:

- **Mode.** The window is small but the contents are every OAuth token the user has authorized.
- **Durability.** No `fsync` before the rename, so a crash can promote a truncated temp.
- **Uniqueness.** The fixed `<name>.tmp` is shared by every process pointed at the store — the server and the `openworker-connectors` CLI, for instance — so two concurrent writes can interleave into one temp and rename the mix into place. The `threading.Lock` only covers one process.

And those compound into the bad one: a truncated `secrets.json` makes `_read` raise `JSONDecodeError`, which was caught and turned into `{}`. The next `put()` then writes a **one-key store, silently discarding every other credential the user had connected.**

Fix: `mkstemp` (0600 before a byte is written) + `fsync` + unique name + cleanup on failure, and `_read(strict=True)` on the read-modify-write paths raises `SecretStoreCorrupt` rather than overwriting a file it couldn't parse. `get`/`status` still degrade quietly, so reads are unaffected.

**Worth calling out:** this turns a silent credential wipe into a visible failure in the connector-save path. I think that's the right trade, but it *is* a behavior change and it's the thing I'd most expect you to push back on. If you'd rather it moved the bad file aside and continued, that's a small edit.

---

### What I checked and did not change

A few things looked like problems and weren't, in case it saves you the same detour:

- `PermissionEngine` only path-scopes writes carrying a literal `path` argument, so `apply_patch` / `apply_unified_diff` — which carry paths inside the patch body — pass that check untouched. But aisuite's `files` toolkit re-resolves every diff path against the roots (`_resolve_diff_path`), so the enforcement is real, one layer down.
- `::ffff:127.0.0.1` as a URL literal skips the `ipv4_mapped` unwrap that the resolved path in `web/guard.py` does. It's caught anyway by `is_private` on 3.10–3.12, so it's cosmetic rather than a bypass.

Separately: `web/guard.py` checking every redirect hop and naming DNS rebinding as explicitly out of scope, and the `icacls` path in `secrets.py` because `chmod 0600` is a silent no-op on Windows, are both better than what I usually find. The comments explain *why*, which is why these three were findable at all.

### Verification

- Full backend suite: **1,092 passed, 1 skipped**. (`tests/test_shell.py::test_background_task_runs_and_exits` is timing-flaky under parallel load and passes in isolation; it touches neither changed module.)
- The three new compaction tests fail against unpatched source — including the perf one at 1.28 s vs the 0.25 s bound — so none of them are vacuous.
- The secret-store tests can't be isolated the same way, since importing `SecretStoreCorrupt` fails on `main`. That one rests on reading the code: baseline `_read` swallows `JSONDecodeError` and returns `{}`, and `put` writes that back.

Happy to split this into three PRs if that reviews better.
