### PR TITLE
feat(packaging): wire Windows Authenticode signing, activated by repo secrets (#36, #37)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,16 @@
 #   APPLE_API_KEY                the API key id
 #   APPLE_API_ISSUER             the API issuer id
 # When the secrets are absent (forks, scratch runs) the build degrades to unsigned —
-# installable via `xattr -cr`. Windows remains unsigned (Authenticode is a later step).
+# installable via `xattr -cr`.
+#
+# Windows Authenticode: same shape — build_windows.ps1 signs the sidecar exe and hands
+# Tauri the signing config when credentials are present, and degrades to unsigned when
+# they are absent. Provide ONE of (see docs/windows-signing.md for procurement + details):
+#   WINDOWS_SIGN_COMMAND             custom sign command template, %1 = file to sign
+#                                    (cloud signing CLIs: Azure Trusted Signing et al.)
+#   WINDOWS_CERTIFICATE_THUMBPRINT   cert already provisioned in the runner's store
+#   WINDOWS_CERTIFICATE              base64 PFX (+ WINDOWS_CERTIFICATE_PASSWORD)
+# Optional: WINDOWS_TIMESTAMP_URL (RFC 3161 server; defaults to DigiCert's).
 
 name: Release
 
@@ -120,6 +129,13 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Authenticode (unset secrets arrive as "" — the script treats empty as absent
+          # and builds unsigned, so forks and scratch runs are unaffected).
+          WINDOWS_SIGN_COMMAND: ${{ secrets.WINDOWS_SIGN_COMMAND }}
+          WINDOWS_CERTIFICATE_THUMBPRINT: ${{ secrets.WINDOWS_CERTIFICATE_THUMBPRINT }}
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          WINDOWS_TIMESTAMP_URL: ${{ secrets.WINDOWS_TIMESTAMP_URL }}
         run: ./packaging/build_windows.ps1
 
       - name: Stage artifacts (versioned + stable names)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It runs on your machine and doesn't lock you into any model: bring your own API 
 <sub>macOS 12+ · signed & notarized · auto-updates</sub>
 
 [**⬇ Windows 10/11 (x64)**](https://download.openworker.com/windows)
-<sub>builds are not yet code-signed, so SmartScreen will warn; signing is in progress</sub>
+<sub>builds are not yet code-signed, so SmartScreen will warn — the signing pipeline is in place pending a certificate ([docs/windows-signing.md](docs/windows-signing.md))</sub>
 
 Open the app, add a model key (or point it at Ollama), and ask for something real.
 

--- a/docs/windows-signing.md
+++ b/docs/windows-signing.md
@@ -1,0 +1,115 @@
+# Windows code signing
+
+**Status:** the release pipeline is wired for Authenticode signing and activates
+automatically when signing credentials are present as repo secrets (#36 / #37).
+Releases stay unsigned until a signing credential is procured — this document is the
+decision guide for that procurement and the runbook for turning it on.
+
+## Why this matters beyond the SmartScreen popup
+
+- **SmartScreen** shows "Windows protected your PC" for unsigned (and unknown)
+  binaries. Users learn to click "More info → Run anyway" — training the exact
+  behavior attackers rely on, which is what the audit in #36 flagged.
+- **Smart App Control** (Windows 11) is the harder wall: on machines where SAC is on
+  — it starts in evaluation mode on new Windows 11 installs and locks on for many
+  consumer machines — unsigned binaries are **blocked, not warned**. There is no
+  "Run anyway"; turning SAC off requires a decision the user can't revert without
+  reinstalling Windows. For those users, unsigned = the app simply doesn't run.
+- **SAC evaluates every PE that executes, not just the installer.** The app exe *and*
+  the PyInstaller sidecar (`openworker-server.exe`) each get evaluated at run time.
+  This is why `build_windows.ps1` signs the sidecar explicitly: Tauri's bundler signs
+  only its own outputs, and `resources` ship verbatim. A signed installer with an
+  unsigned sidecar installs fine and then fails at first backend start — the failure
+  mode looks exactly like #382 and is miserable to diagnose from user reports.
+- **AV/EDR reputation:** every release changes every file hash. Unsigned + new hash
+  = recurring false-positive quarantines. A stable signing identity accrues
+  reputation that carries across releases.
+
+## What to procure
+
+| Option | Ballpark cost | SmartScreen reputation | CI fit | Notes |
+|---|---|---|---|---|
+| **Azure Trusted Signing** | ~$10/month | Immediate (Microsoft-vouched) | Best — OIDC auth, no key custody | Public-trust identity validation currently requires an organization with 3+ years of verifiable history |
+| **OV certificate** (cloud-HSM: DigiCert KeyLocker, SSL.com eSigner, …) | ~$250–600/yr | Accrues with download volume (expect weeks of warnings on a fresh identity) | Good — vendor CLI in CI | Since the 2023 CA/B rules, new code-signing keys must live in HSMs — plain exportable PFX files are largely a thing of the past |
+| **EV certificate** (hardware token) | ~$300–700/yr | Immediate | Poor — a USB token can't live in a CI runner | Fine for locally-produced release builds; the cloud variants above fit CI better |
+
+Recommendation: **Azure Trusted Signing if the org passes identity validation**;
+otherwise an OV certificate with the CA's cloud signing CLI. (Prices and eligibility
+rules move — verify against the provider before purchasing.)
+
+## How the pipeline consumes it
+
+`packaging/build_windows.ps1` resolves credentials from the environment, first match
+wins. All of them absent → the build is unsigned and behaves exactly as today.
+
+1. **`WINDOWS_SIGN_COMMAND`** — a full command template; `%1` is replaced with the
+   path of the file to sign. This is the escape hatch that fits any cloud signing
+   CLI. Example (Azure Trusted Signing via [trusted-signing-cli](https://github.com/Levminer/trusted-signing-cli),
+   authenticated with `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET`):
+
+   ```
+   trusted-signing-cli -e https://eus.codesigning.azure.net -a <account> -c <profile> %1
+   ```
+
+   Note: Tauri substitutes `%1` in the *string* form of `signCommand` by splitting on
+   spaces — if your tool's path contains spaces, use your own `--config` overlay with
+   the `{cmd, args}` object form instead.
+
+2. **`WINDOWS_CERTIFICATE_THUMBPRINT`** — SHA-1 thumbprint of a certificate already
+   provisioned in the machine's certificate store (hardware token on a release
+   machine, or a pre-provisioned runner). The script uses `signtool` from the
+   installed Windows SDK.
+
+3. **`WINDOWS_CERTIFICATE` + `WINDOWS_CERTIFICATE_PASSWORD`** — base64-encoded PFX,
+   imported into `CurrentUser\My` for the duration of the build and then signed by
+   thumbprint, so the password never appears on a command line or in a config file.
+
+Optional: **`WINDOWS_TIMESTAMP_URL`** — RFC 3161 timestamp server (defaults to
+DigiCert's). Timestamping is non-negotiable: it is what keeps signatures valid after
+the certificate expires.
+
+**What gets signed:** the sidecar `openworker-server.exe` (explicitly, before
+bundling), then the app exe, the NSIS setup `.exe`, and the `.msi` (by Tauri during
+`tauri build`). The script verifies every produced artifact carries a valid
+signature and fails the build otherwise — a sign step that silently no-ops is worse
+than an unsigned build, because nobody looks at a green release.
+
+**For CI:** add the chosen secrets to the repo and the Windows job picks them up
+(see the env block in `.github/workflows/release.yml`). Unset secrets arrive as
+empty strings and are treated as absent, so forks and scratch runs keep building
+unsigned without any configuration.
+
+**Not in `tauri.conf.json`:** signing config deliberately travels through a
+generated `--config` overlay, never the checked-in config. A hardcoded
+`certificateThumbprint` makes `tauri build` fail on every machine that doesn't hold
+that certificate — dev builds must stay green with zero setup.
+
+## Verifying a release
+
+```powershell
+# Any of the produced artifacts:
+signtool verify /pa /all .\OpenWorker-windows-setup.exe
+Get-AuthenticodeSignature .\OpenWorker-windows.msi | Format-List
+
+# The sidecar inside an installed copy:
+Get-AuthenticodeSignature "$env:LOCALAPPDATA\OpenWorker\sidecar\openworker-server.exe"
+```
+
+First-launch expectations after signing is live:
+
+| | Unsigned (today) | Signed, new identity (OV) | Signed, Trusted Signing / established identity |
+|---|---|---|---|
+| SmartScreen | Warns | Still warns until reputation accrues | No warning |
+| Smart App Control | **Blocks** | Runs | Runs |
+
+## Field notes (from shipping a Tauri + PyInstaller-sidecar app through OEM QA)
+
+- Smart App Control blocked the *bundled sidecar binary*, not the installer — the
+  app "installed fine" and then failed at first backend start. If a signed build
+  still dies on a SAC machine, check the sidecar and any helper PEs first, not the
+  installer signature.
+- Reputation is per-identity *and* per-file: with an OV cert, expect the first
+  signed release to still trip SmartScreen; it fades as downloads accrue under the
+  same identity. Don't rotate identities — that resets the clock.
+- Keep the unsigned path first-class forever (forks, scratch builds, contributors) —
+  a build that *requires* credentials stops being reproducible by the community.

--- a/packaging/build_windows.ps1
+++ b/packaging/build_windows.ps1
@@ -7,7 +7,10 @@
   The Windows counterpart to build_dmg.sh:
     1. PyInstaller-bundle the server into a standalone onedir folder (no venv at runtime).
     2. Stage it at binaries\sidecar\ for Tauri's `resources` slot.
-    3. `tauri build --bundles nsis,msi` -> Coworker NSIS setup .exe + .msi (resources copied in).
+    3. Authenticode-sign the staged sidecar exe when signing credentials are present
+       (Tauri's bundler only signs the artifacts it produces — resources ship as-is,
+       and Smart App Control evaluates every PE that runs, not just the installer).
+    4. `tauri build --bundles nsis,msi` -> Coworker NSIS setup .exe + .msi (resources copied in).
 
   Prerequisites (see the toolchain notes in the PR/plan):
     - Rust (rustup) with the x86_64-pc-windows-msvc target + the MSVC C++ build tools (link.exe).
@@ -17,8 +20,17 @@
       calls sys.exit() at import if typer is absent, which aborts the freeze.
         py -m venv .venv ; .\.venv\Scripts\pip install -e ".[bedrock]" pyinstaller tzdata typer
 
-  The result is UNSIGNED — first launch shows a SmartScreen warning ("More info" -> "Run anyway").
-  Authenticode signing is a later step.
+  Authenticode signing mirrors the macOS pattern in release.yml: it activates when signing
+  credentials are present in the environment and the build degrades to UNSIGNED when they
+  are absent (first launch then shows a SmartScreen warning; machines with Smart App
+  Control on block the app outright). Three credential shapes, first match wins — see
+  docs/windows-signing.md for procurement and details:
+    WINDOWS_SIGN_COMMAND               full custom command template, %1 = file to sign
+                                       (cloud signing CLIs: Trusted Signing et al.)
+    WINDOWS_CERTIFICATE_THUMBPRINT     signtool against a cert already in the store
+                                       (hardware token / pre-provisioned machine)
+    WINDOWS_CERTIFICATE (+ _PASSWORD)  base64 PFX, imported for this build
+    WINDOWS_TIMESTAMP_URL              RFC 3161 timestamp server override (default DigiCert)
 
   Experimental (use-at-your-own-risk) connectors are EXCLUDED from this build by default —
   the spec strips coworker.connectors.experimental. Self-builders can opt in with:
@@ -62,13 +74,82 @@ if ($running) {
     Start-Sleep -Seconds 1
 }
 
-Write-Host "==> [1/3] PyInstaller: bundling openworker-server ($Triple)" -ForegroundColor Cyan
+# --- Authenticode signing (opt-in; absent credentials -> unsigned build, unchanged) ---------
+# Resolution order mirrors the header: custom command > store thumbprint > base64 PFX.
+# Empty env vars (unset repo secrets arrive as "") count as absent.
+
+function Find-SignTool {
+    $cmd = Get-Command signtool.exe -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    # Not on PATH (typical): newest x64 signtool from the installed Windows SDK.
+    $kits = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin"
+    if (Test-Path $kits) {
+        $tool = Get-ChildItem -Path $kits -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '\\x64\\' } |
+            Sort-Object FullName -Descending | Select-Object -First 1
+        if ($tool) { return $tool.FullName }
+    }
+    throw "signing credentials are configured but signtool.exe was not found - install the Windows 10/11 SDK."
+}
+
+$TimestampUrl = if ($env:WINDOWS_TIMESTAMP_URL) { $env:WINDOWS_TIMESTAMP_URL } else { "http://timestamp.digicert.com" }
+$SignCommandTemplate = $null   # string with %1 -> signs one file; also handed to Tauri
+$SignWindowsConfig   = $null   # merged into bundle.windows via the --config overlay
+
+if ($env:WINDOWS_SIGN_COMMAND) {
+    # Tauri substitutes %1 in signCommand's string form (split on spaces — a template
+    # whose tool path contains spaces needs the {cmd,args} object form via a manual
+    # overlay instead).
+    $SignCommandTemplate = $env:WINDOWS_SIGN_COMMAND
+    $SignWindowsConfig   = @{ signCommand = $SignCommandTemplate }
+} else {
+    $Thumbprint = $env:WINDOWS_CERTIFICATE_THUMBPRINT
+    if (-not $Thumbprint -and $env:WINDOWS_CERTIFICATE) {
+        # Base64 PFX (CI secret) -> import into the user store for this build; from
+        # there on it is thumbprint signing, so the password never reaches a command
+        # line or config file.
+        $PfxPath = Join-Path ([IO.Path]::GetTempPath()) "ocw-signing.pfx"
+        [IO.File]::WriteAllBytes($PfxPath, [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE))
+        try {
+            $PfxPass = ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -AsPlainText -Force
+            $Imported = Import-PfxCertificate -FilePath $PfxPath -CertStoreLocation Cert:\CurrentUser\My -Password $PfxPass
+            $Thumbprint = $Imported.Thumbprint
+        }
+        finally { Remove-Item -Force $PfxPath -ErrorAction SilentlyContinue }
+    }
+    if ($Thumbprint) {
+        $SignTool = Find-SignTool
+        # signtool's own quoting handles the space-y SDK path; %1 marks the target file.
+        $SignCommandTemplate = "`"$SignTool`" sign /sha1 $Thumbprint /fd sha256 /tr $TimestampUrl /td sha256 %1"
+        # Native Tauri config (it locates signtool itself) rather than signCommand.
+        $SignWindowsConfig = @{
+            certificateThumbprint = $Thumbprint
+            digestAlgorithm       = "sha256"
+            timestampUrl          = $TimestampUrl
+        }
+    }
+}
+
+function Sign-File($path) {
+    # Runs the resolved template on one file, then verifies the signature actually
+    # took — a sign step that silently no-ops is worse than an unsigned build.
+    $cmdline = $SignCommandTemplate -replace '%1', "`"$path`""
+    Write-Host "    signing $path"
+    cmd /c $cmdline
+    if ($LASTEXITCODE -ne 0) { throw "signing failed (exit $LASTEXITCODE): $path" }
+    $sig = Get-AuthenticodeSignature -FilePath $path
+    if ($sig.Status -ne "Valid") {
+        throw "signature verification failed for $path (status: $($sig.Status))"
+    }
+}
+
+Write-Host "==> [1/4] PyInstaller: bundling openworker-server ($Triple)" -ForegroundColor Cyan
 & $PyInst --noconfirm --clean `
     --distpath (Join-Path $Here "dist") --workpath (Join-Path $Here "build") `
     (Join-Path $Here "openworker-server.spec")
 if ($LASTEXITCODE -ne 0) { throw "PyInstaller failed (exit $LASTEXITCODE)" }
 
-Write-Host "==> [2/3] staging sidecar resources" -ForegroundColor Cyan
+Write-Host "==> [2/4] staging sidecar resources" -ForegroundColor Cyan
 # Onedir bundle (exe + _internal\) ships via Tauri `resources`, landing at <install>\sidecar\
 # next to the app exe — onefile's per-launch self-extraction cost seconds of boot splash.
 $BinDir = Join-Path $Gui "src-tauri\binaries"
@@ -81,28 +162,59 @@ Remove-Item -Force (Join-Path $BinDir "openworker-server-$Triple.exe") -ErrorAct
 Copy-Item -Recurse -Force $Src $Dst
 Write-Host "    -> $Dst"
 
-Write-Host "==> [3/3] tauri build (--bundles $Bundles)" -ForegroundColor Cyan
-# Auto-update artifacts (NSIS setup .exe + minisign .sig): produced only when the updater
-# signing key env is present (CI secret TAURI_SIGNING_PRIVATE_KEY). Keyless builds skip
-# the overlay so dev builds keep working; keyless RELEASES strand installs without
-# auto-update.
-$UpdaterArgs = @()
+Write-Host "==> [3/4] Authenticode signing (sidecar)" -ForegroundColor Cyan
+if ($SignCommandTemplate) {
+    # The sidecar ships via Tauri `resources`, which the bundler copies verbatim — it
+    # signs only its own outputs (app exe, installers). Smart App Control evaluates
+    # every PE at run time, so an unsigned sidecar fails on SAC machines even under a
+    # signed installer. Sign the staged copy; the bundler picks it up from here.
+    Sign-File (Join-Path $Dst "openworker-server.exe")
+} else {
+    Write-Host "    note: no signing credentials in env - installers will be UNSIGNED (SmartScreen warns; Smart App Control blocks). See docs/windows-signing.md." -ForegroundColor Yellow
+}
+
+Write-Host "==> [4/4] tauri build (--bundles $Bundles)" -ForegroundColor Cyan
+# One --config overlay carries everything conditional: updater artifacts (needs the
+# minisign key) and Authenticode config. An overlay FILE, not inline JSON (quotes are
+# lost through the PowerShell -> npm.cmd -> cmd hop; "key must be a string", v0.1.3
+# run) — and not tauri.conf.json itself, so dev builds on machines without any of
+# these credentials keep working unchanged.
+$OverlayCfg = @{ bundle = @{} }
 if ($env:TAURI_SIGNING_PRIVATE_KEY) {
-    # Pass the overlay as a FILE: inline JSON loses its quotes through the
-    # PowerShell -> npm.cmd -> cmd hop ("key must be a string", v0.1.3 run).
-    $Overlay = Join-Path ([IO.Path]::GetTempPath()) "ocw-updater-overlay.json"
-    Set-Content -Path $Overlay -Value '{"bundle":{"createUpdaterArtifacts":true}}' -Encoding ascii
-    $UpdaterArgs = @("--config", $Overlay)
+    $OverlayCfg.bundle.createUpdaterArtifacts = $true
 } else {
     Write-Host "    WARNING: no updater signing key - building WITHOUT auto-update artifacts (not releasable)." -ForegroundColor Yellow
 }
+if ($SignWindowsConfig) {
+    $OverlayCfg.bundle.windows = $SignWindowsConfig
+}
+$OverlayArgs = @()
+if ($OverlayCfg.bundle.Count -gt 0) {
+    $Overlay = Join-Path ([IO.Path]::GetTempPath()) "ocw-build-overlay.json"
+    Set-Content -Path $Overlay -Value ($OverlayCfg | ConvertTo-Json -Depth 8) -Encoding ascii
+    $OverlayArgs = @("--config", $Overlay)
+}
 Push-Location $Gui
 try {
-    & npm run tauri build -- --bundles $Bundles @UpdaterArgs
+    & npm run tauri build -- --bundles $Bundles @OverlayArgs
     if ($LASTEXITCODE -ne 0) { throw "tauri build failed (exit $LASTEXITCODE)" }
 }
 finally {
     Pop-Location
+}
+
+if ($SignCommandTemplate) {
+    # Belt-and-suspenders: fail the build if any produced installer somehow shipped
+    # unsigned (e.g. a Tauri config regression) — CI must not release it silently.
+    $BundleOut = Join-Path $Gui "src-tauri\target\release\bundle"
+    Get-ChildItem -Path $BundleOut -Recurse -Include *.exe, *.msi -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            $sig = Get-AuthenticodeSignature -FilePath $_.FullName
+            if ($sig.Status -ne "Valid") {
+                throw "unsigned artifact in a signed build: $($_.FullName) (status: $($sig.Status))"
+            }
+        }
+    Write-Host "    all bundle artifacts verified signed" -ForegroundColor Green
 }
 
 $BundleDir = Join-Path $Gui "src-tauri\target\release\bundle"


### PR DESCRIPTION
## Summary

Towards #36 / #37 (Windows builds are unsigned). Per the maintainer note in #36 there is no signing account yet — so this PR does **not** require one. It makes the release pipeline signing-ready: when a signing credential lands as a repo secret, the next release comes out fully signed; until then (and on forks / scratch runs) every build is byte-for-byte the current unsigned behavior. The included doc is the procurement decision guide for when that account gets opened.

This deliberately mirrors the two patterns the repo already uses: the macOS `APPLE_*` block in `release.yml` (secrets present → signed; absent → degrade gracefully) and the existing `TAURI_SIGNING_PRIVATE_KEY` overlay mechanism in `build_windows.ps1`.

## What changed

**`packaging/build_windows.ps1`** — resolves credentials from the environment, first match wins, all-absent = no-op:
1. `WINDOWS_SIGN_COMMAND` — custom command template (`%1` = file), the escape hatch that fits any cloud signing CLI (Azure Trusted Signing, KeyLocker, eSigner, …)
2. `WINDOWS_CERTIFICATE_THUMBPRINT` — `signtool` against a cert already in the store (hardware token / pre-provisioned runner)
3. `WINDOWS_CERTIFICATE` (+ `_PASSWORD`) — base64 PFX, imported for the build and then signed by thumbprint, so the password never reaches a command line or config file

It signs the **PyInstaller sidecar explicitly** before `tauri build`: the sidecar ships via `resources`, which the bundler copies verbatim — and Smart App Control evaluates every PE at run time, so a signed installer with an unsigned sidecar installs fine and then dies at first backend start (a failure mode that presents exactly like #382). After the build, every produced `.exe`/`.msi` is verified to carry a valid signature and the build fails otherwise — a sign step that silently no-ops is worse than an unsigned build.

**`.github/workflows/release.yml`** — passes the new secrets through (unset secrets arrive as empty strings and count as absent) and documents them in the header, mirroring the `APPLE_*` block.

**`docs/windows-signing.md`** — procurement decision matrix (Trusted Signing ~$10/mo with immediate SmartScreen reputation, vs OV cloud-HSM, vs EV token and why tokens don't fit CI), the runbook, verification commands, and field notes from shipping a Tauri + PyInstaller-sidecar app through OEM QA on SAC-enabled machines.

**`README.md`** — the Windows download caption now points at the doc.

**Deliberately NOT in `tauri.conf.json`:** a hardcoded `certificateThumbprint` makes `tauri build` fail on every machine that doesn't hold that cert. Signing config travels through a generated `--config` overlay only; dev builds stay green with zero setup.

## Validation

Ran this branch's **full Release workflow on a fork** (no secrets configured → exercises the no-credentials path end-to-end on real runners): all three build jobs green, Windows included — https://github.com/lmanchu/openworker/actions/runs/31314011128

The Windows job log shows the degradation behaving as documented:

```
==> [3/4] Authenticode signing (sidecar)
    note: no signing credentials in env - installers will be UNSIGNED (SmartScreen warns; Smart App Control blocks). See docs/windows-signing.md.
==> [4/4] tauri build (--bundles nsis,msi)
```

Also: `release.yml` YAML validated; repo CI (pytest / gui-unit / gui-e2e) green on the branch. The signed path needs a run by whoever holds real credentials — happy to iterate if anything surfaces there.

Not closing #36/#37 with this PR: those should stay open until a credential is procured and a signed release actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)