### PR TITLE
fix(desktop): surface sidecar startup failures instead of hanging silently (#382)

### DIFF
--- a/surfaces/gui/e2e/server-fault.spec.ts
+++ b/surfaces/gui/e2e/server-fault.spec.ts
@@ -1,0 +1,40 @@
+// #382: a packaged desktop app whose sidecar died used to render a fully navigable UI
+// where every backend call hung forever with no error surfaced. With the shell now
+// reporting `get_server_status`, the SPA must fail fast to the fault screen — not the
+// folder gate, and not an endless splash.
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+test("a dead sidecar surfaces the server-fault screen instead of a silent hang", async ({
+  page,
+}) => {
+  // Simulate the desktop shell: __TAURI__ is present and reports the sidecar exited.
+  await page.addInitScript(() => {
+    (globalThis as any).__TAURI__ = {
+      core: {
+        invoke: async (cmd: string) => {
+          if (cmd === "get_server_status") {
+            return {
+              status: "exited",
+              detail: "exit status: 3",
+              bin_path:
+                "/Applications/OpenWorker.app/Contents/Resources/sidecar/openworker-server",
+              log_path: "/Users/me/.config/coworker/logs/openworker-server.log",
+            };
+          }
+          return null;
+        },
+      },
+    };
+  });
+  // Nothing is listening: every health probe dies, exactly like the field report.
+  await page.route("**/v1/health", (route) => route.abort());
+  await page.goto("/");
+
+  const fault = page.getByTestId("server-fault");
+  await expect(fault).toBeVisible({ timeout: 10_000 });
+  await expect(fault).toContainText("exited during startup");
+  await expect(fault).toContainText("openworker-server.log");
+  // The folder gate must NOT be offered — nothing behind it works.
+  await expect(page.locator(".gate-input")).toHaveCount(0);
+});

--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -32,6 +32,18 @@ use uuid::Uuid;
 
 /// The sidecar server child — killed on exit (orphaned servers have bitten us before).
 struct ServerProcess(Mutex<Option<Child>>);
+/// What the shell knows about its sidecar's startup, queryable from the SPA via
+/// `get_server_status`. "starting" flips to "listening" once the port accepts, or to
+/// "spawn_failed"/"exited" if the launch failed — so a backend that never came up is
+/// reported instead of the UI hanging on requests that can never answer (#382).
+#[derive(Clone, Serialize)]
+struct ServerStatusPayload {
+    status: &'static str, // "starting" | "listening" | "spawn_failed" | "exited"
+    detail: Option<String>,
+    bin_path: String,
+    log_path: String,
+}
+struct ServerStatus(Mutex<ServerStatusPayload>);
 /// The active keep-awake guard while keep-awake is on (None when off). Dropping the guard
 /// releases the hold (kills `caffeinate` on macOS, clears the execution state on Windows).
 struct KeepAwake(Mutex<Option<KeepAwakeGuard>>);
@@ -110,13 +122,17 @@ fn desktop_prefs_path() -> PathBuf {
     state_dir().join("desktop.json")
 }
 
+fn server_log_path() -> PathBuf {
+    state_dir().join("logs").join("openworker-server.log")
+}
+
 /// The sidecar's log file: `<state_dir>/logs/openworker-server.log`, fresh per
 /// launch with the previous run kept as `.old`. None (→ /dev/null) only if the
 /// directory can't be created — logging must never block startup.
 fn server_log_file() -> Option<std::fs::File> {
-    let dir = state_dir().join("logs");
+    let path = server_log_path();
+    let dir = path.parent()?.to_path_buf();
     std::fs::create_dir_all(&dir).ok()?;
-    let path = dir.join("openworker-server.log");
     if path.exists() {
         let _ = std::fs::rename(&path, dir.join("openworker-server.log.old"));
     }
@@ -274,6 +290,14 @@ fn set_keep_awake(state: tauri::State<KeepAwake>, enabled: bool) -> bool {
 #[tauri::command]
 fn start_window_drag(window: tauri::WebviewWindow) -> bool {
     window.start_dragging().is_ok()
+}
+
+/// The SPA polls this when its health checks fail: a sidecar that failed to launch or
+/// exited during startup can't be polled away, so the GUI shows a fault screen with the
+/// log path instead of hanging forever (#382).
+#[tauri::command]
+fn get_server_status(state: tauri::State<ServerStatus>) -> ServerStatusPayload {
+    state.0.lock().unwrap().clone()
 }
 
 // -- local dictation ---------------------------------------------------------------------------
@@ -609,6 +633,7 @@ pub fn run() {
             get_keep_awake,
             set_keep_awake,
             start_window_drag,
+            get_server_status,
             get_dictation_status,
             start_dictation,
             stop_dictation,
@@ -626,7 +651,8 @@ pub fn run() {
         ])
         .setup(move |app| {
             // 1. Start the Python server sidecar on the chosen port (inherits our env).
-            let mut server_cmd = Command::new(server_bin());
+            let server_bin_path = server_bin();
+            let mut server_cmd = Command::new(&server_bin_path);
             server_cmd
                 .args(["--host", "127.0.0.1", "--port", &port.to_string()])
                 // The sidecar self-exits if we die abruptly (dev-watcher restart, crash) —
@@ -665,14 +691,70 @@ pub fn run() {
                 use std::os::windows::process::CommandExt;
                 server_cmd.creation_flags(0x0800_0000);
             }
+            let mut status_seed = ServerStatusPayload {
+                status: "starting",
+                detail: None,
+                bin_path: server_bin_path.display().to_string(),
+                log_path: server_log_path().display().to_string(),
+            };
             let child = match server_cmd.spawn() {
                 Ok(child) => Some(child),
                 Err(e) => {
+                    // A Finder-launched app has no visible stderr, so this alone left the
+                    // packaged app hanging silently when the sidecar was missing (#382) —
+                    // hence the status record the SPA can query.
                     eprintln!("[coworker] failed to start server sidecar: {e}");
+                    status_seed.status = "spawn_failed";
+                    status_seed.detail = Some(e.to_string());
                     None
                 }
             };
+            let monitor = child.is_some();
             app.manage(ServerProcess(Mutex::new(child)));
+            app.manage(ServerStatus(Mutex::new(status_seed)));
+
+            // Watch the launch resolve: "starting" → "listening" once the port accepts,
+            // or → "exited" if the process dies first (bad interpreter, missing dylib,
+            // crashed bootloader… — the log has the specifics). Either outcome ends the
+            // thread; steady-state cost is zero.
+            if monitor {
+                let handle = app.handle().clone();
+                std::thread::spawn(move || {
+                    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+                    loop {
+                        std::thread::sleep(std::time::Duration::from_millis(500));
+                        if let Some(proc_state) = handle.try_state::<ServerProcess>() {
+                            let exited = {
+                                let mut guard = proc_state.0.lock().unwrap();
+                                match guard.as_mut() {
+                                    // Taken by the exit path — the app is quitting.
+                                    None => return,
+                                    Some(child) => child.try_wait().ok().flatten(),
+                                }
+                            };
+                            if let Some(code) = exited {
+                                if let Some(st) = handle.try_state::<ServerStatus>() {
+                                    let mut p = st.0.lock().unwrap();
+                                    p.status = "exited";
+                                    p.detail = Some(code.to_string());
+                                }
+                                return;
+                            }
+                        }
+                        let up = std::net::TcpStream::connect_timeout(
+                            &addr,
+                            std::time::Duration::from_millis(400),
+                        )
+                        .is_ok();
+                        if up {
+                            if let Some(st) = handle.try_state::<ServerStatus>() {
+                                st.0.lock().unwrap().status = "listening";
+                            }
+                            return;
+                        }
+                    }
+                });
+            }
 
             // Restore keep-awake from the last session.
             let ka = if read_keep_awake_pref() {

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -46,7 +46,7 @@ import { itemsFromMessages } from "./itemsFromMessages";
 import { addTurnUsage, emptyUsage, usageFromMessages } from "./usage";
 import { streamMode } from "./streamGate";
 import { InboxItemCard } from "./components/InboxItemCard";
-import { isTauri, platformOS, startWindowDrag } from "./tauri";
+import { getServerStatus, isTauri, platformOS, startWindowDrag, type ServerStatus } from "./tauri";
 import { Icon } from "./components/Icon";
 import { Sidebar } from "./components/Sidebar";
 import { ThinkingBlock, Transcript } from "./components/Transcript";
@@ -55,6 +55,7 @@ import { Markdown } from "./components/Markdown";
 import { SearchModal } from "./components/SearchModal";
 import { SessionIntro } from "./components/SessionIntro";
 import { FolderGate } from "./components/FolderGate";
+import { ServerFault } from "./components/ServerFault";
 import { Onboarding } from "./components/Onboarding";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { ScheduledView } from "./components/ScheduledView";
@@ -393,6 +394,9 @@ export function App() {
   // Retry health for a while: the desktop shell starts its sidecar in parallel, so the
   // server may not answer for a second or two. Only fall back to the gate once it's truly up.
   const [booting, setBooting] = useState(true);
+  // Desktop only: the shell reported its sidecar dead or unreachable — full-stop screen
+  // with diagnostics instead of a UI where every backend call hangs (#382).
+  const [serverFault, setServerFault] = useState<ServerStatus | null>(null);
   const [onboarding, setOnboarding] = useState(false);
   // True once we've resumed a prior conversation on boot (drives the splash wording).
   const [resumedExisting, setResumedExisting] = useState(false);
@@ -477,14 +481,32 @@ export function App() {
           loadSettings();
           if (!cancelled) setBooting(false);
         })
-        .catch(() => {
+        .catch(async () => {
           if (cancelled) return;
-          if (tries <= 0) {
+          // Desktop: ask the shell what happened to its sidecar. A launch failure or an
+          // early exit can't be polled away, so fail fast to the fault screen instead of
+          // burning the remaining retries (#382 — the packaged app used to render a fully
+          // navigable UI where every backend call hung silently). If retries exhaust while
+          // it's still "starting", surface that too rather than offering a dead folder gate.
+          if (isTauri()) {
+            const s = await getServerStatus().catch(() => null);
+            if (cancelled) return;
+            if (s && (s.status === "spawn_failed" || s.status === "exited")) {
+              setServerFault(s);
+              setBooting(false);
+              return;
+            }
+            if (tries <= 0) {
+              setServerFault(s ?? { status: "starting", detail: null, bin_path: "", log_path: "" });
+              setBooting(false);
+              return;
+            }
+          } else if (tries <= 0) {
             setBooting(false);
             setShowGate(true);
-          } else {
-            setTimeout(() => attempt(tries - 1), 500);
+            return;
           }
+          setTimeout(() => attempt(tries - 1), 500);
         });
     };
     attempt(40); // ~20s of 500ms retries
@@ -1213,6 +1235,11 @@ export function App() {
     if (!desktop || event.button !== 0) return;
     startWindowDrag();
   };
+
+  // A dead backend outranks the splash and the gate: nothing behind either works.
+  if (serverFault) {
+    return <ServerFault fault={serverFault} onRetry={() => window.location.reload()} />;
+  }
 
   if (booting || !uiReady) {
     return (

--- a/surfaces/gui/src/components/ServerFault.test.tsx
+++ b/surfaces/gui/src/components/ServerFault.test.tsx
@@ -1,0 +1,55 @@
+// The full-stop screen for a sidecar that never came up (#382): the headline tracks the
+// failure kind, diagnostics (detail / log / binary) render only when actually known, and
+// Reload triggers the caller's retry.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ServerFault } from "./ServerFault";
+
+afterEach(cleanup);
+
+const base = {
+  detail: null as string | null,
+  bin_path: "/Applications/OpenWorker.app/Contents/Resources/sidecar/openworker-server",
+  log_path: "/Users/me/.config/coworker/logs/openworker-server.log",
+};
+
+describe("ServerFault", () => {
+  it("reports an early exit with the exit detail and both diagnostic paths", () => {
+    render(
+      <ServerFault
+        fault={{ ...base, status: "exited", detail: "exit status: 3" }}
+        onRetry={() => {}}
+      />,
+    );
+    const text = screen.getByTestId("server-fault").textContent ?? "";
+    expect(text).toContain("exited during startup");
+    expect(screen.getByTestId("server-fault-detail").textContent).toContain("exit status: 3");
+    expect(text).toContain(base.log_path);
+    expect(text).toContain(base.bin_path);
+  });
+
+  it("reports an unresponsive server without inventing diagnostics it doesn't have", () => {
+    render(
+      <ServerFault
+        fault={{ status: "starting", detail: null, bin_path: "", log_path: "" }}
+        onRetry={() => {}}
+      />,
+    );
+    const text = screen.getByTestId("server-fault").textContent ?? "";
+    expect(text).toContain("isn't responding");
+    expect(screen.queryByTestId("server-fault-detail")).toBeNull();
+    expect(text).not.toContain("Server log");
+  });
+
+  it("Reload invokes the retry callback", () => {
+    const onRetry = vi.fn();
+    render(
+      <ServerFault
+        fault={{ ...base, status: "spawn_failed", detail: "No such file or directory (os error 2)" }}
+        onRetry={onRetry}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("server-fault-retry"));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/surfaces/gui/src/components/ServerFault.tsx
+++ b/surfaces/gui/src/components/ServerFault.tsx
@@ -1,0 +1,65 @@
+import { Icon } from "./Icon";
+import type { ServerStatus } from "../tauri";
+
+// Full-stop screen for the desktop shell when its local agent server is not there:
+// launch failed, exited during startup, or never answered. Every feature needs that
+// backend, so a clear stop with the log path beats the previous behavior — a fully
+// navigable UI where every request hung forever with no error (#382).
+interface Props {
+  fault: ServerStatus;
+  onRetry: () => void;
+}
+
+const HEADLINES: Record<ServerStatus["status"], string> = {
+  spawn_failed: "The local agent server couldn't be launched",
+  exited: "The local agent server exited during startup",
+  starting: "The local agent server isn't responding",
+  listening: "The local agent server isn't responding",
+};
+
+export function ServerFault({ fault, onRetry }: Props) {
+  return (
+    <div className="gate-overlay">
+      <div className="gate" data-testid="server-fault">
+        <div className="gate-mark">
+          <Icon name="logo" size={28} />
+        </div>
+        <h2>{HEADLINES[fault.status] ?? HEADLINES.starting}</h2>
+        <p className="gate-sub">
+          The window is fine, but the background server that does the actual work never
+          came up — so connectors, sessions, and automations would all hang. The server
+          log usually says why.
+        </p>
+        {fault.detail && (
+          <div className="gate-error" data-testid="server-fault-detail">
+            {fault.status === "exited" ? `Server process ${fault.detail}` : fault.detail}
+          </div>
+        )}
+        {fault.log_path && (
+          <>
+            <div className="gate-label">Server log</div>
+            <p className="gate-sub gate-path">
+              <code>{fault.log_path}</code>
+            </p>
+          </>
+        )}
+        {fault.bin_path && (
+          <>
+            <div className="gate-label">Server binary</div>
+            <p className="gate-sub gate-path">
+              <code>{fault.bin_path}</code>
+            </p>
+          </>
+        )}
+        <p className="gate-sub">
+          If reloading doesn't help, quit OpenWorker from the tray icon and open it again.
+        </p>
+        <div className="gate-foot">
+          <button className="btn primary" data-testid="server-fault-retry" onClick={onRetry}>
+            Reload
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/surfaces/gui/src/styles.css
+++ b/surfaces/gui/src/styles.css
@@ -822,6 +822,8 @@ button.btn.danger { color: var(--accent); }
 .gate-input input:focus { border-color: var(--accent); }
 .gate-error { color: var(--accent); font-size: 12.5px; margin-top: 8px; }
 .gate-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--faint); margin: 18px 0 6px; }
+/* Diagnostic paths on the server-fault screen: long absolute paths must wrap inside the card. */
+.gate-path { word-break: break-all; margin: 0; }
 .gate-recents { display: flex; flex-direction: column; max-height: 200px; overflow-y: auto; }
 .gate-recent { display: flex; flex-direction: column; padding: 8px 10px; border-radius: 8px; cursor: pointer; }
 .gate-recent:hover { background: var(--panel); }

--- a/surfaces/gui/src/tauri.ts
+++ b/surfaces/gui/src/tauri.ts
@@ -77,6 +77,21 @@ export const setKeepAwake = (enabled: boolean) => invoke<boolean>("set_keep_awak
 /** Begin native window dragging from a custom title/header region. */
 export const startWindowDrag = () => invoke<boolean>("start_window_drag");
 
+// --- Sidecar server status (desktop only) ----------------------------------------
+
+export type ServerStatus = {
+  status: "starting" | "listening" | "spawn_failed" | "exited";
+  detail: string | null;
+  bin_path: string;
+  log_path: string;
+};
+
+/** The shell's view of its Python sidecar: launched and listening, still starting, or
+ * dead — with the log/binary paths for diagnostics. The SPA polls this when health
+ * checks fail so a server that never came up is reported instead of hanging (#382).
+ * null in the browser build. */
+export const getServerStatus = () => invoke<ServerStatus>("get_server_status");
+
 // Local dictation is native-only. The browser build deliberately keeps this unavailable rather
 // than silently sending microphone audio to a server.
 export const getDictationStatus = () => invoke<DictationStatus>("get_dictation_status");


### PR DESCRIPTION
## Summary

Fixes the "silent" half of #382: on the packaged desktop app, when the Python sidecar never comes up, the UI renders fully navigable while every backend call hangs forever — no error surfaced anywhere.

Root-cause chain (code-verified on main):

- `server_bin()` (`src-tauri/src/lib.rs`) resolves through the sidecar candidates; when `spawn()` fails, the only signal is an `eprintln!` — invisible for a Finder-launched app. The shell then continues with no server.
- Even when the spawn succeeds, nothing watches the child: if it exits during startup (bad interpreter, missing dylib, crashed bootloader…) or never binds its port, nothing notices.
- The SPA's boot health polling (`App.tsx`) burns its ~20s of retries and then presents the normal UI as if everything were fine.

## What changed

- **Shell (Rust):** records sidecar startup state — `"starting"` → `"listening"` once the port accepts, or `"spawn_failed"` / `"exited"` (with the exit status) — and exposes it via a new `get_server_status` command. A short-lived watcher thread resolves the state and exits; steady-state cost is zero.
- **SPA:** when boot health checks fail on desktop, it asks the shell. A dead sidecar fails fast (no 20-second wait) to a full-stop fault screen with the failure detail plus the server log and binary paths; a sidecar that never answers gets the same screen once retries exhaust. The browser build keeps today's behavior.
- The fault screen deliberately outranks the folder gate — nothing behind the gate works without the backend.

This doesn't fix whatever kills a given machine's sidecar (likely several distinct causes behind #382), but it converts each of them from an indefinite silent hang into a visible, diagnosable stop — the log path shown is exactly where the answer lands.

For anyone hitting this today on current builds: `~/.config/coworker/logs/openworker-server.log` already captures the sidecar's stdout/stderr and should say why yours died.

## Validation

- `npx tsc --noEmit` — clean
- `npx vitest run` — 114 passed (3 new, `ServerFault` component)
- `npx playwright test e2e/server-fault.spec.ts e2e/boot.spec.ts e2e/error-retry.spec.ts e2e/smoke.spec.ts` — 6 passed (1 new: dead sidecar → fault screen, and the folder gate must not appear)
- `cargo check` in `src-tauri` — clean
- No Python changes.

## Screenshots

**Broken (current main, simulated dead sidecar):** the app renders a normal, fully navigable UI; every backend action hangs with no error:

![before](https://raw.githubusercontent.com/lmanchu/openworker/pr-assets/before.png)

**Fixed — sidecar exited during startup:**

![after-exited](https://raw.githubusercontent.com/lmanchu/openworker/pr-assets/after-exited.png)

**Fixed — sidecar alive but never answering (retries exhausted):**

![after-unresponsive](https://raw.githubusercontent.com/lmanchu/openworker/pr-assets/after-unresponsive.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)