### PR TITLE
fix(gui): The chat box did not detect the input method status and sent the message directly

### DIFF
--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -358,7 +358,7 @@ export function Composer(props: Props) {
         return;
       }
     }
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       submit();
     }


### PR DESCRIPTION
## Summary

Moves the project-ownership control (SessionProjectPicker) out of the crowded bottom composer row into its own toolbar line **above the textarea**, matching Codex's desktop layout. The chip renders **only for fresh sessions** (0 messages): once a session has history its binding is fixed, so the control would only invite churn (owner ask 2026-08-03).

## Scope

**GUI**
- `Composer`: Add the condition `&& !e.nativeEvent.isComposing`

**Tests**
before enter
<img width="466" height="105" alt="image" src="https://github.com/user-attachments/assets/a2e8739b-0cfd-4b9c-af06-b6da6d5a86a7" />
after enter
<img width="779" height="104" alt="image" src="https://github.com/user-attachments/assets/ff771c37-8a05-475d-8cb3-e52d194dc001" />
result

## Prerequisite commits included

This branch is based on `main` and includes two previously-unpushed local fixes that the project UI sits on (they touch the same components):
- `feat(i18n): add Simplified Chinese (zh-CN) localization` — the translation infra + strings the picker uses
- `fix(gui): don't send message on Enter while IME is composing` — Composer/FolderGate/Sidebar touchpoints

They are separated into their own commits so they can be reviewed independently.