### PR TITLE
feat: (gui) implement DeleteConfirmModal for delete confirmations across the application

### DIFF
--- a/surfaces/gui/src/components/DeleteConfirmModal.test.tsx
+++ b/surfaces/gui/src/components/DeleteConfirmModal.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { DeleteConfirmModal } from "./DeleteConfirmModal";
+
+afterEach(cleanup);
+
+describe("DeleteConfirmModal", () => {
+  it("renders the warning copy and calls the supplied handlers", async () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <DeleteConfirmModal
+        isOpen
+        title="Delete automation?"
+        description="This action permanently removes the automation and it cannot be restored."
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByText("Delete automation?")).toBeTruthy();
+    expect(screen.getByText(/cannot be restored/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("delete-confirm-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId("delete-confirm-delete"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <DeleteConfirmModal
+        isOpen={false}
+        title="Delete automation?"
+        description="This action permanently removes the automation and it cannot be restored."
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/surfaces/gui/src/components/DeleteConfirmModal.tsx
+++ b/surfaces/gui/src/components/DeleteConfirmModal.tsx
@@ -1,0 +1,51 @@
+interface DeleteConfirmModalProps {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onCancel: () => void;
+  onConfirm: () => void | Promise<void>;
+}
+
+export function DeleteConfirmModal({
+  isOpen,
+  title,
+  description,
+  confirmLabel = "Delete",
+  cancelLabel = "Cancel",
+  onCancel,
+  onConfirm,
+}: DeleteConfirmModalProps) {
+  if (!isOpen) return null;
+
+  const handleConfirm = async () => {
+    await onConfirm();
+  };
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/35 px-4" role="presentation">
+      <div className="w-full max-w-md rounded-2xl border border-line bg-panel shadow-2xl" role="dialog" aria-modal="true" aria-labelledby="delete-confirm-title">
+        <div className="px-5 py-5">
+          <h2 id="delete-confirm-title" className="text-[16px] font-semibold tracking-tight text-ink">
+            {title}
+          </h2>
+          <p className="mt-2 text-[13px] leading-5 text-muted">{description}</p>
+        </div>
+        <div className="flex items-center justify-end gap-2 border-t border-line px-5 py-4">
+          <button className="btn sm" data-testid="delete-confirm-cancel" onClick={onCancel}>
+            {cancelLabel}
+          </button>
+          <button
+            className="btn sm"
+            data-testid="delete-confirm-delete"
+            onClick={() => void handleConfirm()}
+            style={{ backgroundColor: "var(--danger)", color: "#fff", borderColor: "var(--danger)" }}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/surfaces/gui/src/components/ScheduledView.tsx
+++ b/surfaces/gui/src/components/ScheduledView.tsx
@@ -13,6 +13,7 @@ import {
 import { Icon } from "./Icon";
 import { PanelHead } from "./IntegrationsView";
 import { AutomationQuickstart } from "./AutomationQuickstart";
+import { DeleteConfirmModal } from "./DeleteConfirmModal";
 
 // Shared utility strings (the §28 page shell — mirrors IntegrationsView's constants).
 const CARD = "rounded-xl2 border border-line bg-panel";
@@ -68,6 +69,11 @@ export function ScheduledView({ onOpenRun, onRunNow, initialOpenId }: Props) {
   const [openId, setOpenId] = useState<string | null>(initialOpenId ?? null);
   const [showForm, setShowForm] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<{
+    id: string;
+    title: string;
+    onConfirm: () => void | Promise<void>;
+  } | null>(null);
 
   // The sidebar's Scheduled band can retarget an ALREADY-open Automations surface —
   // initial state alone would ignore the change (UX-023).
@@ -118,9 +124,27 @@ export function ScheduledView({ onOpenRun, onRunNow, initialOpenId }: Props) {
   }
 
   const empty = tasks.length === 0;
+  const closeDeleteModal = () => setPendingDelete(null);
+  const handleDeleteConfirm = async () => {
+    if (!pendingDelete) return;
+    try {
+      await pendingDelete.onConfirm();
+    } finally {
+      closeDeleteModal();
+    }
+  };
 
   return (
     <Shell>
+      {pendingDelete && (
+        <DeleteConfirmModal
+          isOpen
+          title={`Delete “${pendingDelete.title}”?`}
+          description="This action permanently removes the automation and it cannot be restored."
+          onCancel={closeDeleteModal}
+          onConfirm={handleDeleteConfirm}
+        />
+      )}
       <div className="flex items-start gap-3">
         <div className="flex-1 min-w-0">
           <PanelHead title="Automations" sub="Recurring tasks OpenWorker runs on a schedule." />
@@ -174,10 +198,17 @@ export function ScheduledView({ onOpenRun, onRunNow, initialOpenId }: Props) {
                   className="sched-card-del"
                   title="Delete automation"
                   aria-label={`Delete ${t.title}`}
-                  onClick={async (e) => {
+                  onClick={(e) => {
                     e.stopPropagation();
-                    await deleteAutomation(t.id);
-                    refresh();
+                    setPendingDelete({
+                      id: t.id,
+                      title: t.title,
+                      onConfirm: async () => {
+                        await deleteAutomation(t.id);
+                        announceAutomationsChanged();
+                        await refresh();
+                      },
+                    });
                   }}
                 >
                   <Icon name="trash" size={14} />
@@ -296,6 +327,10 @@ function TaskDetail({
   const [time, setTime] = useState("09:00");
   const [freq, setFreq] = useState("daily");
   const [saving, setSaving] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<{
+    title: string;
+    onConfirm: () => void | Promise<void>;
+  } | null>(null);
 
   // The seen mark AS OF opening — the "new" pills compare against this frozen value
   // while mark-seen advances the stored one (badge clears; highlights survive).
@@ -358,6 +393,15 @@ function TaskDetail({
     await updateAutomation(id, { enabled: !task.enabled });
     refresh();
   };
+  const closeDeleteModal = () => setPendingDelete(null);
+  const handleDeleteConfirm = async () => {
+    if (!pendingDelete) return;
+    try {
+      await pendingDelete.onConfirm();
+    } finally {
+      closeDeleteModal();
+    }
+  };
   const remove = async () => {
     await deleteAutomation(id);
     announceAutomationsChanged(); // the sidebar band must not wait out its poll
@@ -366,6 +410,15 @@ function TaskDetail({
 
   return (
     <Shell>
+      {pendingDelete && (
+        <DeleteConfirmModal
+          isOpen
+          title={`Delete “${pendingDelete.title}”?`}
+          description="This action permanently removes the automation and it cannot be restored."
+          onCancel={closeDeleteModal}
+          onConfirm={handleDeleteConfirm}
+        />
+      )}
       <button className="text-[13px] text-muted hover:text-ink mb-3" onClick={onBack}>
         ← Automations
       </button>
@@ -395,7 +448,15 @@ function TaskDetail({
                   ▶ Run now
                 </button>
                 <button className="btn sm" onClick={startEdit}>Edit</button>
-                <button className="btn sm danger-btn" onClick={remove}>
+                <button
+                  className="btn sm danger-btn"
+                  onClick={() =>
+                    setPendingDelete({
+                      title: task.title,
+                      onConfirm: remove,
+                    })
+                  }
+                >
                   <Icon name="trash" size={14} /> Delete
                 </button>
               </>

--- a/surfaces/gui/src/components/SettingsView.tsx
+++ b/surfaces/gui/src/components/SettingsView.tsx
@@ -42,6 +42,7 @@ import { ModelsTab } from "./ManageTabs";
 import { GalleryModal } from "./GalleryModal";
 import { PersonasTab } from "./PersonasTab";
 import { SkillsTab } from "./SkillsTab";
+import { DeleteConfirmModal } from "./DeleteConfirmModal";
 import { showPersonas } from "../flags";
 
 // Settings, restructured (Option 2) into a full-page surface that mirrors IntegrationsView's shell:
@@ -158,6 +159,7 @@ function VoiceInputSection() {
   const [phase, setPhase] = useState<"idle" | "downloading" | "verifying" | "testing" | "transcribing">("idle");
   const [error, setError] = useState<string | null>(null);
   const [testTranscript, setTestTranscript] = useState("");
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const desktop = isTauri();
 
   const publish = (next: DictationStatus) => {
@@ -227,7 +229,6 @@ function VoiceInputSection() {
   };
 
   const remove = async () => {
-    if (!window.confirm("Delete the local Whisper model and disable Voice Input?")) return;
     setError(null);
     try {
       publish(await deleteDictationModel());
@@ -317,7 +318,7 @@ function VoiceInputSection() {
                 <>
                   <span className="text-[11.5px] px-2 py-1 rounded-full bg-green-50 text-green-700">Verified</span>
                   <button className={BTN_BORDERED} onClick={() => void repair()}>Repair</button>
-                  <button className="text-[12px] text-red-600 px-2 py-2" onClick={() => void remove()}>Delete</button>
+                  <button className="text-[12px] text-red-600 px-2 py-2" onClick={() => setShowDeleteConfirm(true)}>Delete</button>
                 </>
               ) : downloading ? (
                 <button className={BTN_BORDERED} onClick={() => void cancelDownload()}>Cancel</button>
@@ -356,6 +357,17 @@ function VoiceInputSection() {
           {error && <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-3 py-2.5 text-[12px] text-red-700">{error}</div>}
         </div>
       )}
+      <DeleteConfirmModal
+        isOpen={showDeleteConfirm}
+        title="Delete voice model?"
+        description="This removes the local Whisper model and disables Voice Input until you download it again."
+        confirmLabel="Delete"
+        onCancel={() => setShowDeleteConfirm(false)}
+        onConfirm={async () => {
+          setShowDeleteConfirm(false);
+          await remove();
+        }}
+      />
     </section>
   );
 }

--- a/surfaces/gui/src/components/Sidebar.test.tsx
+++ b/surfaces/gui/src/components/Sidebar.test.tsx
@@ -137,12 +137,12 @@ describe("Chronological list row actions (⋮ menu)", () => {
     fireEvent.click(screen.getByTestId("row-menu-archive"));
     expect(baseProps.onArchiveSession).toHaveBeenCalledWith("s-ops-1", true);
 
-    // Delete is two-step: first click arms ("Delete?"), the second deletes.
+    // Delete now confirms through the shared modal.
     openOpsMenu();
     fireEvent.click(screen.getByTestId("row-menu-delete"));
     expect(baseProps.onDeleteSession).not.toHaveBeenCalled();
-    expect(screen.getByTestId("row-menu-delete").textContent).toContain("Delete?");
-    fireEvent.click(screen.getByTestId("row-menu-delete"));
+    expect(screen.getByTestId("delete-confirm-delete")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("delete-confirm-delete"));
     expect(baseProps.onDeleteSession).toHaveBeenCalledWith("s-ops-1");
   });
 

--- a/surfaces/gui/src/components/Sidebar.tsx
+++ b/surfaces/gui/src/components/Sidebar.tsx
@@ -25,6 +25,7 @@ import { ConnectorIcon } from "../connectors/ConnectorIcon";
 import { Icon, type IconName } from "./Icon";
 import { PersonaGlyph, personaGlyph } from "./personaIcon";
 import { SearchModal } from "./SearchModal";
+import { DeleteConfirmModal } from "./DeleteConfirmModal";
 import { baseName } from "../paths";
 import { showPersonas } from "../flags";
 
@@ -214,9 +215,8 @@ export function Sidebar(props: Props) {
   }, []);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
-  // Two-step delete inside the row's ⋮ menu: Delete arms ("Delete?"), a second click deletes.
-  // Archive is the primary way to put a conversation away — one click, reversible.
-  const [confirmDelId, setConfirmDelId] = useState<string | null>(null);
+  // Delete confirmation is handled by the shared modal, while archive stays one-click and reversible.
+  const [pendingDelete, setPendingDelete] = useState<{ sessionId: string; title: string } | null>(null);
   // The open row-actions ⋮ menu (one at a time). Fixed-position, not absolute: the expanded
   // accordion group clips overflow (its rounded fill), so an absolute popover on its lower rows
   // would be cut off — same constraint as SlackDetail's person picker.
@@ -228,13 +228,12 @@ export function Sidebar(props: Props) {
   } | null>(null);
   const closeRowMenu = () => {
     setRowMenu(null);
-    setConfirmDelId(null);
   };
   const openRowMenu = (id: string, anchor: HTMLElement) => {
     const r = anchor.getBoundingClientRect();
     const MENU_W = 160; // w-40
     const MENU_H = 150; // ~4 items + divider; only used to flip upward near the window bottom
-    setConfirmDelId(null);
+    setPendingDelete(null);
     setRowMenu({
       id,
       top: r.bottom + 4 + MENU_H > window.innerHeight ? r.top - MENU_H : r.bottom + 4,
@@ -486,31 +485,17 @@ export function Sidebar(props: Props) {
                 props.onArchiveSession(s.session_id, !s.archived),
               )}
               <div className="h-px bg-line my-1 mx-2" />
-              {confirmDelId === s.session_id ? (
-                <button
-                  title="Click again to permanently delete"
-                  className="w-full flex items-center gap-2 px-2.5 py-1.5 text-[12.5px] text-left font-medium text-danger hover:bg-paper"
-                  data-testid="row-menu-delete"
-                  role="menuitem"
-                  onClick={() => {
-                    closeRowMenu();
-                    props.onDeleteSession(s.session_id);
-                  }}
-                >
-                  <Icon name="trash" size={13} className="shrink-0" />
-                  <span className="flex-1">Delete?</span>
-                </button>
-              ) : (
-                <button
-                  className="w-full flex items-center gap-2 px-2.5 py-1.5 text-[12.5px] text-left text-danger hover:bg-paper"
-                  data-testid="row-menu-delete"
-                  role="menuitem"
-                  onClick={() => setConfirmDelId(s.session_id)}
-                >
-                  <Icon name="trash" size={13} className="shrink-0" />
-                  <span className="flex-1">Delete</span>
-                </button>
-              )}
+              <button
+                className="w-full flex items-center gap-2 px-2.5 py-1.5 text-[12.5px] text-left text-danger hover:bg-paper"
+                data-testid="row-menu-delete"
+                role="menuitem"
+                onClick={() => {
+                  setPendingDelete({ sessionId: s.session_id, title });
+                }}
+              >
+                <Icon name="trash" size={13} className="shrink-0" />
+                <span className="flex-1">Delete</span>
+              </button>
             </div>
           </>
         )}
@@ -981,6 +966,13 @@ export function Sidebar(props: Props) {
     );
   };
 
+  const handleDeleteConfirm = () => {
+    if (!pendingDelete) return;
+    closeRowMenu();
+    setPendingDelete(null);
+    props.onDeleteSession(pendingDelete.sessionId);
+  };
+
   return (
     <div
       className="sidebar flex flex-col min-h-0 bg-panel border-r border-line"
@@ -1270,6 +1262,15 @@ export function Sidebar(props: Props) {
         </div>
       </div>
 
+      {pendingDelete && (
+        <DeleteConfirmModal
+          isOpen
+          title={`Delete “${pendingDelete.title}”?`}
+          description="This action permanently removes the conversation and it cannot be restored."
+          onCancel={() => setPendingDelete(null)}
+          onConfirm={handleDeleteConfirm}
+        />
+      )}
       {searchModalOpen && (
         <SearchModal
           sessions={props.sessions}

--- a/surfaces/gui/src/components/SkillsTab.tsx
+++ b/surfaces/gui/src/components/SkillsTab.tsx
@@ -31,6 +31,8 @@ const BTN_BORDERED =
   "text-[12.5px] px-3 py-2 rounded-lg border border-line bg-paper hover:border-lineStrong shrink-0";
 const BADGE =
   "text-[11px] px-2 py-0.5 rounded-full border border-line bg-paper text-muted shrink-0";
+const BTN_DELETE_BORDERED =
+  "text-[12.5px] px-3 py-2 rounded-lg danger shrink-0 border border-line bg-paper hover:border-lineStrong shrink-0";
 
 type Editor = {
   mode: "new" | "edit";
@@ -403,12 +405,12 @@ export function SkillsTab({
               <Icon name="pencil" size={13} />
             </button>
             <button
-              className={BTN_BORDERED}
+              className={armedDelete === row.name ? BTN_DELETE_BORDERED : BTN_BORDERED}
               aria-label={`Delete ${row.name}`}
               onClick={() => remove(row)}
               onBlur={() => setArmedDelete(null)}
             >
-              {armedDelete === row.name ? "Confirm delete" : <Icon name="trash" size={13} />}
+              {armedDelete === row.name ? "Confirm delete" : <Icon name="trash" size={13} className="danger" />}
             </button>
             <label className="inline-flex items-center gap-1.5 text-[12px] text-muted">
               <input

--- a/surfaces/gui/src/styles.css
+++ b/surfaces/gui/src/styles.css
@@ -451,6 +451,7 @@ button.btn.icon-only:hover { color: var(--ink); }
 button.btn:hover { background: var(--paper); }
 button.btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
 button.btn.danger { color: var(--accent); }
+.danger { color: var(--danger); }
 
 /* composer — the wrap/card/head/bar layout is supplied by Tailwind utilities on the elements
    (Composer.tsx); only the textarea reset + drag-ring remain in CSS. */


### PR DESCRIPTION
- Created a reusable component to handle the destructive action like "Delete"
- Updated the icon color, text color of Delete action
- Updated unit tests 
<img width="1176" height="125" alt="image" src="https://github.com/user-attachments/assets/f86a953f-fd89-4077-9bc3-beabf326dcd0" />


**Automation** - 
<img width="1910" height="902" alt="openworker-delete-2" src="https://github.com/user-attachments/assets/66138e02-4937-4f10-98de-5ba74bd91af9" />
<img width="1907" height="911" alt="openworker-delete-1" src="https://github.com/user-attachments/assets/2acf9270-7be3-44a5-a4d1-d9248164a33b" />

**Conversation** - 
<img width="1910" height="910" alt="openworker-delete-3" src="https://github.com/user-attachments/assets/a390e7df-e737-49ff-a546-9851af016041" />

**Skills** - 
<img width="1906" height="912" alt="openworker-delete-5" src="https://github.com/user-attachments/assets/27996ad0-c2c4-41d1-b981-47d583f0712e" />
<img width="1907" height="907" alt="openworker-delete-4" src="https://github.com/user-attachments/assets/ef2ae73b-9eba-4b94-adf4-ff773b288dea" />

**Voice Input** - 
<img width="1907" height="992" alt="openworker-delete-6" src="https://github.com/user-attachments/assets/d430935f-9a9a-4c95-9824-2b3892de75a9" />
