### PR TITLE
fix(gui): open external links in the default browser via tauri-plugin-opener

### DIFF
--- a/surfaces/gui/src-tauri/Cargo.toml
+++ b/surfaces/gui/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }

--- a/surfaces/gui/src-tauri/capabilities/default.json
+++ b/surfaces/gui/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:window:allow-set-focus",
     "core:window:allow-unminimize",
     "dialog:default",
-    "autostart:default"
+    "autostart:default",
+    "opener:default"
   ]
 }

--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -597,6 +597,7 @@ pub fn run() {
             show_main(app);
         }))
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,

--- a/surfaces/gui/src/components/Markdown.test.tsx
+++ b/surfaces/gui/src/components/Markdown.test.tsx
@@ -2,7 +2,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { Markdown, OPEN_ARTIFACT_EVENT } from "./Markdown";
 
-afterEach(cleanup);
+vi.mock("../tauri", () => ({ openExternal: vi.fn() }));
+const { openExternal } = await import("../tauri");
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 // §34 (UX-016): [Title](artifact:path) renders as a chip that opens the artifact viewer via
 // a window event; ordinary links keep the open-externally treatment.
@@ -28,6 +34,13 @@ describe("Markdown artifact links", () => {
     const a = container.querySelector("a")!;
     expect(a.getAttribute("target")).toBe("_blank");
     expect(a.getAttribute("href")).toBe("https://example.com");
+  });
+
+  it("clicking an ordinary link opens it via openExternal (default browser)", () => {
+    const { container } = render(<Markdown text="see [the docs](https://example.com)" />);
+    const a = container.querySelector("a")!;
+    fireEvent.click(a);
+    expect(openExternal).toHaveBeenCalledWith("https://example.com");
   });
 
   it("chip title falls back to the filename when the link text is empty", () => {

--- a/surfaces/gui/src/components/Markdown.tsx
+++ b/surfaces/gui/src/components/Markdown.tsx
@@ -1,6 +1,7 @@
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Icon } from "./Icon";
+import { openExternal } from "../tauri";
 
 // §34 (UX-016): the agent ends a deliverable turn with plain markdown —
 // [Title](artifact:relative/path) — and the renderer turns it into a chip that opens the
@@ -50,7 +51,22 @@ export function Markdown({ text }: { text: string }) {
               return <ArtifactChip path={href.slice("artifact:".length)} title={title} />;
             }
             return (
-              <a href={href} {...props} target="_blank" rel="noreferrer">
+              <a
+                href={href}
+                {...props}
+                target="_blank"
+                rel="noreferrer"
+                onClick={(e) => {
+                  // In the Tauri desktop shell, target="_blank" navigates the webview
+                  // instead of opening the system browser. Intercept the click and
+                  // hand the URL to the opener plugin (which launches the default
+                  // browser); fall back to the default anchor behaviour in browser dev.
+                  if (href) {
+                    e.preventDefault();
+                    openExternal(href);
+                  }
+                }}
+              >
                 {children}
               </a>
             );

--- a/surfaces/gui/src/tauri.ts
+++ b/surfaces/gui/src/tauri.ts
@@ -125,9 +125,10 @@ export const clearPendingUpdate = () => invokeStrict<void>("clear_pending_update
  * Windows hands off to the installer). */
 export const installUpdate = () => invokeStrict<void>("install_update");
 
-/** Best-effort open a URL in the user's browser. Uses the Tauri opener plugin if present, else
- * `window.open`. The caller should also render the raw URL so it stays copyable if both no-op
- * (the desktop webview has no opener plugin wired yet). */
+/** Best-effort open a URL in the user's default browser. Uses the Tauri opener
+ * plugin if present (desktop shell), else falls back to `window.open` (browser
+ * dev mode). The caller should also render the raw URL so it stays copyable if
+ * both no-op. */
 export function openExternal(url: string): void {
   const opener = (globalThis as any).__TAURI__?.opener;
   if (opener?.openUrl) {


### PR DESCRIPTION
## Problem

In the Tauri desktop shell, clicking a link in an assistant message (rendered as markdown) does not open the user's default browser. Instead, the anchor tag's `target="_blank"` attempts to navigate the webview itself, which either does nothing or opens inside the app window — not the system browser.

The root cause was two-fold:
1. **No opener plugin**: `tauri-plugin-opener` was not installed, so `window.__TAURI__.opener` was `undefined` and `openExternal()` in `tauri.ts` could only fall back to `window.open()` (which also navigates the webview, not the system browser).
2. **No click interception**: `Markdown.tsx` rendered links as plain `<a target="_blank">` without calling `openExternal()`, so even if the opener plugin had been present, the links wouldn't have used it.

## Fix

**1. Wire up `tauri-plugin-opener` (Rust shell)**
- Add `tauri-plugin-opener = "2"` to `Cargo.toml`
- Register `tauri_plugin_opener::init()` in `lib.rs`
- Grant `opener:default` permission in `capabilities/default.json`

**2. Intercept link clicks in the frontend**
- In `Markdown.tsx`, add an `onClick` handler that calls `e.preventDefault()` + `openExternal(href)` for external links, so the URL is handed to the opener plugin (which launches the default browser) instead of navigating the webview
- Falls back to `window.open()` in browser dev mode (where the opener plugin is not present)
- Updated the comment on `openExternal()` that said "the desktop webview has no opener plugin wired yet" — it is now wired

**3. Tests**
- Added a test verifying that clicking an ordinary markdown link calls `openExternal` with the correct URL
- All 109 existing frontend tests continue to pass

## Files changed

| File | Change |
|------|--------|
| `surfaces/gui/src-tauri/Cargo.toml` | Add `tauri-plugin-opener` dependency |
| `surfaces/gui/src-tauri/src/lib.rs` | Register opener plugin |
| `surfaces/gui/src-tauri/capabilities/default.json` | Grant `opener:default` permission |
| `surfaces/gui/src/tauri.ts` | Update `openExternal` comment |
| `surfaces/gui/src/components/Markdown.tsx` | Intercept clicks → `openExternal()` |
| `surfaces/gui/src/components/Markdown.test.tsx` | Add click→openExternal test |

## Verification

```
✓ src/components/Markdown.test.tsx (4 tests) — 27ms
✓ 18 test files, 109 tests passed (2.53s)
``