### PR TITLE
fix(providers): correct GLM-5.2 context window to 1M

### DIFF
--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -147,7 +147,7 @@ MATRIX: dict[str, ModelEntry] = {
     ),
     # OpenRouter slugs are lowercase `<lab>/<model>` (checked against their catalog
     # 2026-07-25); same labs as above, one key for all of them.
-    "openrouter:z-ai/glm-5.2": ModelEntry("GLM-5.2 · via OpenRouter", _AGENTIC, 128_000),
+    "openrouter:z-ai/glm-5.2": ModelEntry("GLM-5.2 · via OpenRouter", _AGENTIC, 1_000_000),
     "openrouter:moonshotai/kimi-k2.6": ModelEntry(
         "Kimi K2.6 · via OpenRouter", _AGENTIC, 256_000
     ),


### PR DESCRIPTION
## Summary
- `coworker/providers/matrix.py` listed the OpenRouter GLM-5.2 entry with a 128K context window, but GLM-5.2 actually exposes a 1,000,000-token context.
- Updated the entry to `1_000_000` so callers stop under-provisioning requests routed through OpenRouter.

## Context
Only the OpenRouter path was affected; the native `zai:glm-5.2` entry is a separate row. No behavioral change beyond the larger advertised window.

## Test plan
- [ ] `python -c "from coworker.providers.matrix import MATRIX; print(MATRIX['openrouter:z-ai/glm-5.2'])"`
- [ ] Verify a >128K-token prompt routed via OpenRouter is no longer rejected by the matrix entry itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)