### PR TITLE
ci: typecheck the GUI in the gui-unit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: npm ci
         working-directory: surfaces/gui
         run: npm ci
+      - name: Typecheck
+        working-directory: surfaces/gui
+        run: npx tsc --noEmit
       - name: Unit tests
         working-directory: surfaces/gui
         run: npm test


### PR DESCRIPTION
**What was broken**: the GUI README tells contributors to run `npx tsc --noEmit`, and `npm run build` starts with `tsc` — but CI runs neither (`gui-unit` runs vitest, `gui-e2e` runs Playwright, and nothing builds a bundle). A type error merges green today and only surfaces when someone next builds locally.

**Fix**: one `npx tsc --noEmit` step inside the existing `gui-unit` job, reusing that job's `npm ci` — no extra runner, a few extra seconds.

**Verified locally**: `npx tsc --noEmit` exits 0 on current `main` (so this turns red only for future regressions), and the vitest suite still passes 82/82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)