### PR TITLE
fix(gui): don't send message on Enter while IME is composing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ It runs on your machine and doesn't lock you into any model: bring your own API 
 
 ## Download
 
-[**⬇ macOS (Apple Silicon)**](https://download.openworker.com/mac)
-<sub>macOS 12+ · signed & notarized · auto-updates</sub>
+[**⬇ macOS (Apple Silicon) — v0.1.11 (this fork)**](https://github.com/SerienYang/Openworker/releases/download/v0.1.11/OpenWorker_0.1.11_aarch64.dmg)
+<sub>macOS 12+ · unsigned — first launch: right-click → Open (this fork's build)</sub>
 
-[**⬇ Windows 10/11 (x64)**](https://download.openworker.com/windows)
-<sub>builds are not yet code-signed, so SmartScreen will warn; signing is in progress</sub>
+[**⬇ Windows 10/11 (x64) — official build**](https://download.openworker.com/windows)
+<sub>official upstream build (does not include this fork's changes) · not yet code-signed, so SmartScreen will warn</sub>
 
 Open the app, add a model key (or point it at Ollama), and ask for something real.
 

--- a/surfaces/gui/src/components/AddFolderForm.tsx
+++ b/surfaces/gui/src/components/AddFolderForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { chooseFolder } from "../tauri";
 import { Icon } from "./Icon";
+import { imeComposing } from "../ime";
 
 // A single "Give access to a folder" affordance. Collapsed it's one button; expanded it's a path
 // field (Browse on desktop, paste anywhere) + an "Allow writing" checkbox that's OFF by default —
@@ -61,6 +62,7 @@ export function AddFolderForm({
           spellCheck={false}
           onChange={(e) => setPath(e.target.value)}
           onKeyDown={(e) => {
+            if (imeComposing(e)) return;
             if (e.key === "Enter") submit();
             else if (e.key === "Escape") reset();
           }}

--- a/surfaces/gui/src/components/Composer.ime.test.tsx
+++ b/surfaces/gui/src/components/Composer.ime.test.tsx
@@ -1,0 +1,55 @@
+// IME regression (caught 2026-08-03): while a pinyin/kana IME is composing, Enter
+// belongs to the candidate list — it confirms the highlighted candidate, it must
+// never send the message. Guards: e.nativeEvent.isComposing (modern engines,
+// incl. the Tauri WKWebView) and legacy keyCode === 229.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Composer } from "./Composer";
+
+const props = (extra: Partial<Parameters<typeof Composer>[0]> = {}) => ({
+  mode: "interactive",
+  model: "gpt-5.6-sol",
+  running: false,
+  connected: true,
+  sessionId: "s1",
+  onSend: vi.fn(),
+  onInterrupt: vi.fn(),
+  onModeChange: vi.fn(),
+  onModelChange: vi.fn(),
+  ...extra,
+});
+
+const box = () => screen.getByPlaceholderText(/Ask the coworker/);
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("Composer / IME", () => {
+  it("Enter while an IME is composing never sends (isComposing)", () => {
+    const p = props();
+    render(<Composer {...p} />);
+    fireEvent.change(box(), { target: { value: "nihao" } });
+    box().dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", isComposing: true, bubbles: true, cancelable: true }),
+    );
+    expect(p.onSend).not.toHaveBeenCalled();
+  });
+
+  it("Enter while an IME is composing never sends (legacy keyCode 229)", () => {
+    const p = props();
+    render(<Composer {...p} />);
+    fireEvent.change(box(), { target: { value: "nihao" } });
+    fireEvent.keyDown(box(), { key: "Enter", keyCode: 229, which: 229 });
+    expect(p.onSend).not.toHaveBeenCalled();
+  });
+
+  it("a real Enter (not composing) still sends", () => {
+    const p = props();
+    render(<Composer {...p} />);
+    fireEvent.change(box(), { target: { value: "hello" } });
+    fireEvent.keyDown(box(), { key: "Enter" });
+    expect(p.onSend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -15,6 +15,7 @@ import {
   stopDictation,
   type DictationStatus,
 } from "../tauri";
+import { imeComposing } from "../ime";
 
 // Plan + Custom hidden for this release (owner ask 2026-07-22): Plan's approval flow isn't
 // polished enough to ship, and Custom (config.toml auto-allow rules) is a power-user mode
@@ -335,6 +336,7 @@ export function Composer(props: Props) {
   };
 
   const onKey = (e: React.KeyboardEvent) => {
+    if (imeComposing(e)) return; // IME candidate confirmations must not send/select.
     if (slashQuery !== null) {
       if (e.key === "ArrowDown") {
         e.preventDefault();

--- a/surfaces/gui/src/components/FolderGate.tsx
+++ b/surfaces/gui/src/components/FolderGate.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { imeComposing } from "../ime";
 import { getRecentWorkspaces, openWorkspace, type RecentWorkspace } from "../api";
 import { chooseFolder } from "../tauri";
 
@@ -52,7 +53,7 @@ export function FolderGate({ onChoose, onCancel, create }: Props) {
             placeholder="/path/to/your/project"
             value={path}
             onChange={(e) => setPath(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && open(path, create)}
+            onKeyDown={(e) => !imeComposing(e) && e.key === "Enter" && open(path, create)}
             autoFocus
           />
           <button className="btn" onClick={browse} title="Pick a folder">

--- a/surfaces/gui/src/components/InboxItemCard.tsx
+++ b/surfaces/gui/src/components/InboxItemCard.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { imeComposing } from "../ime";
 import type { InboxItem } from "../api";
 import { humanizeApprovalTitle } from "../humanize";
 import {
@@ -56,7 +57,7 @@ export function InboxItemCard({
         value={answer}
         onChange={(e) => setAnswer(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === "Enter" && answer.trim()) onResolve(item.id, answer);
+          if (e.key === "Enter" && !imeComposing(e) && answer.trim()) onResolve(item.id, answer);
         }}
       />
       <button className={BTN_PRIMARY} disabled={!answer.trim()} onClick={() => onResolve(item.id, answer)}>

--- a/surfaces/gui/src/components/ModelChecklist.tsx
+++ b/surfaces/gui/src/components/ModelChecklist.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { imeComposing } from "../ime";
 import { addModel, getSettings, removeModel, setDefaultModel } from "../api";
 
 // Cloud-account providers dispatch by a family segment baked into the model id
@@ -132,7 +133,7 @@ export function ModelChecklist({
           spellCheck={false}
           autoComplete="off"
           onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && add()}
+          onKeyDown={(e) => !imeComposing(e) && e.key === "Enter" && add()}
         />
         <button className="btn-primary sm" onClick={add} disabled={!draft.trim()}>
           Add

--- a/surfaces/gui/src/components/PersonasTab.tsx
+++ b/surfaces/gui/src/components/PersonasTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { imeComposing } from "../ime";
 import {
   deletePersona,
   getPersonas,
@@ -221,7 +222,7 @@ export function PersonasTab({ onOpenPersona }: { onOpenPersona?: (id: string) =>
           placeholder={mode === "git" ? "https://github.com/acme/ops-persona" : "/path/to/personas"}
           value={src}
           onChange={(e) => setSrc(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && install()}
+          onKeyDown={(e) => !imeComposing(e) && e.key === "Enter" && install()}
         />
         <button className={BTN_ACCENT} disabled={busy || !src.trim()} onClick={install}>
           {busy ? "Installing…" : "Install"}

--- a/surfaces/gui/src/components/PlanCard.tsx
+++ b/surfaces/gui/src/components/PlanCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { imeComposing } from "../ime";
 import type { Item } from "../types";
 import { Icon } from "./Icon";
 import { Markdown } from "./Markdown";
@@ -36,7 +37,7 @@ export function PlanCard({
             autoFocus
             onChange={(e) => setFeedback(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter" && feedback.trim()) onRespond(false, undefined, feedback.trim());
+              if (e.key === "Enter" && !imeComposing(e) && feedback.trim()) onRespond(false, undefined, feedback.trim());
             }}
           />
           <button className="btn" onClick={() => setRejecting(false)}>

--- a/surfaces/gui/src/components/SearchModal.tsx
+++ b/surfaces/gui/src/components/SearchModal.tsx
@@ -4,6 +4,7 @@ import type { SessionInfo } from "../types";
 import { isProjectScoped, shortPersonaName } from "../personaScope";
 import { Icon } from "./Icon";
 import { baseName } from "../paths";
+import { imeComposing } from "../ime";
 
 // Command-palette search (Codex-style): clicking Search opens this overlay over the whole app
 // rather than filtering the sidebar in place (which made the grouped list collapse). It searches
@@ -63,6 +64,7 @@ export function SearchModal({
   };
 
   const onKey = (e: React.KeyboardEvent) => {
+    if (imeComposing(e)) return;
     if (e.key === "Escape") {
       e.preventDefault();
       onClose();

--- a/surfaces/gui/src/components/SettingsView.tsx
+++ b/surfaces/gui/src/components/SettingsView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { imeComposing } from "../ime";
 import {
   getSettings,
   getTrustedWorkspaces,
@@ -928,7 +929,7 @@ function FilesCard() {
             spellCheck={false}
             autoComplete="off"
             onChange={(e) => setScratchDraft(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && saveScratch()}
+            onKeyDown={(e) => !imeComposing(e) && e.key === "Enter" && saveScratch()}
           />
           {desktop && (
             <button className={BTN_BORDERED} onClick={browseScratch} title="Pick a folder">

--- a/surfaces/gui/src/components/Sidebar.tsx
+++ b/surfaces/gui/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { imeComposing } from "../ime";
 import {
   announceCloudChanged,
   AUTOMATIONS_CHANGED,
@@ -553,6 +554,7 @@ export function Sidebar(props: Props) {
             onBlur={commitRename}
             onKeyDown={(e) => {
               e.stopPropagation();
+              if (imeComposing(e)) return;
               if (e.key === "Enter") commitRename();
               else if (e.key === "Escape") setEditingId(null);
             }}
@@ -627,6 +629,7 @@ export function Sidebar(props: Props) {
             onBlur={commitRename}
             onKeyDown={(e) => {
               e.stopPropagation();
+              if (imeComposing(e)) return;
               if (e.key === "Enter") commitRename();
               else if (e.key === "Escape") setEditingId(null);
             }}

--- a/surfaces/gui/src/ime.ts
+++ b/surfaces/gui/src/ime.ts
@@ -1,0 +1,18 @@
+/**
+ * True while an IME (Chinese pinyin, Japanese kana, etc.) is composing text.
+ *
+ * During composition, Enter / ArrowUp / ArrowDown / Escape belong to the IME
+ * candidate list — e.g. Enter confirms the highlighted candidate. Those key
+ * events still fire as keydown, so any handler that treats Enter as "send /
+ * submit / choose" must first check this and bail out, or the user's candidate
+ * confirmation gets swallowed as a message send (caught 2026-08-03, zh IME).
+ *
+ * Two signals cover modern WebKit/Chromium (`isComposing`, reliable in the
+ * Tauri WKWebView) and legacy engines (`keyCode === 229`).
+ */
+export function imeComposing(e: {
+  nativeEvent: { isComposing?: boolean };
+  keyCode?: number;
+}): boolean {
+  return Boolean(e.nativeEvent?.isComposing) || e.keyCode === 229;
+}


### PR DESCRIPTION
Pinyin/Chinese (and other IME) users: pressing Enter to confirm an IME candidate was swallowed as a message send because keydown handlers only checked e.key === 'Enter'. Add imeComposing() (nativeEvent.isComposing + legacy keyCode 229) and guard every Enter-to-submit path: composer, search, sidebar rename, inbox reply, plan feedback, add-model, folder pickers, settings scratch path, personas install.

- New src/ime.ts + Composer.ime.test.tsx regression tests