### PR TITLE
fix(gui): prevent Enter from sending during IME composition

### DIFF
--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -358,7 +358,7 @@ export function Composer(props: Props) {
         return;
       }
     }
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       submit();
     }


### PR DESCRIPTION
## Summary

Fixed a bug where, when using the input method, pressing Enter would send the input letter directly instead of displaying text in the message box and waiting for further input or sending.

## Scope

**GUI**
- `Composer`: Add the condition `&& !e.nativeEvent.isComposing`

**Tests**
- before enter
<img width="466" height="105" alt="image" src="https://github.com/user-attachments/assets/a2e8739b-0cfd-4b9c-af06-b6da6d5a86a7" />
- after enter
<img width="779" height="104" alt="image" src="https://github.com/user-attachments/assets/ff771c37-8a05-475d-8cb3-e52d194dc001" />
- result
It wasn't sent directly after pressing Enter, but rather in the message box.