### PR TITLE
fix(inbox): a negated allow word is a refusal, not an approval

### DIFF
--- a/coworker/inbox_routing.py
+++ b/coworker/inbox_routing.py
@@ -26,6 +26,15 @@ _ID_TOKEN = re.compile(r"\[o(?:c)?w:([0-9a-f]{6,})\]")
 # Whole words only — substring matching resolved "disallow" as allow and "note" as deny.
 _ALLOW_WORDS = re.compile(r"\b(?:approve|approved|allow|allowed|yes)\b")
 _DENY_WORDS = re.compile(r"\b(?:deny|denied|reject|rejected|no)\b")
+# An allow word carries the opposite meaning when a negator sits just in front of it
+# ("not approved", "I don't approve", "no, do not approve this"). Word boundaries alone
+# can't see this: the allow list matches the bare keyword, and since allow was tested
+# first the deny list was never reached. Bounded to two intervening words so it reads
+# adjacency, not a negator appearing anywhere in the message.
+_NEGATED_ALLOW = re.compile(
+    r"\b(?:not|never|no|nope|cannot|can'?t|won'?t|don'?t|doesn'?t|didn'?t|isn'?t|"
+    r"shouldn'?t)\b(?:\W+\w+){0,2}?\W+(?:approve|approved|allow|allowed|yes)\b"
+)
 
 
 @dataclass
@@ -133,10 +142,15 @@ def resolve_from_reply(
         return None
     item_id = m.group(1)
     lowered = reply.lower()
-    if _ALLOW_WORDS.search(lowered) or "👍" in reply or "✅" in reply:
-        resolution = "allow"
-    elif _DENY_WORDS.search(lowered) or "👎" in reply or "❌" in reply:
+    allowed = _ALLOW_WORDS.search(lowered) or "👍" in reply or "✅" in reply
+    denied = _DENY_WORDS.search(lowered) or "👎" in reply or "❌" in reply
+    # Deny is tested first so a reply carrying both intents ("denied - do not allow")
+    # lands closed rather than open: a wrong deny costs a second click, a wrong allow
+    # has already sent the email or run the command.
+    if _NEGATED_ALLOW.search(lowered) or denied:
         resolution = "deny"
+    elif allowed:
+        resolution = "allow"
     else:
         resolution = _ID_TOKEN.sub("", reply).strip()  # free-text answer to a question
     return resolve(item_id, resolution)

--- a/tests/test_inbox_routing.py
+++ b/tests/test_inbox_routing.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from coworker.inbox import InboxStore
 from coworker.inbox_routing import (
     DEFAULT_INBOX,
@@ -122,3 +124,57 @@ def test_emoji_reactions_still_resolve(tmp_path):
     resolve_from_reply(f"❌ [ow:{b.id}]", store.resolve)
     assert store.get(a.id).resolution == "allow"
     assert store.get(b.id).resolution == "deny"
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        "not approved",
+        "I don't approve",
+        "no, do not approve this",
+        "please don't allow that",
+        "never approve this one",
+    ],
+)
+def test_negated_allow_word_resolves_as_deny(tmp_path, reply):
+    """An allow keyword behind a negator is a refusal. Word boundaries alone matched the
+    bare keyword, and allow was tested first, so these all resolved as allow."""
+    store = InboxStore(tmp_path / "inbox.json")
+    item = store.add_approval("s1", "Send the invoice?", inbox="ops")
+    assert resolve_from_reply(f"{reply} [ow:{item.id}]", store.resolve) is True
+    assert store.get(item.id).resolution == "deny"
+
+
+def test_mixed_intent_resolves_closed(tmp_path):
+    """Both intents present - the approval gate fails closed."""
+    store = InboxStore(tmp_path / "inbox.json")
+    item = store.add_approval("s1", "Deploy?", inbox="ops")
+    assert resolve_from_reply(f"denied - do not allow [ow:{item.id}]", store.resolve)
+    assert store.get(item.id).resolution == "deny"
+
+
+def test_plain_approval_still_allows(tmp_path):
+    """The reordering must not make approving harder."""
+    store = InboxStore(tmp_path / "inbox.json")
+    for reply in ("approve", "approved", "yes", "allow", "go ahead, approved"):
+        item = store.add_approval("s1", "Deploy?", inbox="ops")
+        resolve_from_reply(f"{reply} [ow:{item.id}]", store.resolve)
+        assert store.get(item.id).resolution == "allow", reply
+
+
+def test_negator_far_from_allow_word_is_not_a_denial(tmp_path):
+    """Adjacency, not a negator appearing anywhere - otherwise ordinary prose that
+    happens to contain `not` would start swallowing approvals."""
+    store = InboxStore(tmp_path / "inbox.json")
+    item = store.add_approval("s1", "Deploy?", inbox="ops")
+    reply = "the staging run did not surface anything new, so approve"
+    resolve_from_reply(f"{reply} [ow:{item.id}]", store.resolve)
+    assert store.get(item.id).resolution == "allow"
+
+
+def test_free_text_answers_are_unaffected(tmp_path):
+    """Questions reuse this path; widening deny must not swallow free-text replies."""
+    store = InboxStore(tmp_path / "inbox.json")
+    q = store.add_question("s1", "Which region?")
+    assert resolve_from_reply(f"north-east node [ow:{q.id}]", store.resolve) is True
+    assert store.get(q.id).resolution == "north-east node"


### PR DESCRIPTION
### The problem

Reply **"not approved"** to an approval request in Slack and OpenWorker approves it — the email goes out.

`resolve_from_reply` (`coworker/inbox_routing.py:137`) checks allow before deny and stops at the first hit:

```python
if _ALLOW_WORDS.search(lowered) or "👍" in reply or "✅" in reply:
    resolution = "allow"
elif _DENY_WORDS.search(lowered) or "👎" in reply or "❌" in reply:
    resolution = "deny"
```

`_ALLOW_WORDS` is `\b(?:approve|approved|allow|allowed|yes)\b`. `"not approved"` matches `approved`, so the first branch wins and the `elif` never runs. The `not` is never read.

#161 added those word boundaries so `"disallow"` stopped matching `allow`. Boundaries fix matching *inside* a word, not the word in front of it.

On `main` at `01b6f83`, against a real `InboxStore`:

<img width="1125" height="661" alt="before" src="https://github.com/user-attachments/assets/9dde4ae0-c1af-465f-b776-a803482eb83d" />


Short answers (`no`, `deny`) work. Full-sentence refusals flip.

### Why it matters

This is the live path for Slack/Telegram approval replies — `manager.py:2830` `_resolve_inbox_reply` routes inbound messages here for `kind="approval"` items, which gate sends, shell commands and file writes. The ownership check above it decides *who* may answer; nothing checked *what they meant*.

It fails in the wrong direction. A misread approval costs a second click. A misread refusal has already sent the email.

### The fix

```python
allowed = _ALLOW_WORDS.search(lowered) or "👍" in reply or "✅" in reply
denied = _DENY_WORDS.search(lowered) or "👎" in reply or "❌" in reply
if _NEGATED_ALLOW.search(lowered) or denied:
    resolution = "deny"
elif allowed:
    resolution = "allow"
```

Deny is tested first, so a reply with both intents (`"denied - do not allow"`) lands closed. And a new pattern catches the case with no deny word at all:

```python
_NEGATED_ALLOW = re.compile(
    r"\b(?:not|never|no|nope|cannot|can'?t|won'?t|don'?t|doesn'?t|didn'?t|isn'?t|"
    r"shouldn'?t)\b(?:\W+\w+){0,2}?\W+(?:approve|approved|allow|allowed|yes)\b"
)
```

The `{0,2}` window is deliberate. `ask_user` questions reuse this parser, so a broader rule would start swallowing free-text answers. `"did not surface anything new, so approve"` still resolves as allow — there's a test pinning it.

Emoji reactions, plain approvals and the free-text path are unchanged.

<img width="1125" height="661" alt="before" src="https://github.com/user-attachments/assets/9dde4ae0-c1af-465f-b776-a803482eb83d" />

### Tests

6 new cases in `tests/test_inbox_routing.py`, plus 3 pinning what must not change, alongside the ones #161 added.

- Source reverted (`git checkout main -- coworker/inbox_routing.py`): **6 failed, 15 passed**
- With the fix: **21 passed**
- Full suite: **1121 passed, 1 skipped**

