### PR TITLE
docs: user guides for MCP servers and skills

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,98 @@
+# Using MCP servers
+
+OpenWorker can use any tool reachable over [MCP](https://modelcontextprotocol.io/)
+(Model Context Protocol). Each configured server's tools join the agent's toolbox as
+`mcp__<server>__<tool>`, and they go through the same approval flow as every other
+consequential tool.
+
+## Where configuration lives
+
+| File | Scope | Applies |
+|---|---|---|
+| `<state-dir>/mcp.json` | Global — every session | always |
+| `<workspace>/.coworker/mcp.json` | One project | only after you trust that workspace |
+
+`<state-dir>` is `~/.config/coworker` on macOS/Linux and `%APPDATA%\coworker` on
+Windows (`$COWORKER_STATE_DIR` overrides it anywhere).
+
+Two rules keep this safe:
+
+- **Untrusted workspaces are never read.** A stdio server is a process that starts when
+  a session opens, so a repository you merely cloned must not get to define one. The
+  workspace file only takes effect after you trust that folder (the app prompts; the
+  same gate covers a repository's `allowed_commands`).
+- **Global wins on a name clash.** Even a trusted repository cannot silently redefine a
+  server you configured globally by reusing its name.
+
+The app's MCP page edits the global file. Servers that back a built-in connector
+(for example Jira or monday.com) are managed from the Integrations page instead and do
+not appear on the MCP page.
+
+## File format
+
+The standard `mcpServers` JSON — a config you already use with Claude Desktop, Cursor,
+or Codex can be pasted as-is:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/me/notes"]
+    },
+    "internal-api": {
+      "url": "https://mcp.example.com/mcp",
+      "headers": {"Authorization": "Bearer ${INTERNAL_API_TOKEN}"},
+      "include_tools": ["search", "read_doc"],
+      "requires_approval": false
+    },
+    "issue-tracker": {
+      "url": "https://mcp.tracker.example/mcp",
+      "auth": "oauth"
+    }
+  }
+}
+```
+
+Per-server fields:
+
+- `command`, `args`, `env`, `cwd` — a stdio server, spawned locally.
+- `url`, `headers` — an HTTP server (`streamable-http`/`sse`; `type` may name the
+  transport explicitly, otherwise a `url` implies HTTP).
+- `enabled` — set `false` to keep a server configured but inert.
+- `include_tools` / `exclude_tools` — limit which of the server's tools are offered.
+- `requires_approval` — defaults to `true`: every call asks first. Set `false` only for
+  a server you trust to act unprompted; you can also relax specific tools by pattern in
+  `<state-dir>/risk_overrides.json`.
+- `auth: "oauth"` — browser sign-in for HTTP servers (below).
+
+`${VAR}` references in `command`, `args`, `env`, `url`, and `headers` are resolved at
+load time from your environment and `<state-dir>/.env` — so a token never has to be
+written into `mcp.json` itself.
+
+## OAuth servers
+
+Servers declaring `auth: "oauth"` use OAuth 2.1 with PKCE and Dynamic Client
+Registration: no client id to pre-register, and the broker holds nothing — the flow is
+entirely between your machine and the server. Connect from the MCP page; a browser
+window completes the sign-in, and tokens land in OpenWorker's local secret store,
+never in `mcp.json`.
+
+A session will never launch a browser on its own: if a server needs (re-)auth at turn
+time it is skipped and marked on the MCP page, and the session simply runs without its
+tools until you reconnect. Signing out forgets both the tokens and the dynamic client
+registration.
+
+## Statuses on the MCP page
+
+`connected` (reachable, tools listed) · `authorizing` (browser flow in progress) ·
+`needs_auth` (reconnect to sign in again) · `configured` (defined, not yet probed) ·
+`disabled` (`enabled: false`). Connection errors are shown per server so a dark server
+says why.
+
+## For API users
+
+The sidecar exposes the same operations over REST (token header required):
+`GET/POST /v1/mcp`, `PATCH/DELETE /v1/mcp/{name}`, `GET /v1/mcp/{name}/tools`,
+`POST /v1/mcp/{name}/connect`, `POST /v1/mcp/{name}/signout`, `POST /v1/mcp/reload`.
+These edit the **global** file only.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,21 +1,30 @@
 # Using skills
 
-A skill is a folder of instructions the agent can pull in when a task calls for it —
-the same `SKILL.md` format Anthropic's tools use, so a skill written for Claude Code
-works here and vice versa. Use one to
-teach OpenWorker a repeatable procedure: your report format, a deploy checklist, how to
-fill in a specific spreadsheet, the house style for customer emails.
+A skill is a folder of instructions the agent pulls in when a task calls for it — the
+same `SKILL.md` format Anthropic's tools use, so a skill written for Claude Code works
+here and vice versa. Use one to teach OpenWorker a repeatable procedure: your report
+format, a deploy checklist, how to fill in a specific spreadsheet, the house style for
+customer emails.
 
-## Where skills live
+Manage skills from **Settings ▸ Skills**: create and edit in place, upload, move
+between scopes, enable/disable, or reveal the folder on disk. The folder is the truth —
+everything below works the same whether a skill arrived via the app or was dropped into
+the directory by hand.
+
+## Scopes
 
 | Directory | Scope |
 |---|---|
 | `<state-dir>/skills/<skill-name>/` | Global — every session |
-| `<workspace>/.coworker/skills/<skill-name>/` | One project |
+| `<workspace>/.coworker/skills/<skill-name>/` | Project — sessions in that workspace |
 
 `<state-dir>` is `~/.config/coworker` on macOS/Linux and `%APPDATA%\coworker` on
-Windows (`$COWORKER_STATE_DIR` overrides it anywhere). Each skill is one folder
-containing a `SKILL.md`, plus any files it wants to reference.
+Windows (`$COWORKER_STATE_DIR` overrides it anywhere). A project skill lives in the
+repository, so committing `.coworker/skills/` shares it with teammates for free. When a
+project skill and a global skill share a name, the project copy wins.
+
+Skill names become folder names, so they are restricted to letters, digits, dots,
+dashes, and underscores (max 64 characters).
 
 ## Format
 
@@ -38,25 +47,56 @@ Frontmatter:
 - `description` — **the one line the model sees up front**, so make it say both what
   the skill does and when to reach for it; a vague description means the skill never
   gets loaded.
+- `source` — provenance stamp (`uploaded` for uploads); absent means created locally.
 - `allowed-tools` — optional, comma-separated. Parsed for compatibility with the
   shared format, but currently informational: what the agent may actually *do* is
   governed by OpenWorker's permission modes and approvals, not by this list.
 
 The body is free-form markdown. It can reference files shipped in the skill's folder
-(templates, examples, scripts) by relative name — the agent gets the folder's path
-when it loads the skill and reads them with its normal tools. A script bundled with a
-skill still runs through the shell tool's approval gate like any other command.
+(templates, examples, scripts) by relative name — the agent gets the folder's path when
+it loads the skill and reads them with its normal tools. A script bundled with a skill
+still runs through the shell tool's approval gate like any other command.
 
 ## How the agent uses them — progressive disclosure
 
 Skill bodies are not stuffed into every prompt. At session start the agent sees only a
-catalog — each skill's name and description. When a task matches, it calls the
-`load_skill` tool, which returns the full instructions plus the folder path. So you
-can keep many skills installed without weighing every conversation down; only the
+catalog — each enabled skill's name and description. When a task matches, it calls the
+`load_skill` tool, which returns the full instructions plus the folder path. So you can
+keep many skills installed without weighing every conversation down; only the
 description line is always-on context.
 
-That also means the description is doing the routing. If a skill isn't being picked
-up, sharpen its description ("Use when …") rather than growing the body.
+That also means the description is doing the routing. If a skill isn't being picked up,
+sharpen its description ("Use when …") rather than growing the body. A skill created
+mid-session is loadable immediately (`load_skill` rescans on a miss); its catalog line
+appears from the next session.
+
+## Turning skills off
+
+Two switches, both personal:
+
+- **Settings ▸ Skills** disables a skill everywhere. The off-switch lives in your
+  `<state-dir>/skills-settings.json`, deliberately *not* inside the skill folder — a
+  project skill travels with the repo, and your disable must not be committed to
+  teammates.
+- **Per session**, a skill can be muted for just that conversation.
+
+Any-off-wins: a Settings disable cannot be resurrected by a session toggle. If a
+skill's instructions were already loaded into a running conversation, disabling it also
+tells that conversation to stop following them — instructions already in history would
+otherwise keep steering the model.
+
+## Adding skills
+
+- **Create in the app** — Settings ▸ Skills ▸ New: name, description, instructions.
+- **Upload** — a `.zip` containing exactly one skill (its `SKILL.md` at the root or in
+  one top-level folder; resource files ride along), or a bare `SKILL.md` whose
+  frontmatter carries the name. Uploads are staged and previewed — nothing lands in a
+  scope directory until you confirm.
+- **Drop a folder** into a scope directory by hand.
+- **Ask the agent** — after working out a procedure in conversation, the agent can
+  offer to save it via the `save_skill` tool. The save is approval-gated: the card
+  shows the full name, description, instructions, and any bundled files before
+  anything is written, and bundled files may only come from the session's own folders.
 
 ## Skills, `AGENTS.md`, and personas
 
@@ -66,7 +106,10 @@ up, sharpen its description ("Use when …") rather than growing the body.
 - A persona is a bigger unit: a persona defines who the agent *is* (system prompt,
   tools, connectors), and may recommend skills; a skill just teaches a procedure.
 
-## Checking what's installed
+## For API users
 
-The sidecar lists discovered global skills at `GET /v1/skills` (token header
-required). Workspace skills are discovered per session from the session's workspace.
+The sidecar exposes management over REST (token header required):
+`GET /v1/skills?workspace=…` (rows with scope, source, enabled, file count),
+`POST /v1/skills`, `PATCH/DELETE /v1/skills/{name}`, `POST /v1/skills/{name}/move`,
+`POST /v1/skills/upload` + `/upload/confirm` (staged), and per-session toggles at
+`GET/POST /v1/sessions/{id}/skills`.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,72 @@
+# Using skills
+
+A skill is a folder of instructions the agent can pull in when a task calls for it —
+the same `SKILL.md` format Anthropic's tools use, so a skill written for Claude Code
+works here and vice versa. Use one to
+teach OpenWorker a repeatable procedure: your report format, a deploy checklist, how to
+fill in a specific spreadsheet, the house style for customer emails.
+
+## Where skills live
+
+| Directory | Scope |
+|---|---|
+| `<state-dir>/skills/<skill-name>/` | Global — every session |
+| `<workspace>/.coworker/skills/<skill-name>/` | One project |
+
+`<state-dir>` is `~/.config/coworker` on macOS/Linux and `%APPDATA%\coworker` on
+Windows (`$COWORKER_STATE_DIR` overrides it anywhere). Each skill is one folder
+containing a `SKILL.md`, plus any files it wants to reference.
+
+## Format
+
+```markdown
+---
+name: weekly-report
+description: Write the weekly status report. Use when asked for the weekly report or a status update.
+---
+
+# Weekly report
+
+1. Read `template.md` in this skill's folder for the section layout.
+2. Pull last week's numbers with the `github` and `linear` tools.
+3. Keep the summary under 200 words; numbers go in the table, not the prose.
+```
+
+Frontmatter:
+
+- `name` — the skill's id (defaults to the folder name).
+- `description` — **the one line the model sees up front**, so make it say both what
+  the skill does and when to reach for it; a vague description means the skill never
+  gets loaded.
+- `allowed-tools` — optional, comma-separated. Parsed for compatibility with the
+  shared format, but currently informational: what the agent may actually *do* is
+  governed by OpenWorker's permission modes and approvals, not by this list.
+
+The body is free-form markdown. It can reference files shipped in the skill's folder
+(templates, examples, scripts) by relative name — the agent gets the folder's path
+when it loads the skill and reads them with its normal tools. A script bundled with a
+skill still runs through the shell tool's approval gate like any other command.
+
+## How the agent uses them — progressive disclosure
+
+Skill bodies are not stuffed into every prompt. At session start the agent sees only a
+catalog — each skill's name and description. When a task matches, it calls the
+`load_skill` tool, which returns the full instructions plus the folder path. So you
+can keep many skills installed without weighing every conversation down; only the
+description line is always-on context.
+
+That also means the description is doing the routing. If a skill isn't being picked
+up, sharpen its description ("Use when …") rather than growing the body.
+
+## Skills, `AGENTS.md`, and personas
+
+- `AGENTS.md` (global in `<state-dir>`, per-project in the workspace root) is standing
+  guidance injected into **every** session — use it for always-true preferences.
+  A skill is for procedures that apply only to some tasks, loaded on demand.
+- A persona is a bigger unit: a persona defines who the agent *is* (system prompt,
+  tools, connectors), and may recommend skills; a skill just teaches a procedure.
+
+## Checking what's installed
+
+The sidecar lists discovered global skills at `GET /v1/skills` (token header
+required). Workspace skills are discovered per session from the session's workspace.


### PR DESCRIPTION
Answers #68 — there was no user-facing documentation for either feature.

Two guides, written from the code's actual behavior rather than aspiration:

- **`docs/mcp.md`** — config locations and the workspace-trust gate (an untrusted repo's `.coworker/mcp.json` is never read; global wins on a name clash), the full `mcpServers` field reference with a paste-ready example, `${VAR}` resolution via the secret store, the OAuth 2.1 + PKCE + DCR flow and why a session never launches a browser on its own, the MCP page statuses, and the REST endpoints for from-source users.
- **`docs/skills.md`** — the `SKILL.md` folder format, global vs per-workspace discovery directories, progressive disclosure (catalog line up front, `load_skill` on demand) and why the description line does the routing, the honest note that `allowed-tools` is parsed but informational today, and how skills relate to `AGENTS.md` and personas.

Claims were checked against `coworker/mcp/config.py`, `coworker/mcp/oauth.py`, `coworker/skills/base.py`, `coworker/agent.py::_skill_dirs`, and `manager.list_skills` / the `/v1/mcp*` routes.

If you have a different documentation structure planned, treat the content as the offer and reshape the layout freely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)