### PR TITLE
Risk overrides Phase 2: REST + GUI surface for per-tool MCP risk

### DIFF
--- a/coworker/overrides.py
+++ b/coworker/overrides.py
@@ -34,14 +34,36 @@ def _specificity(pattern: str) -> int:
 
 
 class RiskOverrideStore:
+    """Rules live in one JSON file; every instance watches its mtime and reloads
+    lazily, so a REST write through one instance is seen by the per-engine
+    instances already captured in live PermissionEngines — no rebuild needed."""
+
     def __init__(self, path: Optional[str | Path] = None) -> None:
         self.path = Path(path) if path else None
-        self._rules: list[_Rule] = self._load()
+        self._mtime: Optional[float] = None
+        self._rules: list[_Rule] = []
+        self._refresh()
+
+    def _refresh(self) -> None:
+        """Reload from disk iff the file changed since we last read it."""
+        if not self.path:
+            return
+        try:
+            mtime = self.path.stat().st_mtime
+        except OSError:
+            self._rules, self._mtime = [], None
+            return
+        if mtime == self._mtime:
+            return
+        self._rules, self._mtime = self._load(), mtime
 
     def _load(self) -> list[_Rule]:
         if not (self.path and self.path.is_file()):
             return []
-        data = json.loads(self.path.read_text(encoding="utf-8"))
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return []
         rules = []
         for r in data.get("rules", []):
             try:
@@ -66,15 +88,36 @@ class RiskOverrideStore:
             ),
             encoding="utf-8",
         )
+        try:
+            self._mtime = self.path.stat().st_mtime
+        except OSError:
+            self._mtime = None
 
     def set_rule(self, pattern: str, risk: RiskClass | str) -> None:
         """Add/replace a user override (the everyday path writes this from the approval UI)."""
         risk = RiskClass(risk) if not isinstance(risk, RiskClass) else risk
+        self._refresh()
         self._rules = [r for r in self._rules if r.pattern != pattern]
         self._rules.append(_Rule(pattern, risk))
         self.save()
 
+    def remove_rule(self, pattern: str) -> bool:
+        """Delete an override by exact pattern. True if a rule was removed."""
+        self._refresh()
+        before = len(self._rules)
+        self._rules = [r for r in self._rules if r.pattern != pattern]
+        if len(self._rules) == before:
+            return False
+        self.save()
+        return True
+
+    def rules(self) -> list[dict]:
+        """Current rules as plain dicts (REST/GUI listing)."""
+        self._refresh()
+        return [{"pattern": r.pattern, "risk": r.risk.value} for r in self._rules]
+
     def resolve(self, tool_name: str) -> Optional[RiskClass]:
+        self._refresh()
         best: Optional[RiskClass] = None
         best_score = -1
         for r in self._rules:

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -793,6 +793,20 @@ def create_app(manager: SessionManager) -> FastAPI:
             )
         )
 
+    @app.get("/v1/risk-overrides")
+    def risk_overrides_list() -> dict[str, Any]:
+        return manager.list_risk_overrides()
+
+    @app.post("/v1/risk-overrides")
+    def risk_overrides_set(body: dict) -> dict[str, Any]:
+        # User-local trust decision (GUI/REST). Personas/packages never reach this
+        # path — the no-self-grant rule lives in the store's design, not here.
+        return manager.set_risk_override(body or {})
+
+    @app.delete("/v1/risk-overrides")
+    def risk_overrides_delete(pattern: str) -> dict[str, Any]:
+        return manager.delete_risk_override(pattern)
+
     @app.post("/v1/mcp/reload")
     async def mcp_reload() -> dict[str, Any]:
         return await manager.reload_mcp()

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -159,6 +159,12 @@ class SessionManager:
                 self.secrets, default_provider="openai", on_use=self._note_provider_use
             )
         self.mcp = MCPManager(secrets=self.secrets)
+        # The user-local risk-override store (Phase 2). Same file as the per-engine
+        # instances in build_engine; the store's mtime watch makes REST writes here
+        # visible to live engines without a rebuild.
+        from ..overrides import RiskOverrideStore
+
+        self.risk_overrides = RiskOverrideStore(state_dir() / "risk_overrides.json")
         # OAuth MCP servers with a sign-in in flight / their last connect error —
         # feeds list_mcp's status so the GUI can show "authorizing…" and failures.
         self._mcp_authorizing: set[str] = set()
@@ -1125,11 +1131,53 @@ class SessionManager:
                     "name": name,
                     "ok": True,
                     "tools": [
-                        {"name": t.name, "description": getattr(t, "description", "")}
-                        for t in conn.tools
+                        self._mcp_tool_row(server, t) for t in conn.tools
                     ],
                 }
         return {"name": name, "ok": False, "error": "unknown server", "tools": []}
+
+    def _mcp_tool_row(self, server: Any, t: Any) -> dict[str, Any]:
+        """One tool listing row, enriched with its registry name and effective risk
+        so the GUI can render per-tool risk controls (Phase 2 overrides)."""
+        from types import SimpleNamespace
+
+        from ..mcp.tools import tool_name as mcp_tool_name
+        from ..risk import classify
+
+        full = mcp_tool_name(server.name, t.name)
+        meta = SimpleNamespace(requires_approval=server.requires_approval, category="mcp")
+        return {
+            "name": t.name,
+            "description": getattr(t, "description", ""),
+            "full_name": full,
+            "risk": classify(full, meta, self.risk_overrides.resolver()).value,
+            "default_risk": classify(full, meta).value,
+            "overridden": self.risk_overrides.resolve(full) is not None,
+        }
+
+    # ---- risk overrides (Phase 2 surface) -----------------------------------
+    def list_risk_overrides(self) -> dict[str, Any]:
+        return {"rules": self.risk_overrides.rules()}
+
+    def set_risk_override(self, payload: dict[str, Any]) -> dict[str, Any]:
+        from ..risk import RiskClass
+
+        pattern = str(payload.get("pattern") or "").strip()
+        if not pattern:
+            return {"ok": False, "error": "pattern is required"}
+        try:
+            risk = RiskClass(str(payload.get("risk") or ""))
+        except ValueError:
+            return {
+                "ok": False,
+                "error": f"risk must be one of {[r.value for r in RiskClass]}",
+            }
+        self.risk_overrides.set_rule(pattern, risk)
+        return {"ok": True, "rules": self.risk_overrides.rules()}
+
+    def delete_risk_override(self, pattern: str) -> dict[str, Any]:
+        removed = self.risk_overrides.remove_rule(pattern)
+        return {"ok": removed, "rules": self.risk_overrides.rules()}
 
     async def reload_mcp(self) -> dict[str, Any]:
         """Drop live MCP connections so new sessions reconnect with fresh config."""

--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -548,6 +548,8 @@ export async function mockApi(page: import("@playwright/test").Page) {
   const automations: any[] = [{ ...AUTOMATION }, { ...AUTOMATION_CLEAN }];
   // MCP servers (empty by default; the granola OAuth quick-add test populates it).
   const mcpServers: any[] = [];
+  // User-local risk overrides (Phase 2): pattern → risk, mutated by /v1/risk-overrides.
+  const riskOverrides: { pattern: string; risk: string }[] = [];
   const automationRuns: any[] = AUTOMATION_RUNS.map((r) => ({ ...r }));
   // Per-session unattended flag — mutable so the composer's "Send to Inbox" toggle persists and
   // the app reads it back (which is what gates parking approvals to the Inbox vs an inline card).
@@ -1561,6 +1563,41 @@ export async function mockApi(page: import("@playwright/test").Page) {
           s2._flip = false;
         }
         return json({ ok: true });
+      }
+      // Tool listing with per-tool effective risk (Phase 2 overrides). Two tools:
+      // by MCP default both are external ("asks") until a user override relaxes one.
+      const mt = p.match(/\/v1\/mcp\/([^/]+)\/tools$/);
+      if (mt && m === "GET") {
+        const server = decodeURIComponent(mt[1]);
+        const tools = ["get_status", "set_value"].map((name) => {
+          const full = `mcp__${server}__${name}`;
+          const ov = riskOverrides.find((r) => r.pattern === full);
+          return {
+            name,
+            description: `${name} on ${server}`,
+            full_name: full,
+            risk: ov ? ov.risk : "external",
+            default_risk: "external",
+            overridden: !!ov,
+          };
+        });
+        return json({ name: server, ok: true, tools });
+      }
+    }
+    if (p.endsWith("/v1/risk-overrides")) {
+      if (m === "GET") return json({ rules: riskOverrides });
+      if (m === "POST") {
+        const b = req.postDataJSON();
+        const i = riskOverrides.findIndex((r) => r.pattern === b.pattern);
+        if (i >= 0) riskOverrides.splice(i, 1);
+        riskOverrides.push({ pattern: b.pattern, risk: b.risk });
+        return json({ ok: true, rules: riskOverrides });
+      }
+      if (m === "DELETE") {
+        const pat = new URL(req.url()).searchParams.get("pattern");
+        const i = riskOverrides.findIndex((r) => r.pattern === pat);
+        if (i >= 0) riskOverrides.splice(i, 1);
+        return json({ ok: i >= 0, rules: riskOverrides });
       }
     }
     if (p.endsWith("/v1/unrouted")) return json([]);

--- a/surfaces/gui/e2e/mcp-tool-risk.spec.ts
+++ b/surfaces/gui/e2e/mcp-tool-risk.spec.ts
@@ -1,0 +1,37 @@
+// Per-tool MCP risk overrides (Phase 2): the tools list shows each tool's
+// effective risk, and clicking a tool toggles a user-local "trust as read-only"
+// override — relaxed tools run without approval prompts, and the override is
+// removable in place.
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+async function openMcpTab(page) {
+  await page.goto("/");
+  await page.getByTestId("account-row").click();
+  await page.getByRole("button", { name: "Connectors", exact: true }).click();
+  await page.getByRole("button", { name: "MCP servers", exact: true }).click();
+}
+
+test("tool chips show risk and toggle a read override", async ({ page }) => {
+  await openMcpTab(page);
+
+  // Connect the curated Granola preset so a server row exists (mock flips it).
+  await page.getByTestId("mcp-preset-granola").getByRole("button", { name: "Connect" }).click();
+  const row = page.locator(".space-y-2 > div").filter({ hasText: "granola" }).first();
+  await expect(row).toContainText("connected", { timeout: 10_000 });
+
+  // Open the tools list: both tools ask by MCP's conservative default.
+  await row.getByRole("button", { name: "tools", exact: true }).click();
+  const statusChip = row.getByTestId("mcp-tool-risk-get_status");
+  await expect(statusChip).toContainText("asks");
+  await expect(row.getByTestId("mcp-tool-risk-set_value")).toContainText("asks");
+
+  // Trust the read tool: chip flips to auto (runs without asking); the other stays gated.
+  await statusChip.click();
+  await expect(statusChip).toContainText("auto");
+  await expect(row.getByTestId("mcp-tool-risk-set_value")).toContainText("asks");
+
+  // Click again: the override is removed and approval is restored.
+  await statusChip.click();
+  await expect(statusChip).toContainText("asks");
+});

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -306,10 +306,41 @@ export async function deleteMcpServer(name: string) {
   return res.json();
 }
 
+export interface McpToolRow {
+  name: string;
+  description: string;
+  /** Registry name (`mcp__<server>__<tool>`) — the pattern risk overrides match. */
+  full_name: string;
+  /** Effective risk with the user's overrides applied. */
+  risk: string;
+  /** What the tool would be without overrides (MCP default: external → asks). */
+  default_risk: string;
+  overridden: boolean;
+}
+
 export async function getMcpTools(
   name: string,
-): Promise<{ ok: boolean; error?: string; tools: { name: string; description: string }[] }> {
+): Promise<{ ok: boolean; error?: string; tools: McpToolRow[] }> {
   const res = await fetch(`${httpBase()}/v1/mcp/${encodeURIComponent(name)}/tools`);
+  return res.json();
+}
+
+// User-local risk overrides (Phase 2): relax a trusted MCP tool to `read` so it
+// stops prompting, or remove the override to restore the conservative default.
+export async function setRiskOverride(pattern: string, risk: string) {
+  const res = await fetch(`${httpBase()}/v1/risk-overrides`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ pattern, risk }),
+  });
+  return res.json();
+}
+
+export async function deleteRiskOverride(pattern: string) {
+  const res = await fetch(
+    `${httpBase()}/v1/risk-overrides?pattern=${encodeURIComponent(pattern)}`,
+    { method: "DELETE" },
+  );
   return res.json();
 }
 

--- a/surfaces/gui/src/components/ManageTabs.tsx
+++ b/surfaces/gui/src/components/ManageTabs.tsx
@@ -10,6 +10,9 @@ import {
   disallowUser,
   getMcpServers,
   getMcpTools,
+  type McpToolRow,
+  setRiskOverride,
+  deleteRiskOverride,
   signoutMcp,
   getSettings,
   getSubscriptions,
@@ -360,7 +363,7 @@ function McpRow({
   onRemove: () => void;
   onRefresh: () => void;
 }) {
-  const [tools, setTools] = useState<{ name: string; description: string }[] | null>(null);
+  const [tools, setTools] = useState<McpToolRow[] | null>(null);
   const [busy, setBusy] = useState(false);
   const [toolErr, setToolErr] = useState<string | null>(null);
 
@@ -433,17 +436,49 @@ function McpRow({
       )}
       {toolErr && <div className="text-[12.5px] text-danger mt-1.5">{toolErr}</div>}
       {tools && (
-        <div className="mt-2.5 pt-2.5 border-t border-line flex flex-wrap gap-1.5">
+        <div className="mt-2.5 pt-2.5 border-t border-line">
           {tools.length === 0 && <div className="text-[12px] text-faint">No tools.</div>}
-          {tools.map((t) => (
-            <span
-              key={t.name}
-              title={t.description}
-              className="font-mono text-[11.5px] px-1.5 py-0.5 rounded-md bg-paper border border-line"
-            >
-              {t.name}
-            </span>
-          ))}
+          {tools.length > 0 && (
+            <div className="text-[11.5px] text-faint mb-1.5">
+              Click a tool to let it run without asking (marks it read-only for
+              this machine); click again to restore approval.
+            </div>
+          )}
+          <div className="flex flex-wrap gap-1.5">
+            {tools.map((t) => {
+              const relaxed = t.overridden && t.risk === "read";
+              const asks = t.risk !== "read";
+              return (
+                <button
+                  key={t.name}
+                  data-testid={`mcp-tool-risk-${t.name}`}
+                  title={
+                    t.description +
+                    (relaxed
+                      ? "\n\nOverride active: runs without asking. Click to restore approval."
+                      : asks
+                        ? "\n\nAsks for approval before each call. Click to trust as read-only."
+                        : "\n\nRead-only: runs without asking.")
+                  }
+                  onClick={async () => {
+                    if (t.overridden) await deleteRiskOverride(t.full_name);
+                    else await setRiskOverride(t.full_name, "read");
+                    const res = await getMcpTools(server.name);
+                    if (res.ok) setTools(res.tools);
+                  }}
+                  className={
+                    "font-mono text-[11.5px] px-1.5 py-0.5 rounded-md bg-paper border " +
+                    (relaxed ? "border-ink/60 text-ink" : "border-line text-muted hover:text-ink")
+                  }
+                >
+                  {t.name}
+                  <span className={"ml-1.5 " + (relaxed ? "text-ink" : "text-faint")}>
+                    {relaxed ? "auto" : asks ? "asks" : "read"}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
         </div>
       )}
     </div>

--- a/tests/test_risk_overrides.py
+++ b/tests/test_risk_overrides.py
@@ -66,3 +66,65 @@ def test_persona_manifest_cannot_carry_an_override(tmp_path):
     # The override store the engine reads is untouched by loading a persona.
     store = RiskOverrideStore(tmp_path / "ro.json")
     assert store.resolve("anything") is None
+
+
+# -- Phase 2 surface: live reload + REST ----------------------------------------
+
+
+def test_second_instance_sees_writes_via_mtime(tmp_path):
+    """The write path (REST) and the read path (live engines) hold separate store
+    instances over one file; a write through one must be visible to the other
+    without a rebuild."""
+    import os
+
+    path = tmp_path / "ro.json"
+    writer = RiskOverrideStore(path)
+    reader = RiskOverrideStore(path)  # captured at engine build, long-lived
+    assert reader.resolve("mcp__hg__status") is None
+    writer.set_rule("mcp__hg__*", "read")
+    # Same-second writes can share an mtime on coarse filesystems; nudge it the
+    # way a later real-world write would land.
+    os.utime(path, (path.stat().st_atime, path.stat().st_mtime + 1))
+    assert reader.resolve("mcp__hg__status") == RiskClass.READ
+
+
+def test_remove_rule_and_rules_listing(tmp_path):
+    store = RiskOverrideStore(tmp_path / "ro.json")
+    store.set_rule("mcp__a__*", "read")
+    store.set_rule("mcp__b__*", "external")
+    assert {r["pattern"] for r in store.rules()} == {"mcp__a__*", "mcp__b__*"}
+    assert store.remove_rule("mcp__a__*") is True
+    assert store.remove_rule("mcp__a__*") is False  # already gone
+    assert store.rules() == [{"pattern": "mcp__b__*", "risk": "external"}]
+    assert store.resolve("mcp__a__x") is None
+
+
+def test_rest_endpoints_round_trip(tmp_path, monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from coworker.server import SessionManager, create_app
+
+    manager = SessionManager(workspace=tmp_path)
+    client = TestClient(create_app(manager))
+
+    assert client.get("/v1/risk-overrides").json() == {"rules": []}
+
+    resp = client.post(
+        "/v1/risk-overrides", json={"pattern": "mcp__heatguard__*", "risk": "read"}
+    ).json()
+    assert resp["ok"] and resp["rules"] == [
+        {"pattern": "mcp__heatguard__*", "risk": "read"}
+    ]
+    # Live engines resolve through the same file immediately.
+    assert manager.risk_overrides.resolve("mcp__heatguard__status") == RiskClass.READ
+
+    bad = client.post("/v1/risk-overrides", json={"pattern": "x", "risk": "nope"}).json()
+    assert not bad["ok"] and "risk must be one of" in bad["error"]
+    missing = client.post("/v1/risk-overrides", json={"risk": "read"}).json()
+    assert not missing["ok"]
+
+    gone = client.delete(
+        "/v1/risk-overrides", params={"pattern": "mcp__heatguard__*"}
+    ).json()
+    assert gone["ok"] and gone["rules"] == []
+    assert client.delete("/v1/risk-overrides", params={"pattern": "never"}).json()["ok"] is False


### PR DESCRIPTION
## What was broken

`RiskOverrideStore` ([coworker/overrides.py](https://github.com/andrewyng/openworker/blob/main/coworker/overrides.py)) is annotated as the Phase 2 relaxation path for MCP's conservative default, and `build_engine` already wires it into every `PermissionEngine` — but nothing could ever **write** it. There was no REST endpoint and no UI, so every MCP tool prompted as `external` forever: a read-only `get_status` call gated exactly like a destructive write, on every single call. Hand-editing `risk_overrides.json` didn't help live sessions either, because rules loaded once at engine build.

Found while running a real deployment: a heatstroke-monitoring automation calling a read-only MCP status tool every 10 minutes — each poll parked an approval.

## What this adds

- **`overrides.py`**: mtime-watched lazy reload — a REST write through the manager's store instance is seen immediately by the per-engine instances captured in live `PermissionEngine`s (no rebuild, no reload endpoint); plus `remove_rule()` / `rules()`.
- **Manager**: a shared store, `list/set/delete` methods, and `/v1/mcp/{name}/tools` rows enriched with `full_name`, effective `risk`, `default_risk`, and `overridden`.
- **REST**: `GET/POST/DELETE /v1/risk-overrides` with risk-class validation. User-local trust decisions only — the persona/no-self-grant boundary is untouched (personas still cannot reach this path).
- **GUI**: tool chips on the MCP server row show `asks` / `read` / `auto`; clicking a tool trusts it as read-only for this machine, clicking again restores approval.

## How it looks

![tool risk chips: get_status relaxed to auto, set_value still asks](https://raw.githubusercontent.com/kayeungadrian-tam/openworker/pr-assets/tool-risk-chips.png)

`get_status` has an active override (runs without asking); `set_value` keeps the conservative default.

## Verification

- `pytest tests -q`: 1108 passed, no new failures (the 7 `test_bedrock_provider` failures reproduce identically on clean `main` in a venv without the `bedrock` extra)
- `npm run build`: clean · `npm test`: no new failures
- Playwright: new `e2e/mcp-tool-risk.spec.ts` (chip toggle round-trip) plus the four adjacent MCP specs, all green
- New unit tests: cross-instance reload propagation, REST round-trip incl. validation errors, remove/list

🤖 Generated with [Claude Code](https://claude.com/claude-code)