### PR TITLE
fix: open session working folder before artifacts exist

### DIFF
--- a/surfaces/gui/src/components/RightRail.test.tsx
+++ b/surfaces/gui/src/components/RightRail.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { RightRail } from "./RightRail";
+
+type Call = { url: string; method: string; body: any };
+
+function stubFetch() {
+	const calls: Call[] = [];
+	const fn = vi.fn(async (url: string, init?: RequestInit) => {
+		const method = (init?.method || "GET").toUpperCase();
+		calls.push({
+			url,
+			method,
+			body: init?.body ? JSON.parse(String(init.body)) : undefined,
+		});
+		const json = url.includes("/artifacts") && method === "GET"
+			? { artifacts: [] }
+			: { ok: true };
+		return { ok: true, json: async () => json } as Response;
+	});
+	vi.stubGlobal("fetch", fn);
+	return calls;
+}
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+});
+
+describe("RightRail", () => {
+	it("opens the session working folder before any artifacts exist", async () => {
+		const calls = stubFetch();
+		render(
+			<RightRail
+				active
+				sessionId="session-1"
+				refreshKey={0}
+				toolNames={[]}
+				todo={[]}
+				running={false}
+			/>,
+		);
+
+		await screen.findByText("No previewable files yet.");
+		fireEvent.click(
+			screen.getByRole("button", { name: "Open session working folder" }),
+		);
+
+		await waitFor(() => {
+			const call = calls.find(
+				(item_call) => item_call.method === "POST"
+					&& item_call.url.includes("/artifacts/reveal"),
+			);
+			expect(call?.body).toEqual({ path: "", mode: "reveal" });
+		});
+	});
+});

--- a/surfaces/gui/src/components/RightRail.tsx
+++ b/surfaces/gui/src/components/RightRail.tsx
@@ -182,15 +182,14 @@ export function RightRail({
             onToggle={() => setOpen({ ...open, artifacts: !open.artifacts })}
             action={
               <>
-                {artifacts.length > 0 && (
-                  <button
-                    className="rail-mini-btn"
-                    onClick={(e) => { e.stopPropagation(); revealArtifact(sessionId, artifacts[0].path, "reveal"); }}
-                    title="Show the folder where these files are saved"
-                  >
-                    <Icon name="folder" size={13} />
-                  </button>
-                )}
+                <button
+                  className="rail-mini-btn"
+                  onClick={(e) => { e.stopPropagation(); revealArtifact(sessionId, "", "reveal"); }}
+                  title="Open session working folder"
+                  aria-label="Open session working folder"
+                >
+                  <Icon name="folder" size={13} />
+                </button>
                 <button className="rail-mini-btn" onClick={(e) => { e.stopPropagation(); refreshArtifacts(); }} title="Refresh artifacts"><Icon name="refresh" size={13} /></button>
               </>
             }


### PR DESCRIPTION
## Summary

- keep the session-folder action visible before any artifacts exist
- open the session workspace root instead of deriving the folder from the first artifact
- give the icon-only action an accessible name
- add a regression test for the empty-artifacts state and request payload

## Root cause

`RightRail` rendered the folder action only when `artifacts.length > 0` and used the first
artifact path to reveal its parent. The backend already resolves an empty artifact path to the
session workspace root, so the UI did not need to wait for a generated file.

## User impact

Users can open a session's working folder immediately to add source files or inspect work in
progress, before OpenWorker has produced an artifact.

## Validation

- `npm test` — 109 passed
- `npx tsc --noEmit`
- `npm run build`
- Playwright visual check — empty artifact state rendered with the folder and refresh actions

Fixes #410
