### PR TITLE
fix(telemetry): make product events opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ A curated model list marks what we've verified for tool-calling work. Adding any
 
 ## Privacy
 
-OpenWorker is local-first. Everything lives on your machine: the agent loop, your conversations, connector tokens, and model keys - all in the app's local secret store. The only cloud piece is a small service that brokers OAuth handshakes for connectors. You can always use the App without signing-in - use the connectors via manually-created credentials/API-keys.
+OpenWorker is local-first. The agent loop, conversations, connector tokens, and model keys remain on your machine in the local secret store. Work data leaves your machine only through the models and integrations you choose.
+
+OpenWorker Cloud is optional. It provides sign-in and brokered OAuth for managed connectors. Managed Slack and GitHub connections route inbound events through OpenWorker Cloud; manual credentials remain available, and Slack Socket Mode connects directly to Slack. The desktop updater also checks OpenWorker's update endpoints for new releases.
+
+Product telemetry is disabled by default. If enabled, it sends content-free product metadata to `api.openworker.com`: a random installation ID, app version, platform, session persona and workspace category, and the slug of a gallery persona that was installed. It never sends prompts, outputs, tool arguments, file paths, or connector content. You can use the app without signing in and configure connectors with manual credentials or API keys.
 
 ## Run from source
 

--- a/coworker/cloud.py
+++ b/coworker/cloud.py
@@ -266,7 +266,7 @@ def fetch_me(secrets: SecretStore, config: Config) -> Optional[dict]:
 
 # --- telemetry (Phase 5) ---------------------------------------------------------
 # One sentence: which coworker type was started and when — nothing else. Signed-in
-# users only, default-on with an opt-out; signed out (or opted out) sends NOTHING.
+# users only, disabled by default; signed out (or opted out) sends NOTHING.
 # Never sent: titles, prompts, outputs, tool args, file paths, connector content.
 
 TELEMETRY_PROFILE = "cloud:telemetry"
@@ -283,7 +283,7 @@ def install_id(secrets: SecretStore) -> str:
 
 def telemetry_enabled(secrets: SecretStore) -> bool:
     profile = secrets.get(TELEMETRY_PROFILE) or {}
-    return bool(profile.get("enabled", True))  # default-on (only matters signed in)
+    return bool(profile.get("enabled", False))  # only matters when signed in
 
 
 def set_telemetry_enabled(secrets: SecretStore, enabled: bool) -> dict[str, Any]:

--- a/coworker/cloud.py
+++ b/coworker/cloud.py
@@ -645,6 +645,8 @@ def gallery_manifest(secrets: SecretStore, config: Config, slug: str) -> Optiona
 
 def gallery_install_event(secrets: SecretStore, config: Config, slug: str) -> None:
     """Best-effort product telemetry (slug/version only, no content)."""
+    if not telemetry_enabled(secrets):
+        return
     token = fresh_access_token(secrets, config)
     if not token:
         return

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -1021,7 +1021,7 @@ def create_app(manager: SessionManager) -> FastAPI:
 
     @app.post("/v1/cloud/telemetry")
     def cloud_telemetry(body: dict) -> dict[str, Any]:
-        """The Phase 5 opt-out toggle. Local preference only — signed-out users
+        """The Phase 5 telemetry preference. Local preference only — signed-out users
         send nothing regardless of this value."""
         from .. import cloud
 

--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -210,7 +210,7 @@ export const CLOUD_STATE = {
   signed_in: false,
   account: "",
   user_id: "",
-  telemetry_enabled: true,
+  telemetry_enabled: false,
 };
 
 const GALLERY_PERSONAS = [
@@ -566,7 +566,7 @@ export async function mockApi(page: import("@playwright/test").Page) {
     signed_in: false,
     account: "",
     user_id: "",
-    telemetry_enabled: true,
+    telemetry_enabled: false,
   });
 
   // The scripted fake agent behind the session WebSocket. Speaks the real event protocol

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -475,10 +475,10 @@ export interface CloudStatus {
   signed_in: boolean;
   account: string;
   user_id: string;
-  telemetry_enabled?: boolean; // Phase 5 opt-out; signed-out users send nothing regardless
+  telemetry_enabled?: boolean; // Disabled by default; signed-out users send nothing regardless
 }
 
-/** Flip the product-telemetry preference (local; only meaningful when signed in). */
+/** Set the local product-telemetry preference (only meaningful when signed in). */
 export async function setCloudTelemetry(
   enabled: boolean,
 ): Promise<{ ok: boolean; telemetry_enabled?: boolean }> {

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -376,10 +376,11 @@ def test_install_id_stable_across_calls(secrets):
     assert cloud.install_id(secrets) == first
 
 
-def test_emit_sends_nothing_signed_out(secrets, config, monkeypatch):
+def test_emit_sends_nothing_by_default(secrets, config, monkeypatch):
     def boom(*a, **k):  # any network call would violate the local-only promise
-        raise AssertionError("signed-out users must send no telemetry")
+        raise AssertionError("telemetry must be opt-in")
 
+    _signed_in(secrets)
     monkeypatch.setattr(cloud.httpx, "post", boom)
     assert (
         cloud.emit_session_created(
@@ -391,6 +392,22 @@ def test_emit_sends_nothing_signed_out(secrets, config, monkeypatch):
             workspace_kind="deliverable",
         )
         is False
+    )
+
+
+def test_emit_sends_nothing_signed_out(secrets, config, monkeypatch):
+    def boom(*a, **k):  # any network call would violate the local-only promise
+        raise AssertionError("signed-out users must send no telemetry")
+
+    cloud.set_telemetry_enabled(secrets, True)
+    monkeypatch.setattr(cloud.httpx, "post", boom)
+    assert not cloud.emit_session_created(
+        secrets,
+        config,
+        session_id="s1",
+        persona_id="sales",
+        persona_family="knowledge",
+        workspace_kind="deliverable",
     )
 
 
@@ -421,6 +438,7 @@ def test_gallery_install_sends_nothing_when_opted_out(secrets, config, monkeypat
 
 def test_emit_is_content_free_and_hashes_session_id(secrets, config, monkeypatch):
     _signed_in(secrets)
+    cloud.set_telemetry_enabled(secrets, True)
     sent = {}
 
     def fake_post(url, **kwargs):

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -410,6 +410,15 @@ def test_emit_sends_nothing_when_opted_out(secrets, config, monkeypatch):
     )
 
 
+def test_gallery_install_sends_nothing_when_opted_out(secrets, config, monkeypatch):
+    _signed_in(secrets)
+    cloud.set_telemetry_enabled(secrets, False)
+    monkeypatch.setattr(
+        cloud.httpx, "post", lambda *a, **k: (_ for _ in ()).throw(AssertionError())
+    )
+    cloud.gallery_install_event(secrets, config, "sales")
+
+
 def test_emit_is_content_free_and_hashes_session_id(secrets, config, monkeypatch):
     _signed_in(secrets)
     sent = {}

--- a/tests/test_cloud_server.py
+++ b/tests/test_cloud_server.py
@@ -31,7 +31,7 @@ def test_cloud_status_signed_out(client):
         "signed_in": False,
         "account": "",
         "user_id": "",
-        "telemetry_enabled": True,  # local default; nothing is sent while signed out
+        "telemetry_enabled": False,  # local default; nothing is sent while signed out
     }
 
 
@@ -207,7 +207,9 @@ def test_delete_persona_after_gallery_install(client, monkeypatch):
 
 
 def test_cloud_status_carries_telemetry_pref_and_toggle_flips_it(client):
-    assert client.get("/v1/cloud/status").json()["telemetry_enabled"] is True
+    assert client.get("/v1/cloud/status").json()["telemetry_enabled"] is False
+    body = client.post("/v1/cloud/telemetry", json={"enabled": True}).json()
+    assert body["ok"] and body["telemetry_enabled"] is True
     body = client.post("/v1/cloud/telemetry", json={"enabled": False}).json()
     assert body["ok"] and body["telemetry_enabled"] is False
     assert client.get("/v1/cloud/status").json()["telemetry_enabled"] is False


### PR DESCRIPTION
## Summary
- Disable product telemetry by default, including for signed-in users.
- Respect the local telemetry preference for both session-created and gallery-install events.
- Document the optional cloud paths and the exact content-free telemetry payload in the README.
- Keep the local preference API and browser fixtures aligned with the opt-in default.

Fixes #398
Fixes #116

## Validation
- `.venv/bin/pytest tests/test_cloud.py tests/test_cloud_server.py -q`
- `npm run build` in `surfaces/gui`
- `npm run e2e -- e2e/cloud.spec.ts e2e/cloud-status-pending.spec.ts` in `surfaces/gui`

## Screenshots
Not applicable: this is a backend preference and documentation change; no in-app telemetry control is rendered.