### PR TITLE
fix(audit): redact nested credential arguments

### DIFF
--- a/coworker/audit.py
+++ b/coworker/audit.py
@@ -18,6 +18,10 @@ _SECRET_KEYS = (
     "access_token",
     "bot_token",
     "app_token",
+    "authorization",
+    "cookie",
+    "credential",
+    "private_key",
     "raw",
 )
 _BODY_KEYS = ("body", "content", "html")
@@ -123,29 +127,31 @@ class AuditStore:
 def _sanitize_args(tool: str, args: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(args, dict):
         return {}
-    out: dict[str, Any] = {}
-    for key, value in args.items():
-        lk = str(key).lower()
-        if any(s in lk for s in _SECRET_KEYS):
-            out[key] = "[redacted]"
-        elif tool == "browser_type" and lk == "text":
-            out[key] = "[redacted input]"
-        elif any(b == lk or lk.endswith("_" + b) for b in _BODY_KEYS):
-            out[key] = "[redacted body]"
-        else:
-            out[key] = _summarize(value)
-    return out
+    return {
+        str(key): _summarize(value, tool=tool, key=str(key))
+        for key, value in args.items()
+    }
 
 
-def _summarize(value: Any) -> Any:
+def _summarize(value: Any, *, tool: str = "", key: str = "") -> Any:
+    lower_key = key.lower()
+    if any(secret_key in lower_key for secret_key in _SECRET_KEYS):
+        return "[redacted]"
+    if tool == "browser_type" and lower_key == "text":
+        return "[redacted input]"
+    if any(body_key == lower_key or lower_key.endswith("_" + body_key) for body_key in _BODY_KEYS):
+        return "[redacted body]"
     if isinstance(value, str):
         return _truncate(value)
     if isinstance(value, (int, float, bool)) or value is None:
         return value
     if isinstance(value, list):
-        return [_summarize(v) for v in value[:10]]
+        return [_summarize(item, tool=tool) for item in value[:10]]
     if isinstance(value, dict):
-        return {str(k): _summarize(v) for k, v in list(value.items())[:20]}
+        return {
+            str(item_key): _summarize(item, tool=tool, key=str(item_key))
+            for item_key, item in list(value.items())[:20]
+        }
     return _truncate(str(value))
 
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,43 @@
+"""Regression coverage for audit-log redaction."""
+
+from __future__ import annotations
+
+from coworker.audit import AuditStore
+
+
+def test_audit_store_redacts_nested_credentials_and_bodies(tmp_path):
+    authorization = "Bearer top-secret"
+    cookie = "session=very-secret"
+    api_key = "api-key-secret"
+    credential = "credential-secret"
+    private_key = "-----BEGIN PRIVATE KEY-----"
+    body = "confidential request body"
+    store = AuditStore(tmp_path / "coworker.db")
+    try:
+        store.append(
+            {
+                "tool": "http_request",
+                "arguments": {
+                    "url": "https://example.test/api",
+                    "headers": {"Authorization": authorization, "Cookie": cookie},
+                    "config": {"api_key": api_key, "credential": credential},
+                    "requests": [{"private_key": private_key, "request_body": body}],
+                },
+            }
+        )
+
+        event = store.list()[0]
+        assert event["args"] == {
+            "url": "https://example.test/api",
+            "headers": {"Authorization": "[redacted]", "Cookie": "[redacted]"},
+            "config": {"api_key": "[redacted]", "credential": "[redacted]"},
+            "requests": [
+                {"private_key": "[redacted]", "request_body": "[redacted body]"}
+            ],
+        }
+
+        persisted_args = store._conn.execute("SELECT args FROM audit_events").fetchone()[0]
+        for secret in (authorization, cookie, api_key, credential, private_key, body):
+            assert secret not in persisted_args
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary
- Redact credential and body fields recursively before audit events are stored.
- Cover nested Authorization, Cookie, api_key, credential, private_key, and request body values.
- Preserve non-sensitive audit arguments.

Fixes #397

## Validation
- `.venv/bin/pytest tests/test_audit.py -q`
- `.venv/bin/pytest tests/test_audit.py tests/test_server.py -q` (43 passed; one unrelated restart test is blocked in this sandbox because it writes to `/Users/aniketshukla/OpenWorker`.)

## Screenshots
Not applicable: backend-only audit log redaction change.