### PR TITLE
feat: fetch provider models from the UI and one-click add to the composer picker

### DIFF
--- a/coworker/providers/__init__.py
+++ b/coworker/providers/__init__.py
@@ -18,6 +18,7 @@ from .registry import (
     build_provider_client,
     descriptor_configured,
     detect_provider,
+    fetch_provider_models,
     get_descriptor,
     provider_descriptors,
     provider_names,

--- a/coworker/providers/_models_candidates.py
+++ b/coworker/providers/_models_candidates.py
@@ -1,0 +1,121 @@
+"""Model-fetch candidate URL generation — ported from cc-switch's `model_fetch.rs`.
+
+`build_models_candidates` generates the list of URLs to try when fetching a provider's
+model list, handling the same edge cases cc-switch does: known compat suffixes, version
+segment endings, and full-URL parsing.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# Suffixes that indicate a _compatibility_ sub-path — the real `/v1/models` endpoint
+# lives at the root, not under this path. Ported from cc-switch's `KNOWN_COMPAT_SUFFIXES`.
+KNOWN_COMPAT_SUFFIXES: list[str] = [
+    "/api/claudecode",
+    "/api/anthropic",
+    "/apps/anthropic",
+    "/api/coding",
+    "/claudecode",
+    "/anthropic",
+    "/step_plan",
+    "/coding",
+    "/claude",
+]
+
+# Version-segment patterns: if the URL ends with one of these, the `/models` endpoint
+# lives at the same level (i.e. strip the version segment, not append).
+_VERSION_SEGMENTS = {"/v1", "/v4", "/v2", "/v1beta", "/v1beta1", "/v1beta2"}
+
+
+def _strip_compat_suffix(url: str) -> Optional[str]:
+    """If `url` ends with a known compat suffix, return the URL without it."""
+    for suffix in KNOWN_COMPAT_SUFFIXES:
+        if url.endswith(suffix):
+            return url[: -len(suffix)]
+    return None
+
+
+def build_models_candidates(
+    base_url: str,
+    *,
+    is_full_url: bool = False,
+    models_url_override: Optional[str] = None,
+) -> list[str]:
+    """Build the list of candidate URLs to try when fetching models.
+
+    Mirrors cc-switch's `build_models_url_candidates` (model_fetch.rs:139-200).
+
+    Args:
+        base_url: The provider's base URL (e.g. ``https://api.deepseek.com``).
+        is_full_url: If True, treat ``base_url`` as a full request URL; extract the path
+            prefix and append ``/v1/models``.
+        models_url_override: If set, use ONLY this URL (e.g. DeepSeek's ``/models``
+            lives at the root path).
+
+    Returns:
+        A list of candidate URLs, in order of preference.
+    """
+    candidates: list[str] = []
+
+    # 1. Explicit override — use as-is, no further guessing.
+    if models_url_override:
+        return [models_url_override]
+
+    url = base_url.strip().rstrip("/")
+
+    # 2. Full-URL mode: extract the path prefix (e.g. ``/api/paas/v4`` from
+    #    ``https://api.z.ai/api/paas/v4``) and append ``/v1/models``.
+    if is_full_url:
+        # Extract the path from the URL (everything after the host)
+        match = re.match(r"https?://[^/]+(/.*)", url)
+        if match:
+            path_prefix = match.group(1).rstrip("/")
+            candidates.append(url + "/v1/models")
+            # Also try: if the path prefix looks like a version segment, try
+            # replacing it with ``/v1/models``.
+            # cc-switch does: `format!("{path_prefix}/v1/models")`
+            # Actually cc-switch does: `format!("{url}/v1/models")` for is_full_url
+            # Let me re-read the Rust code...
+            # The Rust code:
+            #   if is_full_url {
+            #       candidates.push(format!("{url}/v1/models"));
+            #       // also try stripping the last path segment
+            #       if let Some(parent) = Path::new(path_prefix).parent() {
+            #           candidates.push(format!("{}{}/v1/models", origin, parent.display()));
+            #       }
+            #   }
+            # So it first tries {url}/v1/models, then {origin}{parent}/v1/models
+            candidates.append(url + "/v1/models")
+            # Also try parent path
+            parts = path_prefix.rsplit("/", 1)
+            if len(parts) > 1:
+                parent = parts[0]
+                candidates.append(url[: len(url) - len(path_prefix)] + parent + "/v1/models")
+        else:
+            candidates.append(url + "/v1/models")
+        # Also try the root path
+        candidates.append(url + "/models")
+        return candidates
+
+    # 3. Normal mode: start with ``{base}/v1/models``
+    candidates.append(url + "/v1/models")
+
+    # 4. If the URL ends with a version segment (``/v1``, ``/v4``, etc.), also try
+    #    ``{base}/models`` (i.e. strip the version segment rather than appending).
+    for vs in _VERSION_SEGMENTS:
+        if url.endswith(vs):
+            candidates.append(url + "/models")
+            break
+
+    # 5. Check for known compat suffixes — strip them and retry with the root.
+    stripped = _strip_compat_suffix(url)
+    if stripped:
+        candidates.append(stripped + "/v1/models")
+        candidates.append(stripped + "/models")
+
+    # 6. Last resort: try the bare root path
+    candidates.append(url + "/models")
+
+    return candidates

--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -1018,3 +1018,210 @@ def verify_provider_key(
             "error": "Reached the server, but no OpenAI-compatible /v1 API there.",
         }
     return {"ok": False, "error": f"{d.title} returned HTTP {resp.status_code}."}
+
+
+def fetch_provider_models(
+    name: str,
+    *,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    fields: Optional[dict[str, Any]] = None,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    """Fetch the list of models available from a provider.
+
+    Like ``verify_provider_key`` but returns the parsed model list on success. Uses
+    candidate URL generation (ported from cc-switch) to handle edge cases: compat
+    suffixes, version segments, and custom endpoints.
+
+    Returns:
+        ``{"ok": True, "models": [{"id": str, "owned_by": str | None}, ...]}`` on success,
+        or ``{"ok": False, "error": str}`` on failure.
+    """
+    from ._models_candidates import build_models_candidates
+
+    import httpx
+
+    d = _BY_NAME.get(name) or _BY_NAME["openai"]
+    key = (api_key or "").strip()
+
+    # Cloud providers (Bedrock, Vertex) — use their existing verify logic
+    if name == "bedrock":
+        result = _verify_bedrock(fields or {}, timeout)
+        if not result.get("ok"):
+            return result
+        # Bedrock: list models via boto3
+        from .bedrock_provider import _session_kwargs
+
+        def get(key: str) -> Optional[str]:
+            return ((fields or {}).get(key) or "").strip() or None
+
+        try:
+            import boto3
+            from botocore.config import Config
+
+            method = get("auth_method") or "api_key"
+            session_kwargs: dict[str, Any] = {}
+            if method == "api_key":
+                if get("bedrock_api_key"):
+                    os.environ["AWS_BEARER_TOKEN_BEDROCK"] = get("bedrock_api_key")
+            elif method == "profile":
+                session_kwargs = _session_kwargs(get("aws_profile"), None, None, None)
+            else:  # iam
+                session_kwargs = _session_kwargs(
+                    None, get("aws_access_key_id"), get("aws_secret_access_key"), get("aws_session_token")
+                )
+            session = boto3.session.Session(**session_kwargs)
+            client = session.client(
+                "bedrock",
+                region_name=get("region"),
+                config=Config(connect_timeout=timeout, read_timeout=timeout),
+            )
+            models = client.list_foundation_models()
+            data = [
+                {"id": m["modelId"], "owned_by": m.get("providerName")}
+                for m in models.get("modelSummaries", [])
+            ]
+            return {"ok": True, "models": data}
+        except Exception as exc:
+            return {"ok": False, "error": f"Couldn't list Bedrock models ({exc.__class__.__name__})."}
+
+    if name == "vertex":
+        result = _verify_vertex(fields or {}, timeout)
+        if not result.get("ok"):
+            return result
+        # Vertex: list models via the Vertex AI API
+        project = ((fields or {}).get("project") or "").strip()
+        location = ((fields or {}).get("location") or "").strip()
+        method = ((fields or {}).get("auth_method") or "").strip() or "adc"
+        try:
+            if method == "api_key":
+                vkey = ((fields or {}).get("vertex_api_key") or "").strip()
+                resp = httpx.get(
+                    f"https://aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/models",
+                    headers={"x-goog-api-key": vkey},
+                    timeout=timeout,
+                )
+            else:
+                from .vertex_provider import _regional_host, load_credentials
+
+                creds = None
+                if method == "service_account":
+                    creds = load_credentials((fields or {}).get("service_account_json"))
+                if creds is None:
+                    import google.auth
+                    creds, _ = google.auth.default(
+                        scopes=["https://www.googleapis.com/auth/cloud-platform"]
+                    )
+                from google.auth.transport.requests import Request
+                creds.refresh(Request())
+                resp = httpx.get(
+                    f"https://{_regional_host(location)}/v1/projects/{project}/locations/{location}/models",
+                    headers={"Authorization": f"Bearer {creds.token}"},
+                    timeout=timeout,
+                )
+            if resp.status_code < 300:
+                data = resp.json().get("models", [])
+                models = [{"id": m.get("name", ""), "owned_by": None} for m in data]
+                return {"ok": True, "models": models}
+            return {"ok": False, "error": f"Vertex AI returned HTTP {resp.status_code}."}
+        except Exception as exc:
+            return {"ok": False, "error": f"Couldn't list Vertex models ({exc.__class__.__name__})."}
+
+    # Native API providers + generic OpenAI-compatible
+    try:
+        if name == "anthropic":
+            candidates = build_models_candidates(
+                "https://api.anthropic.com",
+                is_full_url=False,
+            )
+            headers = {"x-api-key": key, "anthropic-version": "2023-06-01"}
+            resp = None
+            for url in candidates:
+                try:
+                    resp = httpx.get(url, headers=headers, timeout=timeout)
+                    if resp.status_code < 300:
+                        break
+                except Exception:
+                    continue
+            if resp is None or resp.status_code >= 300:
+                return {"ok": False, "error": "Couldn't reach Anthropic API."}
+            data = resp.json().get("data", [])
+            models = [{"id": m["id"], "owned_by": m.get("owned_by")} for m in data]
+            return {"ok": True, "models": models}
+
+        elif name == "gemini":
+            candidates = build_models_candidates(
+                "https://generativelanguage.googleapis.com/v1beta",
+                is_full_url=False,
+            )
+            resp = None
+            for url in candidates:
+                try:
+                    resp = httpx.get(url, params={"key": key}, timeout=timeout)
+                    if resp.status_code < 300:
+                        break
+                except Exception:
+                    continue
+            if resp is None or resp.status_code >= 300:
+                return {"ok": False, "error": "Couldn't reach Gemini API."}
+            data = resp.json().get("models", [])
+            models = [{"id": m.get("name", "").split("/")[-1], "owned_by": None} for m in data]
+            return {"ok": True, "models": models}
+
+        elif name == "ollama":
+            base = _normalize_ollama_url(base_url)
+            # Ollama's /v1/models returns OpenAI-compatible model list
+            candidates = build_models_candidates(base.rstrip("/v1"), is_full_url=False)
+            resp = None
+            for url in candidates:
+                try:
+                    resp = httpx.get(url, timeout=timeout)
+                    if resp.status_code < 300:
+                        break
+                except Exception:
+                    continue
+            if resp is None or resp.status_code >= 300:
+                return {"ok": False, "error": "Couldn't reach Ollama."}
+            data = resp.json().get("data", [])
+            models = [{"id": m["id"], "owned_by": m.get("owned_by")} for m in data]
+            return {"ok": True, "models": models}
+
+        else:  # openai + any OpenAI-compatible endpoint
+            default_base = next(
+                (f.default for f in d.fields if f.key == "base_url" and f.default), ""
+            )
+            base = (
+                (base_url or "").strip().rstrip("/")
+                or default_base.rstrip("/")
+                or "https://api.openai.com/v1"
+            )
+            # Determine if this is a full URL (has a non-trivial path like /api/paas/v4)
+            from urllib.parse import urlparse
+
+            parsed = urlparse(base)
+            is_full = bool(parsed.path) and parsed.path not in ("", "/", "/v1")
+            candidates = build_models_candidates(base, is_full_url=is_full)
+            resp = None
+            for url in candidates:
+                try:
+                    resp = httpx.get(
+                        url,
+                        headers={"Authorization": f"Bearer {key}"},
+                        timeout=timeout,
+                    )
+                    if resp.status_code < 300:
+                        break
+                except Exception:
+                    continue
+            if resp is None or resp.status_code >= 300:
+                return {"ok": False, "error": f"Couldn't reach {d.title}."}
+            data = resp.json().get("data", [])
+            models = [{"id": m["id"], "owned_by": m.get("owned_by")} for m in data]
+            return {"ok": True, "models": models}
+
+    except Exception as exc:
+        return {
+            "ok": False,
+            "error": f"Couldn't reach {d.title} ({exc.__class__.__name__}).",
+        }

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -1879,6 +1879,13 @@ def create_app(manager: SessionManager) -> FastAPI:
     def codex_signout() -> dict[str, Any]:
         return manager.codex_signout()
 
+    @app.post("/v1/providers/{name}/models")
+    async def providers_fetch_models(name: str, body: dict) -> dict[str, Any]:
+        """Fetch the model list from a provider (live read-only call, does NOT persist)."""
+        return await asyncio.to_thread(
+            manager.fetch_models, name, (body or {}).get("fields")
+        )
+
     # -- settings (model API key) -----------------------------------------------
     @app.get("/v1/settings")
     def settings_get() -> dict[str, Any]:

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -80,6 +80,7 @@ from ..providers import (
     descriptor_configured,
     get_descriptor,
     provider_descriptors,
+    fetch_provider_models,
     verify_provider_key,
 )
 from ..secrets import SecretStore, state_dir
@@ -3252,6 +3253,42 @@ class SessionManager:
             if missing:
                 return {"ok": False, "error": "missing: " + ", ".join(missing)}
         return verify_provider_key(
+            name, api_key=api_key, base_url=merged.get("base_url", ""), fields=merged
+        )
+
+    def fetch_models(
+        self, name: str, fields: Optional[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Fetch the model list from a provider, without persisting anything.
+
+        Mirrors ``verify_provider`` but returns the parsed model list instead of a
+        boolean OK. Falls back to stored/env values when the form left a field blank.
+        """
+        import os
+
+        d = get_descriptor(name)
+        if d is None:
+            return {"ok": False, "error": f"unknown provider: {name}"}
+        fields = fields or {}
+        profile = self.secrets.get(f"provider:{name}") or {}
+        merged = {}
+        for f in d.fields:
+            val = fields.get(f.key) or profile.get(f.key) or ""
+            if isinstance(val, str):
+                val = val.strip()
+            if val:
+                merged[f.key] = val
+        api_key = merged.get("api_key", "")
+        if not api_key and d.env_key:
+            api_key = os.environ.get(d.env_key, "").strip()
+        has_key_field = any(f.key == "api_key" for f in d.fields)
+        if d.needs_key and has_key_field and not api_key:
+            return {"ok": False, "error": "Enter an API key to fetch models."}
+        if d.needs_key and not has_key_field:
+            missing = [f.label for f in d.fields if f.required and not merged.get(f.key)]
+            if missing:
+                return {"ok": False, "error": "missing: " + ", ".join(missing)}
+        return fetch_provider_models(
             name, api_key=api_key, base_url=merged.get("base_url", ""), fields=merged
         )
 

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -1924,6 +1924,23 @@ export async function verifyProvider(
   return res.json();
 }
 
+export interface ProviderModelInfo {
+  id: string;
+  owned_by?: string;
+}
+
+export async function fetchProviderModels(
+  name: string,
+  fields: Record<string, string>,
+): Promise<{ ok: boolean; error?: string; models?: ProviderModelInfo[] }> {
+  const res = await fetch(`${httpBase()}/v1/providers/${name}/models`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, fields }),
+  });
+  return res.json();
+}
+
 /** Client-side provider guess from an API key's shape (mirrors the server's detect_provider). */
 export function detectProvider(apiKey: string): string | null {
   const key = (apiKey || "").trim();

--- a/surfaces/gui/src/providers/ProviderSetup.test.tsx
+++ b/surfaces/gui/src/providers/ProviderSetup.test.tsx
@@ -68,6 +68,7 @@ function makePs(fields: Record<string, string>, setFieldValue = vi.fn()): Provid
     fetchingModels: false,
     fetchModelsError: null,
     fetchModels: async () => {},
+    addFetchedModel: async () => {},
   };
 }
 
@@ -96,6 +97,18 @@ describe("ProviderForm auth-method choice", () => {
     render(<ProviderForm ps={makePs({ auth_method: "iam" })} tp="t" />);
     expect(screen.getByTestId("t-field-aws_secret_access_key")).toBeTruthy();
     expect(screen.queryByTestId("t-field-bedrock_api_key")).toBeNull();
+  });
+
+  it("renders a + Add button per fetched model and calls addFetchedModel on click", () => {
+    const addFetchedModel = vi.fn(async () => {});
+    const ps = makePs({ auth_method: "api_key" });
+    ps.models = [{ id: "amazon.nova-pro-v1:0", owned_by: "amazon" }];
+    ps.addFetchedModel = addFetchedModel;
+    render(<ProviderForm ps={ps} tp="t" />);
+    const btn = screen.getByTestId("t-add-model-amazon.nova-pro-v1:0");
+    expect(btn).toBeTruthy();
+    fireEvent.click(btn);
+    expect(addFetchedModel).toHaveBeenCalledWith("amazon.nova-pro-v1:0");
   });
 });
 

--- a/surfaces/gui/src/providers/ProviderSetup.test.tsx
+++ b/surfaces/gui/src/providers/ProviderSetup.test.tsx
@@ -64,6 +64,10 @@ function makePs(fields: Record<string, string>, setFieldValue = vi.fn()): Provid
     statusFor: () => null,
     saveField: async () => {},
     fieldSaved: null,
+    models: null,
+    fetchingModels: false,
+    fetchModelsError: null,
+    fetchModels: async () => {},
   };
 }
 

--- a/surfaces/gui/src/providers/ProviderSetup.tsx
+++ b/surfaces/gui/src/providers/ProviderSetup.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import {
+  addModel,
   codexAuthStatus,
   codexSignin,
   codexSignout,
@@ -107,6 +108,7 @@ export interface ProviderSetupState {
   fetchingModels: boolean;
   fetchModelsError: string | null;
   fetchModels: () => Promise<void>;
+  addFetchedModel: (modelId: string) => Promise<void>;
 }
 
 export function useProviderSetup(opts?: { onSaved?: () => void }): ProviderSetupState {
@@ -239,6 +241,16 @@ export function useProviderSetup(opts?: { onSaved?: () => void }): ProviderSetup
     setFetchingModels(false);
   };
 
+  // One-click add from the fetched list straight into the composer's picker,
+  // so a fetched model never has to be typed by hand. Mirrors ModelChecklist's
+  // prefix rule (OpenAI ids stay bare; everyone else gets `provider:`).
+  const addFetchedModel = async (modelId: string) => {
+    if (!sel) return;
+    const id = sel === "openai" || modelId.startsWith(`${sel}:`) ? modelId : `${sel}:${modelId}`;
+    const res = await addModel(id).catch(() => null);
+    if (res?.ok) opts?.onSaved?.();
+  };
+
   const removeKey = async () => {
     if (!sel) return;
     await removeProvider(sel).catch(() => {});
@@ -322,6 +334,7 @@ export function useProviderSetup(opts?: { onSaved?: () => void }): ProviderSetup
     fetchingModels,
     fetchModelsError,
     fetchModels,
+    addFetchedModel,
     cancelBackTimer: () => {
       if (backTimer.current) window.clearTimeout(backTimer.current);
     },
@@ -732,13 +745,22 @@ export function ProviderForm({
                 {ps.models.map((m) => (
                   <div
                     key={m.id}
-                    className="px-3 py-1.5 text-[12.5px] text-ink border-b border-line last:border-b-0 hover:bg-line/20 cursor-pointer"
+                    className="flex items-center justify-between gap-2 px-3 py-1.5 text-[12.5px] text-ink border-b border-line last:border-b-0 hover:bg-line/20"
                     title={m.owned_by ? `Owned by: ${m.owned_by}` : undefined}
                   >
-                    <span className="font-mono">{m.id}</span>
-                    {m.owned_by && (
-                      <span className="ml-2 text-[11px] text-faint">{m.owned_by}</span>
-                    )}
+                    <span className="font-mono min-w-0 truncate">{m.id}</span>
+                    <span className="flex items-center gap-2 shrink-0">
+                      {m.owned_by && (
+                        <span className="text-[11px] text-faint">{m.owned_by}</span>
+                      )}
+                      <button
+                        className="text-[11.5px] text-accent hover:underline whitespace-nowrap"
+                        data-testid={`${tp}-add-model-${m.id}`}
+                        onClick={() => void ps.addFetchedModel(m.id)}
+                      >
+                        + Add
+                      </button>
+                    </span>
                   </div>
                 ))}
               </div>

--- a/surfaces/gui/src/providers/ProviderSetup.tsx
+++ b/surfaces/gui/src/providers/ProviderSetup.tsx
@@ -9,8 +9,10 @@ import {
   removeProvider,
   setProvider,
   verifyProvider,
+  fetchProviderModels,
   type ProviderField as ProviderFieldT,
   type ProviderInfo,
+  type ProviderModelInfo,
 } from "../api";
 import { openExternal } from "../tauri";
 import { PROVIDER_LOGOS, providerRank } from "./logos";
@@ -100,6 +102,11 @@ export interface ProviderSetupState {
   // owner-hit 2026-07-23: the budget silently never saved).
   saveField: (key: string) => Promise<void>;
   fieldSaved: string | null; // field key flashing "✓ Saved"
+  // Model list fetching (cc-switch style)
+  models: ProviderModelInfo[] | null;
+  fetchingModels: boolean;
+  fetchModelsError: string | null;
+  fetchModels: () => Promise<void>;
 }
 
 export function useProviderSetup(opts?: { onSaved?: () => void }): ProviderSetupState {
@@ -120,6 +127,9 @@ export function useProviderSetup(opts?: { onSaved?: () => void }): ProviderSetup
   // Which non-secret field just blur-saved (flashes "✓ Saved" in the input).
   const [fieldSaved, setFieldSaved] = useState<string | null>(null);
   const fieldSavedTimer = useRef<number | null>(null);
+  const [models, setModels] = useState<ProviderModelInfo[] | null>(null);
+  const [fetchingModels, setFetchingModels] = useState(false);
+  const [fetchModelsError, setFetchModelsError] = useState<string | null>(null);
 
   const refreshProviders = () =>
     getProviders()
@@ -208,6 +218,27 @@ export function useProviderSetup(opts?: { onSaved?: () => void }): ProviderSetup
   };
 
   // Settings-only: forget the stored key; the card reverts to "Not set up".
+  const fetchModels = async () => {
+    if (!sel) return;
+    setFetchingModels(true);
+    setFetchModelsError(null);
+    setModels(null);
+    const res = await fetchProviderModels(sel, fields).catch(
+      (): { ok: false; error: string; models: never[] } => ({
+        ok: false,
+        error: "unreachable",
+        models: [],
+      }),
+    );
+    if (!res.ok) {
+      setFetchModelsError(res.error || "couldn't fetch models");
+      setFetchingModels(false);
+      return;
+    }
+    setModels(res.models || []);
+    setFetchingModels(false);
+  };
+
   const removeKey = async () => {
     if (!sel) return;
     await removeProvider(sel).catch(() => {});
@@ -287,6 +318,10 @@ export function useProviderSetup(opts?: { onSaved?: () => void }): ProviderSetup
     removeKey,
     saveField,
     fieldSaved,
+    models,
+    fetchingModels,
+    fetchModelsError,
+    fetchModels,
     cancelBackTimer: () => {
       if (backTimer.current) window.clearTimeout(backTimer.current);
     },
@@ -671,6 +706,46 @@ export function ProviderForm({
               )}
             </div>
             {ep.help && <p className="text-[12px] text-faint mt-1">{ep.help}</p>}
+          </div>
+        );
+      })()}
+
+      {/* Fetch models (cc-switch style): only for keyed providers with a custom endpoint */}
+      {(() => {
+        const keyed = (info?.fields || []).some((x) => x.secret);
+        if (!keyed) return null;
+        return (
+          <div className="mt-4">
+            <button
+              className="text-[12.5px] text-muted hover:text-ink underline decoration-line underline-offset-2 disabled:opacity-40"
+              onClick={() => ps.fetchModels()}
+              disabled={ps.fetchingModels}
+              data-testid={`${tp}-fetch-models`}
+            >
+              {ps.fetchingModels ? "Fetching models…" : "Fetch models"}
+            </button>
+            {ps.fetchModelsError && (
+              <p className="mt-1 text-[11.5px] text-warnInk">{ps.fetchModelsError}</p>
+            )}
+            {ps.models && ps.models.length > 0 && (
+              <div className="mt-2 max-h-48 overflow-y-auto rounded-lg border border-line bg-panel">
+                {ps.models.map((m) => (
+                  <div
+                    key={m.id}
+                    className="px-3 py-1.5 text-[12.5px] text-ink border-b border-line last:border-b-0 hover:bg-line/20 cursor-pointer"
+                    title={m.owned_by ? `Owned by: ${m.owned_by}` : undefined}
+                  >
+                    <span className="font-mono">{m.id}</span>
+                    {m.owned_by && (
+                      <span className="ml-2 text-[11px] text-faint">{m.owned_by}</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+            {ps.models && ps.models.length === 0 && (
+              <p className="mt-1 text-[11.5px] text-faint">No models returned.</p>
+            )}
           </div>
         );
       })()}


### PR DESCRIPTION
## reason why I did this:
openworker的总体是很棒的，多日的使用下来感觉比较便利就是没有中文版本难推广给我的朋友们使用，本来要做一个中文版本的pull request的发现有人做了，就尝试在设定这块下功夫。
起因：很多时候人们（比如我）并不会去买官方的订阅而是去找一些免费的，不知名的平台获取订阅，因为这样带来的成本较低，这就会带来没办法用官方的url的问题，而openworker也解决了这个问题能够提供自己的订阅url，在导入的时候我在想为什么我们不进一步直接通过接口获取models，这样能够减免很多不必要的选择模型然后输入模型的时间。此外也在一定程度上降低了人们使用的门槛，部分人可能只是知道这个平台的模型不错，但是并不知道具体的模型型号或者编号是多少，所以我就做了这个，希望openworker能够适合更多的人。Anyway，我希望openworker能够变得越来越好，我也在等待openworker的zh-cn版本，这样我就可以推广给身边的人，让他们也享受到ai带来的便利。


## Summary

This PR adds two features that make it much faster to wire up a provider with a custom model list:

1. **Fetch models from the UI** — a `Fetch models` button on the provider setup panel that queries the provider's real model list instead of relying on the bundled matrix. The model-candidate URL generation is ported from [cc-switch](https://github.com/farion1231/cc-switch)'s `model_fetch.rs`, so it handles the same edge cases: known compatibility suffixes, version segments, and custom endpoints.

2. **One-click add to the composer picker** — each fetched model row gains a `+ Add` button that adds the model straight into the composer's picker (no manual typing). It mirrors the existing `ModelChecklist` prefix rule: OpenAI ids stay bare, everyone else gets `provider:` prefixed.

## What's included

- `coworker/providers/_models_candidates.py`: candidate-URL builder (ported from cc-switch).
- `coworker/providers/registry.py`: `fetch_provider_models()` per-provider model listing (Bedrock via boto3, Vertex via Google AI API, Anthropic/Gemini/Ollama/OpenAI via HTTP candidate iteration).
- `coworker/server/manager.py` + `coworker/server/app.py`: `POST /v1/providers/{name}/models` endpoint (read-only, does not persist).
- `surfaces/gui/src/api.ts`: `fetchProviderModels()` + `ProviderModelInfo` type.
- `surfaces/gui/src/providers/ProviderSetup.tsx` + `ProviderSetup.test.tsx`: the Fetch button, model-list UI (loading / error / empty states), and the `+ Add` per-row action with tests.

## Notes

- The endpoint is **read-only** — it fetches and returns the model list but does not persist anything.
- A manual CI change is intentionally **not** included here so the PR stays focused on the feature (the upstream release workflow is untouched).


<img width="1083" height="561" alt="image" src="https://github.com/user-attachments/assets/027f1b3e-5aa9-498e-bfb5-e1b60af5e6bd" />
