### PR TITLE
Fix IME Enter key submission

### DIFF
--- a/surfaces/gui/src/components/Composer.input.test.tsx
+++ b/surfaces/gui/src/components/Composer.input.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Composer } from "./Composer";
+
+const props = () => ({
+  mode: "interactive",
+  model: "gpt-5.6-sol",
+  running: false,
+  connected: true,
+  onSend: vi.fn(),
+  onInterrupt: vi.fn(),
+  onModeChange: vi.fn(),
+  onModelChange: vi.fn(),
+});
+
+const box = () => screen.getByPlaceholderText(/Ask the coworker/);
+
+afterEach(cleanup);
+
+describe("Composer keyboard input", () => {
+  it("does not send when Enter confirms an active IME composition", () => {
+    const p = props();
+    render(<Composer {...p} />);
+    fireEvent.change(box(), { target: { value: "openworker" } });
+    fireEvent.keyDown(box(), { key: "Enter", isComposing: true });
+
+    expect(p.onSend).not.toHaveBeenCalled();
+    expect((box() as HTMLTextAreaElement).value).toBe("openworker");
+  });
+
+  it("does not send for WebKit's process-key fallback after composition ends", () => {
+    const p = props();
+    render(<Composer {...p} />);
+    fireEvent.change(box(), { target: { value: "openworker" } });
+    fireEvent.keyDown(box(), { key: "Enter", keyCode: 229 });
+
+    expect(p.onSend).not.toHaveBeenCalled();
+    expect((box() as HTMLTextAreaElement).value).toBe("openworker");
+  });
+
+  it("still sends with a normal Enter keydown", () => {
+    const p = props();
+    render(<Composer {...p} />);
+    fireEvent.change(box(), { target: { value: "hello" } });
+    fireEvent.keyDown(box(), { key: "Enter", keyCode: 13 });
+
+    expect(p.onSend).toHaveBeenCalledWith("hello", [], undefined);
+  });
+});

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -33,6 +33,12 @@ const PERMISSION_OPTIONS: Option[] = [
 // Drop the provider prefix for display (anthropic:claude-opus-4-8 → claude-opus-4-8); full id on hover.
 const shortModel = (m: string) => (m.includes(":") ? m.split(":").slice(1).join(":") : m);
 
+// WebKit can end the composition immediately before the Enter keydown used to confirm an IME
+// candidate, making `isComposing` false by the time React sees it. In that sequence it still
+// reports the legacy process-key code 229, so keep both signals to avoid sending the draft.
+const isImeConfirmKey = (e: React.KeyboardEvent) =>
+  e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229;
+
 // Identify an attachment by name + payload size so duplicates (e.g. the same file picked twice,
 // or a prefill applied twice) collapse to one chip.
 const attKey = (a: Attachment) =>
@@ -351,14 +357,14 @@ export function Composer(props: Props) {
         setText("");
         return;
       }
-      if (e.key === "Enter" && !e.shiftKey) {
+      if (e.key === "Enter" && !e.shiftKey && !isImeConfirmKey(e)) {
         e.preventDefault();
         const chosen = slashMatches[slashIndex];
         if (chosen) pickSkill(chosen);
         return;
       }
     }
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !isImeConfirmKey(e)) {
       e.preventDefault();
       submit();
     }


### PR DESCRIPTION
## What changed

- Ignore Enter while the composer is handling an active IME composition.
- Handle WebKit's `keyCode === 229` process-key fallback, which can occur after `compositionend` on macOS.
- Apply the guard to both normal message submission and slash-command selection.
- Add regression coverage for active composition, the WebKit fallback, and normal Enter submission.

## Why

When a Chinese IME was used to enter English text, pressing Enter to confirm the pending input could also submit the message. WebKit can report `isComposing` as false by the time React receives that keydown, so checking `isComposing` alone is insufficient.

## Impact

IME confirmation now keeps the draft in the composer. A subsequent normal Enter still sends as expected.

## Validation

- `npm test -- --run src/components/Composer.input.test.tsx src/components/Composer.skills.test.tsx` (11 tests passed)
- `npm run build`
