### PR TITLE
fix: import tomllib's tomli fallback on Python 3.10

### DIFF
--- a/coworker/config.py
+++ b/coworker/config.py
@@ -9,7 +9,10 @@ workspace path. Other permission grants remain global-only.
 
 from __future__ import annotations
 
-import tomllib
+try:
+    import tomllib  # stdlib since 3.11
+except ModuleNotFoundError:  # 3.10, the floor requires-python declares
+    import tomli as tomllib  # type: ignore[no-redef]
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     # IANA tz database for zoneinfo. Windows ships no system tz db, so without this every
     # named schedule timezone (UTC, Asia/Kolkata, …) silently falls back to local time.
     "tzdata; sys_platform == 'win32'",
+    # tomllib landed in the 3.11 stdlib; on the 3.10 floor config.py falls back to tomli.
+    "tomli>=2; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
**What was broken**: `requires-python >= 3.10` and the README both say Python 3.10+, but `coworker/config.py` imports `tomllib` at module top and tomllib only landed in the 3.11 stdlib. On 3.10 the package cannot be imported at all — pytest fails collection of every test module through the `coworker.config` import chain:

```
tests/test_artifact_walk.py:12: in <module>
    from coworker.server.manager import SessionManager
coworker/config.py:12: in <module>
    import tomllib
E   ModuleNotFoundError: No module named 'tomllib'
... 32 errors during collection
```

**Fix**: fall back to the `tomli` package (the pre-stdlib implementation of the same API), declared as a dependency only for `python_version < '3.11'` — 3.11+ installs are byte-for-byte unchanged.

**Verified**: on 3.10, `import coworker.config` succeeds and `load_config()` parses a workspace `config.toml` (trusted-workspace `allowed_commands` round-trip) through the fallback; on 3.12, `tests/test_config.py` still passes 8/8.

If you'd rather raise the floor instead, the alternative is bumping `requires-python` to `>=3.11` plus the README line — happy to rework the PR that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)