### PR TITLE
ci: add a ruff (pyflakes) lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,20 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Ruff (pyflakes — undefined names, dead imports/vars, syntax errors)
+        run: ruff check coworker tests
+
   pytest:
     runs-on: ubuntu-latest
     steps:

--- a/coworker/automation/tools.py
+++ b/coworker/automation/tools.py
@@ -9,7 +9,7 @@ results (the artifacts are real files in that folder).
 
 from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import aisuite as ai
 

--- a/coworker/catalog.py
+++ b/coworker/catalog.py
@@ -14,7 +14,7 @@ catalog (see ``PERMISSIONS-AND-INBOX.md``).
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable
 
 import aisuite as ai

--- a/coworker/connectors/base.py
+++ b/coworker/connectors/base.py
@@ -9,7 +9,7 @@ can `send` outbound. Inbound identity is carried by `SessionSource`; a `target` 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, Awaitable, Callable, Optional
 

--- a/coworker/connectors/descriptors.py
+++ b/coworker/connectors/descriptors.py
@@ -9,7 +9,7 @@ data model — only the connect action differs.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable, Optional
 
 

--- a/coworker/connectors/relay_client.py
+++ b/coworker/connectors/relay_client.py
@@ -30,7 +30,7 @@ import time
 from typing import Any, Awaitable, Callable, Optional, Protocol
 
 from .adapters import _SLACK_MENTION_RE, slack_event_to_event
-from .base import BasePlatformAdapter, InteractionEvent, SendResult, SessionSource
+from .base import BasePlatformAdapter, InteractionEvent, SendResult
 from .senders import _send_slack, _send_slack_interactive
 from .slack_addr import qualify
 

--- a/coworker/permissions.py
+++ b/coworker/permissions.py
@@ -25,8 +25,8 @@ def _has_shell_operators(command: str) -> bool:
     return any(op in command for op in _SHELL_OPERATORS)
 
 from .risk import (  # re-exported for back-compat (manager.py imports WRITE_TOOLS)
-    SHELL_TOOL,
-    WRITE_TOOLS,
+    SHELL_TOOL,  # noqa: F401
+    WRITE_TOOLS,  # noqa: F401
     RiskClass,
     RiskOverrides,
     classify,

--- a/coworker/personas/loading.py
+++ b/coworker/personas/loading.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable
 
 from .manifest import PersonaManifest
 

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -2656,8 +2656,6 @@ class SessionManager:
         """Map an approval resolution (from any surface) to an ApprovalOutcome, handling
         the task-persistent "always_task" vocabulary alongside the session-scoped ones.
         """
-        from ..engine import ApprovalOutcome
-
         if resolution == "always_task":
             self.mint_task_rule(
                 session_id,
@@ -2677,7 +2675,6 @@ class SessionManager:
         return ApprovalOutcome.DENY
 
     def _scheduled_approver(self, task, session_id: str):
-        from ..engine import ApprovalOutcome
         from ..permissions import WRITE_TOOLS
 
         name_allowed = task.name_allowed_tools()

--- a/coworker/skills/store.py
+++ b/coworker/skills/store.py
@@ -28,7 +28,7 @@ from typing import Any, Callable, Optional
 import aisuite as ai
 
 from ..secrets import state_dir
-from .base import Skill, _parse_skill
+from .base import _parse_skill
 
 _NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _MAX_NAME = 64

--- a/coworker/subscriptions.py
+++ b/coworker/subscriptions.py
@@ -21,7 +21,7 @@ import json
 import re
 import threading
 from collections import deque
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "pytest-asyncio", "httpx"]
+dev = ["pytest>=8", "pytest-asyncio", "httpx", "ruff>=0.16"]
 # Inbound messaging listeners (outbound send_message needs only httpx, already a core dep).
 # aiohttp is slack-bolt's Socket Mode transport at runtime (and the FakeSlack test harness
 # drives the real handler) — declare it so CI installs it, not just transitively.
@@ -62,3 +62,15 @@ coworker = ["personas/builtin/*.md"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
+[tool.ruff]
+# CI actually runs 3.12 (see ci.yml); pinning here (rather than deriving from the
+# 3.10-floor `requires-python`) avoids false undefined-name positives on names the
+# stdlib only added later (e.g. `ExceptionGroup`, 3.11+).
+target-version = "py312"
+
+[tool.ruff.lint]
+# Deliberately narrow (owner call — see issue #34): pyflakes catches real latent bugs
+# (undefined names, dead imports/variables, shadowed-unused redefinitions) with ~zero
+# false positives and no style opinions to bikeshed. Widen once this is settled in.
+select = ["E9", "F"]

--- a/tests/test_code_tools.py
+++ b/tests/test_code_tools.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 import subprocess
 from types import SimpleNamespace
 
-import pytest
-
 from coworker.tools.files import file_tools
 from coworker.tools.git import git_tools
 from coworker.tools.search import _py_grep, search_tools

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from coworker.config import load_config
 
 

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -4,8 +4,6 @@ tool, settings/authorization, and the gateway inbound loop — all offline via F
 
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from coworker.connectors import (

--- a/tests/test_dm_routing.py
+++ b/tests/test_dm_routing.py
@@ -3,7 +3,6 @@ background turn) or is parked as unrouted; the legacy super-agent surface is gon
 
 import asyncio
 
-import pytest
 from fastapi.testclient import TestClient
 
 from coworker.connectors.base import MessageEvent, SessionSource

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from email.message import EmailMessage
 
-import pytest
-
 from coworker.connectors.email_tools import (
     build_search_criteria,
     decode_mime_header,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import aisuite as ai
 from coworker.conversations import ConversationStore
 from coworker.memory import Scope, SQLiteMemoryStore, format_memories, memory_tools
 from coworker.sessions import SessionRecord

--- a/tests/test_message_source.py
+++ b/tests/test_message_source.py
@@ -9,7 +9,7 @@ import asyncio
 
 from fastapi.testclient import TestClient
 
-from coworker.connectors.base import MessageEvent, MessageSource, SessionSource
+from coworker.connectors.base import MessageEvent, SessionSource
 from coworker.engine import TurnEngine
 from coworker.permissions import PermissionEngine
 from coworker.providers import AssistantTurn, ModelCapabilities, ProviderClient

--- a/tests/test_multiroot.py
+++ b/tests/test_multiroot.py
@@ -14,7 +14,7 @@ import pytest
 import aisuite as ai
 from coworker.engine import TurnEngine
 from coworker.events import EventType
-from coworker.permissions import Decision, Mode, PermissionEngine
+from coworker.permissions import PermissionEngine
 from coworker.providers import AssistantTurn, ToolCall
 from coworker.roots import RootDir, normalize_roots, render_context
 from coworker.tools import ToolRegistry

--- a/tests/test_plan_mode.py
+++ b/tests/test_plan_mode.py
@@ -195,7 +195,7 @@ def test_discuss_mode_blocks_writes_without_plan_pressure(tmp_path):
         ],
     )
     permissions.mode = Mode.DISCUSS
-    events = _collect(engine, "tweak x.py")
+    _collect(engine, "tweak x.py")
     assert not (tmp_path / "x.py").exists()
     assert any(
         m.get("role") == "tool" and "discuss mode is read-only" in m["content"]

--- a/tests/test_risk_overrides.py
+++ b/tests/test_risk_overrides.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from coworker.overrides import RiskOverrideStore
-from coworker.permissions import Mode, PermissionEngine
+from coworker.permissions import PermissionEngine
 from coworker.risk import RiskClass, classify
 
 MCP_META = SimpleNamespace(requires_approval=True, category="mcp")

--- a/tests/test_skills_api.py
+++ b/tests/test_skills_api.py
@@ -11,7 +11,6 @@ import base64
 import io
 import zipfile
 
-import pytest
 from fastapi.testclient import TestClient
 
 from coworker.providers import AssistantTurn, ModelCapabilities, ProviderClient

--- a/tests/test_skills_sessions.py
+++ b/tests/test_skills_sessions.py
@@ -15,7 +15,6 @@ from coworker.providers import ModelCapabilities, ProviderClient
 from coworker.skills import (
     SessionSkillStore,
     SkillLoader,
-    SkillStore,
     effective_skills,
     skill_catalog_text,
     skill_tools,

--- a/tests/test_skills_store.py
+++ b/tests/test_skills_store.py
@@ -9,7 +9,6 @@ never a marker committed with a project folder).
 from __future__ import annotations
 
 import io
-import json
 import os
 import zipfile
 from pathlib import Path

--- a/tests/test_slack_relay.py
+++ b/tests/test_slack_relay.py
@@ -11,7 +11,7 @@ import pytest
 from coworker.connectors import relay_client
 from coworker.connectors.adapters import make_adapter
 from coworker.connectors.base import InteractionEvent, MessageEvent
-from coworker.connectors.config import ConnectorSettings, load_settings
+from coworker.connectors.config import load_settings
 from coworker.connectors.relay_client import SlackRelayAdapter
 from coworker.connectors.slack_addr import qualify, split
 from coworker.connectors.tools import make_send_message_tool

--- a/tests/test_standing_approvals.py
+++ b/tests/test_standing_approvals.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 
 import aisuite as ai
-import pytest
 
 from coworker.automation import Schedule, ScheduledTask, Scheduler, TaskRun, TaskStore
 from coworker.automation.models import grant_entries, rule_entry, rule_parts

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -2,8 +2,6 @@
 
 import asyncio
 
-import pytest
-
 from coworker.connectors.base import MessageEvent, SessionSource
 from coworker.subscriptions import (
     ChannelBuffer,

--- a/tests/test_tools_permissions.py
+++ b/tests/test_tools_permissions.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 import aisuite as ai
-from coworker.permissions import Decision, Mode, PermissionEngine
+from coworker.permissions import Mode, PermissionEngine
 from coworker.tools import ToolRegistry
 
 


### PR DESCRIPTION
Fixes #34 (the Python half — CI has no linter/type-checker at all today; the GUI's eslint/tsc half looks already covered by #419's typecheck-in-gui-unit).

## What

Adds a `lint` job to `.github/workflows/ci.yml` running `ruff check coworker tests`, and a `[tool.ruff]` config in `pyproject.toml`.

Deliberately narrow rule selection: `select = ["E9", "F"]` — syntax errors + pyflakes only. No style rules, no formatter, nothing to bikeshed about. This is exactly the "cheapest way to catch a whole class of latent bugs (dead imports, undefined names)" the issue asks for, without opening a scope debate about house style. `target-version = "py312"` is pinned to match what CI actually runs (rather than derived from the `>=3.10` `requires-python` floor), which otherwise makes ruff flag `ExceptionGroup` (stdlib-builtin only since 3.11) as an undefined name in `test_mcp_connectors.py` — a false positive, not a real 3.10 incompatibility, since CI only runs 3.12.

The issue suggested "start report-only, then ratchet to blocking." With this narrow a rule set the repo was already 33 violations away from clean, so I fixed those and shipped it blocking from the start rather than adding a report-only phase that would just get skipped over.

## What it found and fixed (33 pre-existing violations)

- **28 dead imports** across `coworker/` and `tests/` — plain unused-import cleanup, `ruff --fix` after manual review of each hit (see below).
- **2 redundant local re-imports** in `manager.py`: `approval_outcome()` and `_scheduled_approver()` each had their own `from ..engine import ApprovalOutcome`, shadowing the name already imported at module level (line 40). That shadowing is *why* ruff flagged the module-level import as unused — the bug was the local duplicates, not the import itself, so I removed the two local ones and kept the module-level one.
- **1 unused local variable** (`events = _collect(...)` in `test_plan_mode.py`, result never read).

One deliberate non-removal: `coworker/permissions.py` re-exports `SHELL_TOOL` and `WRITE_TOOLS` from `.risk` with an explicit comment — `# re-exported for back-compat (manager.py imports WRITE_TOOLS)`. Ruff can't see that manager.py depends on this re-export path, so it flagged both as unused-in-file. I left them in place and added `# noqa: F401` rather than deleting what's an intentional public re-export.

## Testing

- `ruff check coworker tests` → clean.
- Full suite: `1112 passed, 1 skipped` (same venv/extras setup as #449: `uv venv --python 3.11` + `pip install -e ".[dev,bedrock,messaging]"`).
- Every import removal was checked individually first (grepped for re-export markers and cross-module references) before running `ruff --fix` — the permissions.py case above is why that mattered.