### PR TITLE
Require approval before opening browser URLs

### DIFF
--- a/coworker/connectors/tool_defs.py
+++ b/coworker/connectors/tool_defs.py
@@ -36,7 +36,7 @@ TOOL_DEFS: tuple[ConnectorToolDef, ...] = (
         "browser",
         "browser_open_url",
         "Open URL",
-        "read",
+        "write",
         "Open a URL in the Playwright browser.",
     ),
     ConnectorToolDef(

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -257,8 +257,8 @@ def test_engine_connector_tools_are_cowork_scoped(tmp_path):
     assert "browser_read_url" not in helper.registry.names()
     assert "browser_open_url" not in helper.registry.names()
 
-    # §36: browser READS (registry kind) are free; interactions still gate.
-    assert cowork.registry.get("browser_open_url").metadata.requires_approval is False
+    # §36: browser page reads are free; outbound navigation and interactions still gate.
+    assert cowork.registry.get("browser_open_url").metadata.requires_approval is True
     assert cowork.registry.get("browser_snapshot").metadata.requires_approval is False
     assert cowork.registry.get("browser_click").metadata.requires_approval is True
     assert cowork.registry.get("browser_type").metadata.requires_approval is True

--- a/tests/test_send_target_resolution.py
+++ b/tests/test_send_target_resolution.py
@@ -38,7 +38,7 @@ def test_integration_tools_reads_are_free_writes_gate(tmp_path):
     )
 
 
-def test_browser_automation_reads_are_free_interactions_gate():
+def test_browser_automation_reads_are_free_navigation_and_interactions_gate():
     from coworker.connectors.browser_automation import make_browser_automation_tools
 
     tools = {t.__name__: t for t in make_browser_automation_tools()}
@@ -46,7 +46,7 @@ def test_browser_automation_reads_are_free_interactions_gate():
         tools["browser_snapshot"].__aisuite_tool_metadata__.requires_approval is False
     )
     assert (
-        tools["browser_open_url"].__aisuite_tool_metadata__.requires_approval is False
+        tools["browser_open_url"].__aisuite_tool_metadata__.requires_approval is True
     )
     assert tools["browser_click"].__aisuite_tool_metadata__.requires_approval is True
     assert tools["browser_type"].__aisuite_tool_metadata__.requires_approval is True


### PR DESCRIPTION
## Summary
- classify browser_open_url as gate-worthy so model-supplied outbound navigation prompts before opening a real browser URL
- keep browser page reads such as browser_snapshot free
- update connector approval tests to cover navigation gating

Fixes #399.

## Tests
- uv run --extra dev pytest tests/test_send_target_resolution.py tests/test_url_address_guard.py tests/test_connectors.py::test_engine_connector_tools_are_cowork_scoped -q
- git diff --check