### PR TITLE
fix(providers): mark Qwen3.8 Max Preview as vision-capable

### DIFF
--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -105,6 +105,18 @@ MATRIX: dict[str, ModelEntry] = {
     "kimi:kimi-k2.6": ModelEntry("Kimi K2.6 · Moonshot", _AGENTIC, 256_000),
     "minimax:MiniMax-M2.5": ModelEntry("MiniMax M2.5 · MiniMax"),
     "qwen:qwen3-max": ModelEntry("Qwen3 Max · Alibaba", _AGENTIC, 256_000),
+    # Qwen3.8 Max Preview (2026-07): multimodal (text/image/video/document) per Alibaba's
+    # model card, unlike the text-only Qwen3 Max above — needs its own entry so the qwen
+    # prefix heuristic in capabilities.py (vision=False for the whole family) doesn't
+    # strip images client-side (owner report 2026-08-02). PDF unverified over the compat
+    # surface, same caveat as Muse Spark, so it falls back via pdf_support.py too.
+    "qwen:qwen3.8-max-preview": ModelEntry(
+        "Qwen3.8 Max Preview · Alibaba",
+        ModelCapabilities(
+            tools=True, vision=True, parallel_tool_calls=True, streaming=True
+        ),
+        1_000_000,
+    ),
     "xai:grok-4.3": ModelEntry("Grok 4.3 · xAI", _AGENTIC, 256_000),
     "mistral:mistral-large-latest": ModelEntry(
         "Mistral Large · Mistral", _AGENTIC, 128_000

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -388,6 +388,18 @@ def test_matrix_answers_capabilities_for_reseller_ids():
         assert caps.tools and caps.parallel_tool_calls and caps.streaming
 
 
+def test_qwen38_max_preview_is_curated_vision_true():
+    """Qwen3.8 Max Preview is multimodal, unlike the text-only Qwen3 Max — it needs its
+    own matrix entry so the blanket qwen-prefix heuristic (vision=False) doesn't strip
+    images client-side (issue: images silently replaced with a placeholder). The bare
+    Qwen3 Max entry is untouched by the fix."""
+    assert capabilities_for("qwen:qwen3.8-max-preview").vision is True
+    assert capabilities_for("qwen:qwen3-max").vision is False
+    # the heuristic alone (no provider prefix) still can't tell the two apart — the
+    # matrix entry, not the heuristic, is what fixes this.
+    assert capabilities_for("qwen3.8-max-preview").vision is False
+
+
 def test_matrix_labels_and_custom_model_fallback():
     from coworker.providers.matrix import MATRIX, model_labels
 


### PR DESCRIPTION
Fixes #401.

## The bug

Qwen3.8 Max Preview is multimodal (text/image/video/document, per Alibaba's model card), but there's no curated matrix entry for it. `capabilities_for()` falls through to the `qwen`-prefix heuristic in `coworker/providers/capabilities.py`, which hardcodes `vision=False` for the whole family (`deepseek`, `glm`, `kimi`, `minimax`, `qwen`, `grok`, `mistral`, `magistral`). Selecting this model then silently strips any attached image and replaces it with a `[image attachment — not viewable by this model]` placeholder before the request reaches the model — no error, just a quiet capability downgrade.

## The fix

Add a curated matrix entry (`coworker/providers/matrix.py`), the same pattern already used for the other vision exceptions (Muse Spark, the native vendors):

```python
"qwen:qwen3.8-max-preview": ModelEntry(
    "Qwen3.8 Max Preview · Alibaba",
    ModelCapabilities(tools=True, vision=True, parallel_tool_calls=True, streaming=True),
    1_000_000,
),
```

`pdf` is left at its default (`False`) — same caveat as Muse Spark, since PDF ingestion is unverified over the OpenAI-compatible surface for this vendor and falls back via `pdf_support.py`. The existing text-only `qwen:qwen3-max` entry is untouched.

Since `_suggested_models()` builds the "add model" datalist from `models_for_provider()` (matrix-derived) plus `COMPAT_MODELS`, this also makes `qwen3.8-max-preview` show up as a suggestion for the Qwen provider without any change needed there.

## Testing

- Added `test_qwen38_max_preview_is_curated_vision_true` in `tests/test_providers.py`, covering: the new entry resolves `vision=True`, the existing `qwen3-max` entry is unaffected, and a bare (unprefixed) model string still falls through to the conservative heuristic — confirming the matrix entry, not the heuristic, is what fixes this.
- Full suite: `1113 passed, 1 skipped` (`uv venv --python 3.11` + `pip install -e ".[dev,bedrock,messaging]"`, `pytest tests/`) — clean on a fresh env with all optional extras installed.

No UI-visible change (no screenshots) — this is a provider-capabilities data fix; effect is that the composer now sends the image instead of dropping it, per the issue's repro steps.