### PR TITLE
Fix custom model context-window overflow recovery

### DIFF
--- a/coworker/compaction.py
+++ b/coworker/compaction.py
@@ -29,6 +29,12 @@ DEFAULT_CONTEXT_WINDOW = 128_000
 KEEP_RECENT_FRACTION = 0.25
 # The summarizer call itself: tools off, modest ceiling.
 SUMMARY_MAX_TOKENS = 3_000
+# Space the summarizer never spends on its input or requested output. Provider tokenizers
+# and chat framing differ, so this is deliberately conservative rather than exact.
+SUMMARY_SAFETY_MARGIN_TOKENS = 2_048
+# Room kept outside the compacted prompt for a normal assistant response. This scales
+# down for tiny windows but reaches 4k for the 32k+ models that motivated #441.
+RESPONSE_RESERVE_TOKENS = 4_096
 # Per-message clip when rendering the span for the summarizer; tool results are the
 # first casualty (huge and mostly stale — a file read 40 turns ago is better re-read).
 _SPAN_TOOL_RESULT_CLIP = 400
@@ -77,6 +83,55 @@ def should_compact(
     return signal >= trigger_tokens(
         context_window, threshold_pct=threshold_pct, cap_tokens=cap_tokens
     )
+
+
+def summary_call_budget(
+    context_window: Optional[int], *, max_tokens: int = SUMMARY_MAX_TOKENS
+) -> tuple[int, int]:
+    """Return safe ``(input_tokens, output_tokens)`` limits for the summarizer call.
+
+    Recovery must fit inside the same model window that just overflowed. Small local
+    models therefore get a proportionally smaller output allowance and margin, while
+    normal/large windows retain the existing 3k summary ceiling.
+    """
+    try:
+        window = int(context_window or DEFAULT_CONTEXT_WINDOW)
+    except (TypeError, ValueError):
+        window = DEFAULT_CONTEXT_WINDOW
+    window = max(4_096, window)
+    output = min(max(256, int(max_tokens)), SUMMARY_MAX_TOKENS, max(512, window // 8))
+    margin = min(SUMMARY_SAFETY_MARGIN_TOKENS, max(512, window // 16))
+    return max(1_024, window - output - margin), output
+
+
+def retained_history_budget(
+    context_window: Optional[int],
+    *,
+    threshold_pct: float = DEFAULT_THRESHOLD_PCT,
+    cap_tokens: int = DEFAULT_CAP_TOKENS,
+) -> int:
+    """Verbatim-tail budget after compaction, with response and safety reserves.
+
+    The compacted summary, system instructions, tool schemas, injected context, and a
+    normal response all share the model window with this tail. Limiting the base to the
+    usable prompt budget makes high custom thresholds safe instead of assuming the full
+    nominal window is available to retained conversation history.
+    """
+    try:
+        window = int(context_window or DEFAULT_CONTEXT_WINDOW)
+    except (TypeError, ValueError):
+        window = DEFAULT_CONTEXT_WINDOW
+    window = max(4_096, window)
+    response = min(RESPONSE_RESERVE_TOKENS, max(512, window // 8))
+    margin = min(SUMMARY_SAFETY_MARGIN_TOKENS, max(512, window // 16))
+    usable_prompt = max(1_024, window - response - margin)
+    target = min(
+        trigger_tokens(
+            window, threshold_pct=threshold_pct, cap_tokens=cap_tokens
+        ),
+        usable_prompt,
+    )
+    return max(1, int(KEEP_RECENT_FRACTION * target))
 
 
 # -- state --------------------------------------------------------------------
@@ -371,21 +426,63 @@ def _render_span(span: list[dict[str, Any]], *, budget_chars: int = _SPAN_BUDGET
 
 
 def summarizer_messages(
-    span: list[dict[str, Any]], *, prior_summary: str = ""
+    span: list[dict[str, Any]],
+    *,
+    prior_summary: str = "",
+    input_budget_tokens: Optional[int] = None,
 ) -> list[dict[str, Any]]:
     """The provider-ready messages for the summarizer call. On repeated compaction the
     previous summary is message zero of the new span — summarized along with the turns
     since."""
-    body = _render_span(span)
+    # Convert the conservative chars/4 estimator into a render cap after accounting for
+    # the fixed system prompt and message framing. Repeated compaction splits the budget
+    # between the previous summary and recent conversation so neither can crowd out the
+    # other; within each part, the newest text wins.
+    body_chars = _SPAN_BUDGET_CHARS
+    if input_budget_tokens is not None:
+        fixed = estimate_tokens(
+            [
+                {"role": "system", "content": SUMMARY_SYSTEM_PROMPT},
+                {"role": "user", "content": ""},
+            ]
+        )
+        body_chars = max(1_000, (int(input_budget_tokens) - fixed - 64) * 4)
+
+    def _tail(text: str, limit: int) -> str:
+        if len(text) <= limit:
+            return text
+        return "(…oldest content elided…)\n" + text[-limit:]
+
     if prior_summary:
+        prior_chars = body_chars // 2
+        current_chars = body_chars - prior_chars
         body = (
             "[previous compaction summary — fold its still-relevant content into the new "
-            "summary]\n" + prior_summary + "\n\n[conversation since]\n" + body
+            "summary]\n"
+            + _tail(prior_summary, prior_chars)
+            + "\n\n[conversation since]\n"
+            + _render_span(span, budget_chars=current_chars)
         )
-    return [
+    else:
+        body = _render_span(span, budget_chars=body_chars)
+
+    messages = [
         {"role": "system", "content": SUMMARY_SYSTEM_PROMPT},
         {"role": "user", "content": body},
     ]
+    # JSON/message overhead makes chars/4 only approximate. Tighten using the same
+    # estimator that drives compaction and retain the recent tail if the first cap missed.
+    if input_budget_tokens is not None:
+        estimated = estimate_tokens(messages)
+        while estimated > input_budget_tokens and len(body) > 256:
+            excess_chars = (estimated - input_budget_tokens + 32) * 4
+            clipped = _tail(body, max(256, len(body) - excess_chars))
+            if len(clipped) >= len(body):
+                break
+            body = clipped
+            messages[1]["content"] = body
+            estimated = estimate_tokens(messages)
+    return messages
 
 
 def summarize_span(
@@ -395,15 +492,23 @@ def summarize_span(
     *,
     prior_summary: str = "",
     max_tokens: int = SUMMARY_MAX_TOKENS,
+    context_window: Optional[int] = None,
 ) -> str:
     """One summarizer round-trip (blocking — the engine runs it off-loop). Tools are
     disabled; the Settings model override is just a different `model` id. Raises on
     provider failure or an empty summary — the caller owns the retry/trim policy."""
+    input_budget, output_budget = summary_call_budget(
+        context_window, max_tokens=max_tokens
+    )
     turn = provider.complete(
         model=model,
-        messages=summarizer_messages(span, prior_summary=prior_summary),
+        messages=summarizer_messages(
+            span,
+            prior_summary=prior_summary,
+            input_budget_tokens=input_budget,
+        ),
         tools=None,
-        max_tokens=max_tokens,
+        max_tokens=output_budget,
     )
     text = (getattr(turn, "text", None) or "").strip()
     if not text:
@@ -421,6 +526,7 @@ def build_state(
     model: str,
     keep_tokens: int,
     prior: Optional[CompactionState] = None,
+    context_window: Optional[int] = None,
 ) -> Optional[CompactionState]:
     """Summarize everything older than the picked boundary into a new CompactionState.
     On repeated compaction the prior summary heads the new span. Returns None when there
@@ -436,6 +542,7 @@ def build_state(
         model,
         span,
         prior_summary=prior.summary_text if prior is not None else "",
+        context_window=context_window,
     )
     users, dropped = _cap_user_messages(
         prior_users + extract_user_messages(span),

--- a/coworker/engine.py
+++ b/coworker/engine.py
@@ -437,9 +437,12 @@ class TurnEngine:
     def _compaction_config(self) -> dict[str, Any]:
         cfg = dict(self.compaction_settings() or {}) if self.compaction_settings else {}
         if not cfg.get("context_window"):
-            from .providers.matrix import model_context_windows
+            windows = cfg.get("model_context_windows")
+            if not isinstance(windows, dict):
+                from .providers.matrix import model_context_windows
 
-            cfg["context_window"] = model_context_windows().get(self.model)
+                windows = model_context_windows()
+            cfg["context_window"] = windows.get(self.model)
         cfg.setdefault("threshold_pct", _compaction.DEFAULT_THRESHOLD_PCT)
         cfg.setdefault("cap_tokens", _compaction.DEFAULT_CAP_TOKENS)
         return cfg
@@ -470,11 +473,14 @@ class TurnEngine:
         pct = float(cfg["threshold_pct"])
         cap = int(cfg["cap_tokens"])
         window = cfg.get("context_window")
-        keep = int(
-            _compaction.KEEP_RECENT_FRACTION
-            * _compaction.trigger_tokens(window, threshold_pct=pct, cap_tokens=cap)
+        keep = _compaction.retained_history_budget(
+            window, threshold_pct=pct, cap_tokens=cap
         )
         model = str(cfg.get("model") or "") or self.model
+        windows = cfg.get("model_context_windows")
+        summary_window = windows.get(model) if isinstance(windows, dict) else None
+        if summary_window is None and model == self.model:
+            summary_window = window
 
         def _build() -> Optional[_compaction.CompactionState]:
             return _compaction.build_state(
@@ -483,6 +489,7 @@ class TurnEngine:
                 model=model,
                 keep_tokens=keep,
                 prior=self.compaction_state,
+                context_window=summary_window,
             )
 
         state: Optional[_compaction.CompactionState] = None

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -1434,6 +1434,13 @@ def create_app(manager: SessionManager) -> FastAPI:
         # Composer: show the context-window fill bar, or just the popover (owner ask).
         return manager.set_context_bar((body or {}).get("context_bar", True))
 
+    @app.post("/v1/settings/model-context-window")
+    def settings_set_model_context_window(body: dict) -> dict[str, Any]:
+        b = body or {}
+        return manager.set_model_context_window(
+            b.get("model", ""), b.get("context_window")
+        )
+
     @app.post("/v1/settings/pdf")
     def settings_set_pdf(body: dict) -> dict[str, Any]:
         # Token savings (owner ask, 2026-07-17): fallback mode for models without native

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1827,7 +1827,7 @@ class SessionManager:
         selectable = [m for m in self._curated_models() if _selectable(m)]
         if self.model not in selectable:
             selectable.insert(0, self.model)
-        from ..providers.matrix import model_context_windows, model_labels
+        from ..providers.matrix import model_labels
 
         return {
             "provider": "openai",
@@ -1836,9 +1836,9 @@ class SessionManager:
             # Curated-matrix display names ({full id → "GLM-5.2 · via Together"}) so every
             # picker shows human labels; custom models absent here render their raw id.
             "model_labels": model_labels(),
-            # {full id → context window in tokens}, verified matrix entries only —
-            # drives the composer's context-fill meter (absent id → meter hides).
-            "model_context_windows": model_context_windows(),
+            # {full id → effective context window in tokens}. User overrides are merged
+            # over the curated matrix so the meter and compaction use one source of truth.
+            "model_context_windows": self.model_context_windows(),
             "has_key": env_key or stored,
             # Provider-agnostic "can this default model actually run?" — true when the default
             # model's provider is configured (any provider, not just OpenAI). Drives the GUI's
@@ -1920,6 +1920,65 @@ class SessionManager:
         self._save_prefs()
         return {"ok": True, "context_bar": self.context_bar()}
 
+    def model_context_windows(self) -> dict[str, int]:
+        """Effective per-model context windows: curated values plus user overrides.
+
+        Custom model ids have no matrix entry, while proxy/local deployments can expose
+        a different limit for a curated id. Keeping the override in prefs makes both
+        cases explicit and gives the GUI meter and engine compaction identical metadata.
+        """
+        from ..providers.matrix import model_context_windows
+
+        windows = model_context_windows()
+        overrides = self._prefs.get("model_context_windows")
+        if not isinstance(overrides, dict):
+            return windows
+        for model, value in overrides.items():
+            try:
+                tokens = int(value)
+            except (TypeError, ValueError):
+                continue
+            if model and 4_096 <= tokens <= 10_000_000:
+                windows[str(model)] = tokens
+        return windows
+
+    def set_model_context_window(self, model: Any, tokens: Any = None) -> dict[str, Any]:
+        """Persist or clear one model's context-window override.
+
+        ``tokens=None`` (or an empty string) removes only the user override, revealing a
+        curated value again when one exists. The generous ceiling accommodates emerging
+        long-context models without letting malformed values enter compaction math.
+        """
+        model_id = str(model or "").strip()
+        if not model_id:
+            return {"ok": False, "error": "model is required"}
+        overrides = self._prefs.get("model_context_windows")
+        overrides = dict(overrides) if isinstance(overrides, dict) else {}
+        if tokens is None or tokens == "":
+            overrides.pop(model_id, None)
+        else:
+            try:
+                value = int(tokens)
+            except (TypeError, ValueError):
+                return {"ok": False, "error": "context_window must be a number"}
+            if not 4_096 <= value <= 10_000_000:
+                return {
+                    "ok": False,
+                    "error": "context_window must be between 4096 and 10000000 tokens",
+                }
+            overrides[model_id] = value
+        if overrides:
+            self._prefs["model_context_windows"] = overrides
+        else:
+            self._prefs.pop("model_context_windows", None)
+        self._save_prefs()
+        return {
+            "ok": True,
+            "model": model_id,
+            "context_window": self.model_context_windows().get(model_id),
+            "model_context_windows": self.model_context_windows(),
+        }
+
     # -- PDF attachments / token savings (owner ask, 2026-07-17) ----------------
     DEFAULT_PDF_MAX_PAGES = 20
     DEFAULT_PDF_MAX_MB = 10
@@ -1959,6 +2018,9 @@ class SessionManager:
             ),
             # "" → the session's own model (engine falls back to self.model).
             "model": str(self._prefs.get("compaction_model") or ""),
+            # Resolved by TurnEngine against its active model on every check, so edits
+            # apply immediately to already-open sessions.
+            "model_context_windows": self.model_context_windows(),
         }
 
     def compaction_settings_payload(self) -> dict[str, Any]:

--- a/surfaces/gui/e2e/compaction.spec.ts
+++ b/surfaces/gui/e2e/compaction.spec.ts
@@ -46,6 +46,22 @@ test("Settings: Context compaction card edits threshold, cap, and summarizer mod
     card.getByTestId("compaction-model").selectOption("gpt-4o-mini"),
   ]);
   expect(req3.postDataJSON()).toEqual({ compaction_model: "gpt-4o-mini" });
+
+  // A custom model gets explicit context metadata, which the backend shares with the
+  // meter, trigger, retained-history budget, and overflow recovery.
+  await card.getByTestId("context-window-model").selectOption("openai:qwen36-35b");
+  await card.getByTestId("context-window-tokens").fill("32768");
+  const [req4] = await Promise.all([
+    page.waitForRequest(
+      (r) => r.url().endsWith("/v1/settings/model-context-window") && r.method() === "POST",
+    ),
+    card.getByTestId("context-window-save").click(),
+  ]);
+  expect(req4.postDataJSON()).toEqual({
+    model: "openai:qwen36-35b",
+    context_window: 32768,
+  });
+  await expect(card.getByTestId("context-window-tokens")).toHaveValue("32768");
 });
 
 test("the compacted divider renders mid-session and the transcript stays intact", async ({

--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -25,7 +25,7 @@ const HEALTH = { status: "ok", default_workspace: null, model: "anthropic:claude
 const SETTINGS = {
   provider: "openai",
   model: "anthropic:claude-opus-4-8",
-  models: ["anthropic:claude-opus-4-8", "gpt-5.5", "gpt-4o", "gpt-4o-mini", "o3-mini"],
+  models: ["anthropic:claude-opus-4-8", "gpt-5.5", "gpt-4o", "gpt-4o-mini", "o3-mini", "openai:qwen36-35b"],
   has_key: true,
   model_ready: true,
   source: "store",
@@ -922,6 +922,17 @@ export async function mockApi(page: import("@playwright/test").Page) {
     if (p.endsWith("/v1/settings/context-bar") && m === "POST") {
       Object.assign(SETTINGS, req.postDataJSON());
       return json({ ok: true, context_bar: SETTINGS.context_bar });
+    }
+    if (p.endsWith("/v1/settings/model-context-window") && m === "POST") {
+      const b = req.postDataJSON();
+      const windows = SETTINGS.model_context_windows as Record<string, number>;
+      if (b.context_window == null) delete windows[b.model];
+      else windows[b.model] = b.context_window;
+      return json({
+        ok: true,
+        context_window: windows[b.model],
+        model_context_windows: { ...windows },
+      });
     }
     if (p.endsWith("/v1/settings/pdf") && m === "POST") {
       Object.assign(SETTINGS, req.postDataJSON());

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -517,6 +517,22 @@ export function App() {
       })
       .catch(() => {});
 
+  useEffect(() => {
+    const refreshContextWindows = () => loadSettings();
+    window.addEventListener(
+      "coworker:model-context-windows-changed",
+      refreshContextWindows,
+    );
+    return () =>
+      window.removeEventListener(
+        "coworker:model-context-windows-changed",
+        refreshContextWindows,
+      );
+    // Settings changes are infrequent; the event intentionally refreshes the full model
+    // payload so the composer meter cannot drift from the backend's effective values.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Open Settings → Configure Models (from the composer's "No model connected" chip).
   const openModelSetup = () => openSettings("models");
 

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -699,8 +699,8 @@ export interface ModelSettings {
   context_bar?: boolean;
   // Curated-matrix display names ({full id → "GLM-5.2 · via Together"}); custom models absent.
   model_labels?: Record<string, string>;
-  // {full id → context window in tokens}, verified matrix entries only — drives the
-  // composer's context-fill meter (absent id → the meter hides). Optional for older backends.
+  // {full id → effective context window in tokens}. Curated values are merged with
+  // user overrides for custom/proxied models; drives both meter and compaction.
   model_context_windows?: Record<string, number>;
   // Token savings (PDF attachments): fallback for models without native PDF support,
   // and attach-time thresholds. Optional so the GUI is robust to an older backend.
@@ -747,6 +747,24 @@ export async function setCompactionSettings(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(patch),
+  });
+  return res.json();
+}
+
+/** Set one model's context-window override; null restores its curated/default value. */
+export async function setModelContextWindow(
+  model: string,
+  contextWindow: number | null,
+): Promise<{
+  ok: boolean;
+  error?: string;
+  context_window?: number;
+  model_context_windows?: Record<string, number>;
+}> {
+  const res = await fetch(`${httpBase()}/v1/settings/model-context-window`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, context_window: contextWindow }),
   });
   return res.json();
 }

--- a/surfaces/gui/src/components/SettingsView.tsx
+++ b/surfaces/gui/src/components/SettingsView.tsx
@@ -4,6 +4,7 @@ import {
   getTrustedWorkspaces,
   setCompactionSettings,
   setContextBar,
+  setModelContextWindow,
   setOnboarded,
   setPdfSettings,
   setScratchBase,
@@ -694,6 +695,10 @@ function CompactionCard() {
   const [cfg, setCfg] = useState<CompactionSettings | null>(null);
   const [models, setModels] = useState<string[]>([]);
   const [labels, setLabels] = useState<Record<string, string>>({});
+  const [windows, setWindows] = useState<Record<string, number>>({});
+  const [windowModel, setWindowModel] = useState("");
+  const [windowTokens, setWindowTokens] = useState("");
+  const [windowError, setWindowError] = useState("");
 
   useEffect(() => {
     getSettings()
@@ -705,6 +710,14 @@ function CompactionCard() {
         });
         setModels(s.models || []);
         setLabels(s.model_labels || {});
+        setWindows(s.model_context_windows || {});
+        const first = s.model || s.models?.[0] || "";
+        setWindowModel(first);
+        setWindowTokens(
+          s.model_context_windows?.[first]
+            ? String(s.model_context_windows[first])
+            : "",
+        );
       })
       .catch(() =>
         setCfg({
@@ -718,6 +731,32 @@ function CompactionCard() {
   const save = async (patch: Partial<CompactionSettings>) => {
     setCfg((p) => (p ? { ...p, ...patch } : p));
     await setCompactionSettings(patch);
+  };
+
+  const chooseWindowModel = (model: string) => {
+    setWindowModel(model);
+    setWindowTokens(windows[model] ? String(windows[model]) : "");
+    setWindowError("");
+  };
+
+  const saveWindow = async (reset = false) => {
+    const tokens = reset ? null : Number(windowTokens);
+    if (!windowModel) return;
+    if (!reset && (!Number.isInteger(tokens) || Number(tokens) < 4_096)) {
+      setWindowError("Enter at least 4,096 tokens.");
+      return;
+    }
+    const result = await setModelContextWindow(windowModel, tokens as number | null);
+    if (!result.ok) {
+      setWindowError(result.error || "Could not save the context window.");
+      return;
+    }
+    const next = result.model_context_windows || {};
+    setWindows(next);
+    setWindowTokens(next[windowModel] ? String(next[windowModel]) : "");
+    setWindowError("");
+    // App owns the live context meter state; tell it to refresh without a reload.
+    window.dispatchEvent(new CustomEvent("coworker:model-context-windows-changed"));
   };
 
   if (!cfg) return null;
@@ -796,6 +835,51 @@ function CompactionCard() {
       <div className={FIELD_HELP}>
         The summary is written by this model. The default follows whatever model the
         session is using.
+      </div>
+
+      <div className="mt-4 pt-4 border-t border-line">
+        <div className={FIELD_LABEL}>Model context window</div>
+        <div className={FIELD_HELP}>
+          Set the real limit for custom models or provider deployments with a different
+          limit. This value drives the context meter, compaction trigger, retained history,
+          and overflow recovery.
+        </div>
+        <div className="mt-3 flex items-center gap-2.5 flex-wrap">
+          <select
+            value={windowModel}
+            data-testid="context-window-model"
+            className="max-w-[260px] px-2 py-1.5 rounded-lg border border-line bg-paper text-[13px] text-ink outline-none focus:border-accent"
+            onChange={(e) => chooseWindowModel(e.target.value)}
+          >
+            {models.map((m) => (
+              <option key={m} value={m}>{modelLabel(m)}</option>
+            ))}
+          </select>
+          <input
+            type="number"
+            min={4_096}
+            max={10_000_000}
+            step={1_024}
+            placeholder="e.g. 32768"
+            value={windowTokens}
+            data-testid="context-window-tokens"
+            className="w-32 px-2 py-1.5 rounded-lg border border-line bg-paper text-[13px] text-ink outline-none focus:border-accent"
+            onChange={(e) => setWindowTokens(e.target.value)}
+          />
+          <span className="text-[12.5px] text-muted">tokens</span>
+          <button className={BTN_ACCENT} data-testid="context-window-save" onClick={() => void saveWindow()}>
+            Save
+          </button>
+          <button className={BTN_BORDERED} data-testid="context-window-reset" onClick={() => void saveWindow(true)}>
+            Reset
+          </button>
+        </div>
+        {windowError && <div className="mt-2 text-[12px] text-red-600" role="alert">{windowError}</div>}
+        <div className={FIELD_HELP}>
+          Reset removes your override. Curated models return to their built-in value;
+          custom models return to the 128,000-token compaction fallback and the meter
+          becomes unavailable.
+        </div>
       </div>
     </div>
   );

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -17,7 +17,9 @@ from coworker.compaction import (
     extract_working_state,
     is_context_overflow,
     pick_boundary,
+    retained_history_budget,
     should_compact,
+    summary_call_budget,
     summarize_span,
     summarizer_messages,
     trigger_tokens,
@@ -114,6 +116,14 @@ def test_should_compact_crosses_threshold():
     assert should_compact(80_000, 100_000)
 
 
+def test_retained_history_budget_reserves_small_window_headroom():
+    # Even with an aggressive user threshold, a 32k model retains space for system/tool
+    # context, the compacted summary, a normal response, and a safety margin.
+    keep = retained_history_budget(32_768, threshold_pct=0.95, cap_tokens=250_000)
+    assert keep == 6_656
+    assert keep < int(0.25 * 0.95 * 32_768)
+
+
 def test_estimate_tokens_is_chars_over_four():
     msgs = [user("a" * 400)]
     est = estimate_tokens(msgs)
@@ -205,6 +215,23 @@ def test_summarize_span_passes_model_and_raises_on_empty():
 
     with pytest.raises(RuntimeError):
         summarize_span(FakeSummarizer(text="  "), "m", [user("hi")])
+
+
+def test_recovery_summarizer_is_bounded_by_small_model_window():
+    fake = FakeSummarizer()
+    span = [user("oldest request " + "x" * 200_000)]
+    for i in range(20):
+        span += [assistant(f"answer {i} " + "y" * 20_000), user(f"request {i}")]
+
+    summarize_span(fake, "openai:qwen36-35b", span, context_window=32_768)
+
+    call = fake.calls[0]
+    input_budget, output_budget = summary_call_budget(32_768)
+    assert estimate_tokens(call["messages"]) <= input_budget
+    assert call["max_tokens"] == output_budget
+    assert estimate_tokens(call["messages"]) + output_budget < 32_768
+    # Budget clipping keeps the newest recovery context, not the huge oldest paste.
+    assert "request 19" in call["messages"][1]["content"]
 
 
 # -- build + repeated compaction ----------------------------------------------

--- a/tests/test_compaction_engine.py
+++ b/tests/test_compaction_engine.py
@@ -230,6 +230,26 @@ def test_set_compaction_settings_validates_and_round_trips(tmp_path):
     assert payload["compaction_model"] == "gpt-4o-mini"
 
 
+def test_custom_model_context_window_drives_live_engine_config(tmp_path):
+    from coworker.server.manager import SessionManager
+
+    provider = CompactingProvider([AssistantTurn(text="done", finish_reason="stop")])
+    mgr = SessionManager(
+        workspace=tmp_path,
+        data_dir=tmp_path / "data",
+        provider=provider,
+        model="openai:qwen36-35b",
+    )
+    assert mgr.set_model_context_window("openai:qwen36-35b", 32_768)["ok"]
+    engine = mgr.get_engine("small-window", agent="cowork", workspace=str(tmp_path))
+    assert engine is not None
+    assert engine._compaction_config()["context_window"] == 32_768
+
+    # The live settings getter means an already-open engine observes edits immediately.
+    mgr.set_model_context_window("openai:qwen36-35b", 65_536)
+    assert engine._compaction_config()["context_window"] == 65_536
+
+
 def test_compaction_state_survives_save_and_rebuild(tmp_path):
     from coworker.compaction import CompactionState
     from coworker.server.manager import SessionManager

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -68,6 +68,41 @@ def test_settings_rest_roundtrip(tmp_path, monkeypatch):
     )
 
 
+def test_model_context_window_override_rest_roundtrip(tmp_path, monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from coworker.server.app import create_app
+    from coworker.server.manager import SessionManager
+
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    data_dir = tmp_path / "data"
+    client = TestClient(create_app(SessionManager(data_dir=data_dir)))
+
+    saved = client.post(
+        "/v1/settings/model-context-window",
+        json={"model": "openai:qwen36-35b", "context_window": 32_768},
+    ).json()
+    assert saved["ok"] is True
+    assert saved["model_context_windows"]["openai:qwen36-35b"] == 32_768
+    assert client.get("/v1/settings").json()["model_context_windows"][
+        "openai:qwen36-35b"
+    ] == 32_768
+
+    # Overrides survive a manager rebuild and take precedence over curated metadata.
+    rebuilt = SessionManager(data_dir=data_dir)
+    assert rebuilt.model_context_windows()["openai:qwen36-35b"] == 32_768
+    curated = rebuilt.model_context_windows()["anthropic:claude-fable-5"]
+    assert rebuilt.set_model_context_window("anthropic:claude-fable-5", 65_536)[
+        "context_window"
+    ] == 65_536
+    assert rebuilt.set_model_context_window("anthropic:claude-fable-5", None)[
+        "context_window"
+    ] == curated
+
+    invalid = rebuilt.set_model_context_window("openai:qwen36-35b", 1_000)
+    assert invalid["ok"] is False and "4096" in invalid["error"]
+
+
 def test_default_model_and_onboarding_persist(tmp_path, monkeypatch):
     from fastapi.testclient import TestClient
 


### PR DESCRIPTION
## Summary

- add persistent per-model context-window overrides for custom and proxied models
- merge overrides with curated metadata so the context meter and compaction engine share one effective value
- reserve response/safety headroom when retaining recent history and hard-bound recovery summarization to the selected model's window
- add Settings UI plus backend, engine, pure-policy, and Playwright coverage for a 32,768-token custom model

## Verification

- `.venv/bin/python -m pytest -q` — 1116 passed, 1 skipped
- `npm test` — 108 passed
- `npm run build`
- `npm run e2e -- e2e/compaction.spec.ts` — 2 passed

Fixes #441
