### PR TITLE
Add default folders for new Cowork sessions

### DIFF
--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -1446,6 +1446,10 @@ def create_app(manager: SessionManager) -> FastAPI:
     def settings_set_scratch_base(body: dict) -> dict[str, Any]:
         return manager.set_scratch_base(str((body or {}).get("path", "")))
 
+    @app.post("/v1/settings/default-roots")
+    def settings_set_default_roots(body: dict) -> dict[str, Any]:
+        return manager.set_default_roots((body or {}).get("roots"))
+
     @app.post("/v1/settings/nav-layout")
     def settings_set_nav_layout(body: dict) -> dict[str, Any]:
         return manager.set_nav_layout(str((body or {}).get("nav_layout", "")))

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -355,6 +355,54 @@ class SessionManager:
         base = self._prefs.get("scratch_base") or self.DEFAULT_SCRATCH_BASE
         return Path(base).expanduser()
 
+    def _default_root_entries(self, *, existing_only: bool = False) -> list[dict[str, Any]]:
+        """Sanitized account defaults in the same persisted shape as session extra_roots.
+
+        Preferences are user-editable JSON, so reads remain defensive. Paths are stored
+        canonically by ``set_default_roots``; resolving again also safely handles older or
+        hand-written values. Missing defaults stay visible in Settings but are never granted
+        to a newly built engine.
+        """
+        raw = self._prefs.get("default_roots")
+        if not isinstance(raw, list):
+            return []
+        out: list[dict[str, Any]] = []
+        seen: set[Path] = set()
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            value = item.get("path")
+            if not isinstance(value, str) or not value.strip():
+                continue
+            try:
+                path = Path(value).expanduser().resolve()
+            except OSError:
+                continue
+            if existing_only and not path.is_dir():
+                continue
+            if path in seen:
+                continue
+            seen.add(path)
+            out.append(
+                {
+                    "path": str(path),
+                    "writable": bool(item.get("writable", False)),
+                    "label": path.name or str(path),
+                }
+            )
+        return out
+
+    def default_roots(self) -> list[dict[str, Any]]:
+        """Account defaults as the RootInfo-shaped payload consumed by Settings."""
+        return [
+            {
+                **root,
+                "primary": False,
+                "exists": Path(root["path"]).is_dir(),
+            }
+            for root in self._default_root_entries()
+        ]
+
     def _provision_scratch(self, session_id: str) -> str:
         """Create (idempotently) and return this conversation's scratch directory."""
         d = self.scratch_base() / session_id
@@ -431,9 +479,14 @@ class SessionManager:
         # folders the user added (persisted per session). Code/Chat stay single-root (roots=None).
         roots = None
         if ag.family == "knowledge" and ws:
+            inherited = (
+                (record.extra_roots or [])
+                if record
+                else self._default_root_entries(existing_only=True)
+            )
             extra = [
                 r
-                for r in ((record.extra_roots if record else []) or [])
+                for r in inherited
                 if Path(str(r.get("path", ""))).is_dir()
             ]
             roots = [{"path": ws, "writable": True, "label": "scratch"}, *extra]
@@ -1866,6 +1919,7 @@ class SessionManager:
             "context_bar": self.context_bar(),
             "scratch_base": self._prefs.get("scratch_base")
             or self.DEFAULT_SCRATCH_BASE,
+            "default_roots": self.default_roots(),
             # Real on-disk secrets location, so the UI shows the OS-native path instead of a
             # hardcoded POSIX one (Windows -> %APPDATA%\coworker, macOS/Linux -> ~/.config).
             "secrets_path": str(self.secrets.path),
@@ -2087,6 +2141,39 @@ class SessionManager:
         self._prefs["scratch_base"] = path
         self._save_prefs()
         return {"ok": True, **self.get_settings()}
+
+    def set_default_roots(self, roots: Any) -> dict[str, Any]:
+        """Replace the folders inherited by future Cowork sessions.
+
+        Every entry must name a directory that exists at save time. Canonical paths
+        deduplicate aliases and the last entry wins, which makes access toggles an upsert.
+        Existing sessions keep their own persisted snapshot.
+        """
+        if not isinstance(roots, list):
+            return {"ok": False, "error": "roots must be a list"}
+
+        normalized: dict[Path, dict[str, Any]] = {}
+        for item in roots:
+            if not isinstance(item, dict):
+                return {"ok": False, "error": "each root must be an object"}
+            value = item.get("path")
+            if not isinstance(value, str) or not value.strip():
+                return {"ok": False, "error": "each root needs a path"}
+            try:
+                path = Path(value).expanduser().resolve()
+            except OSError as exc:
+                return {"ok": False, "error": str(exc)}
+            if not path.is_dir():
+                return {"ok": False, "error": f"not a directory: {value}"}
+            normalized[path] = {
+                "path": str(path),
+                "writable": bool(item.get("writable", False)),
+                "label": path.name or str(path),
+            }
+
+        self._prefs["default_roots"] = list(normalized.values())
+        self._save_prefs()
+        return {"ok": True, "default_roots": self.default_roots()}
 
     # -- gateway + connector allow-list (inbound messaging) ---------------------
     def allow_user(
@@ -3570,7 +3657,11 @@ class SessionManager:
             if record and record.workspace
             else self._provision_scratch(session_id)
         )
-        extra = (record.extra_roots if record else []) or []
+        extra = (
+            (record.extra_roots or [])
+            if record
+            else self._default_root_entries(existing_only=True)
+        )
         out = [
             {
                 "path": primary,
@@ -3625,6 +3716,7 @@ class SessionManager:
                         mode=self.mode.value,
                         messages=[],
                         agent="cowork",  # folder access is a Cowork affordance
+                        extra_roots=self._default_root_entries(existing_only=True),
                     )
                 )
             extra = [r for r in self.get_roots(session_id) if not r["primary"]]
@@ -3663,6 +3755,18 @@ class SessionManager:
             engine.roots[:] = [r for r in engine.roots if r.path != resolved]
             self.session_store.set_extra_roots(session_id, self._extra_roots_of(engine))
         else:
+            if self.session_store.load(session_id) is None:
+                self.session_store.save(
+                    SessionRecord(
+                        session_id=session_id,
+                        workspace=self._provision_scratch(session_id),
+                        model=self.model,
+                        mode=self.mode.value,
+                        messages=[],
+                        agent="cowork",
+                        extra_roots=self._default_root_entries(existing_only=True),
+                    )
+                )
             current = self.get_roots(session_id)
             if (
                 current

--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -34,6 +34,7 @@ const SETTINGS = {
   surfaces: { cowork: true, chat: false, code: true },
   nav_layout: "grouped",
   scratch_base: "~/OpenWorker",
+  default_roots: [] as any[],
   secrets_path: "/Users/test/.config/coworker/secrets.json",
   sessions_peek: 5,
   // Token savings (PDF attachments): 2-page limit keeps the composer threshold test's
@@ -919,6 +920,18 @@ export async function mockApi(page: import("@playwright/test").Page) {
 
     if (p.endsWith("/v1/health")) return json(HEALTH);
     if (p.endsWith("/v1/settings")) return json(SETTINGS);
+    if (p.endsWith("/v1/settings/default-roots") && m === "POST") {
+      const requested = req.postDataJSON()?.roots;
+      if (!Array.isArray(requested)) return json({ ok: false, error: "roots must be a list" });
+      SETTINGS.default_roots = requested.map((root: any) => ({
+        path: root.path,
+        writable: !!root.writable,
+        label: baseName(root.path),
+        primary: false,
+        exists: true,
+      }));
+      return json({ ok: true, default_roots: SETTINGS.default_roots });
+    }
     if (p.endsWith("/v1/settings/context-bar") && m === "POST") {
       Object.assign(SETTINGS, req.postDataJSON());
       return json({ ok: true, context_bar: SETTINGS.context_bar });

--- a/surfaces/gui/e2e/settings.spec.ts
+++ b/surfaces/gui/e2e/settings.spec.ts
@@ -26,6 +26,55 @@ test("Settings opens as a full page and navigates sections", async ({ page }) =>
   await expect(page.getByTestId("set-provider-openai")).toBeVisible();
 });
 
+test("Settings: default folders are saved with access and apply to new conversations", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("account-row").click();
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+
+  const defaults = page.getByTestId("default-folders");
+  await expect(defaults.getByText("No default folders.")).toBeVisible();
+  await defaults.getByRole("button", { name: "Give access to a folder" }).click();
+  await defaults.getByRole("button", { name: "Choose location" }).click();
+  await expect(defaults.getByPlaceholder(/Choose or paste a folder path/)).toHaveValue(
+    "/tmp/picked-folder",
+  );
+
+  const [addRequest] = await Promise.all([
+    page.waitForRequest(
+      (request) =>
+        request.url().endsWith("/v1/settings/default-roots") && request.method() === "POST",
+    ),
+    defaults.getByRole("button", { name: "Add", exact: true }).click(),
+  ]);
+  expect(addRequest.postDataJSON()).toEqual({
+    roots: [{ path: "/tmp/picked-folder", writable: false }],
+  });
+  const row = defaults.locator(".root-row").filter({ hasText: "/tmp/picked-folder" });
+  await expect(row.getByRole("button", { name: "Read-only" })).toBeVisible();
+
+  const [toggleRequest] = await Promise.all([
+    page.waitForRequest(
+      (request) =>
+        request.url().endsWith("/v1/settings/default-roots") && request.method() === "POST",
+    ),
+    row.getByRole("button", { name: "Read-only" }).click(),
+  ]);
+  expect(toggleRequest.postDataJSON()).toEqual({
+    roots: [{ path: "/tmp/picked-folder", writable: true }],
+  });
+  await expect(row.getByRole("button", { name: "Read-write" })).toBeVisible();
+
+  const [removeRequest] = await Promise.all([
+    page.waitForRequest(
+      (request) =>
+        request.url().endsWith("/v1/settings/default-roots") && request.method() === "POST",
+    ),
+    row.getByTitle("Remove").click(),
+  ]);
+  expect(removeRequest.postDataJSON()).toEqual({ roots: [] });
+  await expect(defaults.getByText("No default folders.")).toBeVisible();
+});
+
 // The launch flag brings the Personas tab back (the gallery/persona suites rely on it).
 test("Settings: Personas tab returns behind the launch flag", async ({ page }) => {
   await page.addInitScript(() => localStorage.setItem("ocw.flag.personas", "1"));

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -687,6 +687,9 @@ export interface ModelSettings {
   onboarded: boolean;
   surfaces: SurfaceVisibility;
   scratch_base: string;
+  // Account defaults copied into newly created Cowork sessions. Existing sessions keep
+  // their own root snapshot; optional for compatibility with older sidecars.
+  default_roots?: RootInfo[];
   secrets_path: string;  // OS-native on-disk location the server reports (not hardcoded)
   // Sidebar layout preference (§7): "flat" = the persona accordions / today's list; "grouped" =
   // bounded per-persona cards. Defaults to "flat" (absent → flat) so the GUI is robust to an older
@@ -794,6 +797,17 @@ export async function setScratchBase(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ path }),
+  });
+  return res.json();
+}
+
+export async function setDefaultRoots(
+  roots: Array<Pick<RootInfo, "path" | "writable">>,
+): Promise<{ ok: boolean; error?: string; default_roots?: RootInfo[] }> {
+  const res = await fetch(`${httpBase()}/v1/settings/default-roots`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ roots }),
   });
   return res.json();
 }

--- a/surfaces/gui/src/components/SettingsView.tsx
+++ b/surfaces/gui/src/components/SettingsView.tsx
@@ -4,6 +4,7 @@ import {
   getTrustedWorkspaces,
   setCompactionSettings,
   setContextBar,
+  setDefaultRoots,
   setOnboarded,
   setPdfSettings,
   setScratchBase,
@@ -41,7 +42,9 @@ import { PanelHead } from "./IntegrationsView";
 import { ModelsTab } from "./ManageTabs";
 import { MemorySection } from "./MemorySection";
 import { GalleryModal } from "./GalleryModal";
+import { AddFolderForm } from "./AddFolderForm";
 import { PersonasTab } from "./PersonasTab";
+import { RootRow } from "./RootRow";
 import { SkillsTab } from "./SkillsTab";
 import { showPersonas } from "../flags";
 
@@ -894,6 +897,8 @@ function FilesCard() {
   const [settings, setSettings] = useState<ModelSettings | null>(null);
   const [scratchDraft, setScratchDraft] = useState("");
   const [scratchMsg, setScratchMsg] = useState<string | null>(null);
+  const [defaultsBusy, setDefaultsBusy] = useState(false);
+  const [defaultsMsg, setDefaultsMsg] = useState<string | null>(null);
   const desktop = isTauri();
 
   const refresh = () =>
@@ -921,6 +926,43 @@ function FilesCard() {
     const picked = await pickFolder();
     if (picked) setScratchDraft(picked);
   };
+
+  const saveDefaults = async (
+    roots: Array<{ path: string; writable: boolean }>,
+  ): Promise<boolean> => {
+    setDefaultsBusy(true);
+    setDefaultsMsg(null);
+    const res = await setDefaultRoots(roots);
+    setDefaultsBusy(false);
+    if (!res.ok || !res.default_roots) {
+      setDefaultsMsg(res.error || "Could not save default folders.");
+      return false;
+    }
+    setSettings((current) =>
+      current ? { ...current, default_roots: res.default_roots } : current,
+    );
+    setDefaultsMsg("Saved for new conversations.");
+    return true;
+  };
+  const defaults = settings?.default_roots ?? [];
+  const addDefault = (path: string, writable: boolean) =>
+    saveDefaults([
+      ...defaults.map((root) => ({ path: root.path, writable: root.writable })),
+      { path, writable },
+    ]);
+  const toggleDefault = (path: string) =>
+    saveDefaults(
+      defaults.map((root) => ({
+        path: root.path,
+        writable: root.path === path ? !root.writable : root.writable,
+      })),
+    );
+  const removeDefault = (path: string) =>
+    saveDefaults(
+      defaults
+        .filter((root) => root.path !== path)
+        .map((root) => ({ path: root.path, writable: root.writable })),
+    );
 
   if (!settings) return null;
 
@@ -952,6 +994,33 @@ function FilesCard() {
         folder; you can grant access to more folders inside any conversation.
       </div>
       {scratchMsg && <div className="text-[12.5px] text-muted mt-2.5">{scratchMsg}</div>}
+
+      <div className="border-t border-line mt-4 pt-4" data-testid="default-folders">
+        <div className={FIELD_LABEL}>Default folders</div>
+        <div className={FIELD_HELP}>
+          New Cowork conversations start with access to these folders. Changes do not affect existing
+          conversations, and each conversation can still change or remove its inherited access.
+        </div>
+        {defaults.length > 0 ? (
+          <div className="mt-2 -mx-1.5">
+            {defaults.map((root) => (
+              <RootRow
+                key={root.path}
+                root={root}
+                busy={defaultsBusy}
+                onToggle={() => void toggleDefault(root.path)}
+                onRemove={(path) => void removeDefault(path)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="text-[12px] text-faint mt-2">No default folders.</div>
+        )}
+        <div className="mt-2">
+          <AddFolderForm onAdd={addDefault} busy={defaultsBusy} compact />
+        </div>
+        {defaultsMsg && <div className="text-[12.5px] text-muted mt-2">{defaultsMsg}</div>}
+      </div>
     </div>
   );
 }

--- a/tests/test_multiroot.py
+++ b/tests/test_multiroot.py
@@ -262,6 +262,110 @@ def test_add_root_before_first_turn_persists(tmp_path):
     assert record is not None and record.agent == "cowork"
 
 
+def test_default_roots_apply_only_to_new_sessions_as_a_persisted_snapshot(tmp_path):
+    mgr = _cowork_manager(tmp_path)
+    old_default = tmp_path / "old-default"
+    new_default = tmp_path / "new-default"
+    old_default.mkdir()
+    new_default.mkdir()
+
+    # A session that already exists when defaults are saved stays unchanged.
+    existing = mgr.get_engine("existing", agent="cowork")
+    assert existing is not None
+    mgr.save("existing", existing)
+
+    saved = mgr.set_default_roots(
+        [{"path": str(old_default), "writable": False}]
+    )
+    assert saved["ok"] is True
+
+    listed = {root["path"]: root for root in mgr.get_roots("fresh")}
+    assert listed[str(old_default.resolve())]["writable"] is False
+    assert listed[str(old_default.resolve())]["primary"] is False
+
+    fresh = mgr.get_engine("fresh", agent="cowork")
+    assert fresh is not None
+    assert old_default.resolve() in {r.path for r in fresh.roots}
+    assert not fresh.permissions._under_writable_root(str(old_default / "blocked.txt"))
+
+    existing_after = _cowork_manager(tmp_path).get_engine("existing", agent="cowork")
+    assert existing_after is not None
+    assert old_default.resolve() not in {r.path for r in existing_after.roots}
+
+    # Defaults are copied into the new session, not referenced live. Changing the
+    # account setting must not rewrite a session that already inherited them.
+    mgr.set_default_roots([{"path": str(new_default), "writable": True}])
+    mgr.save("fresh", fresh)
+    reborn = _cowork_manager(tmp_path)
+    restored = reborn.get_engine("fresh", agent="cowork")
+    assert restored is not None
+    restored_paths = {r.path for r in restored.roots}
+    assert old_default.resolve() in restored_paths
+    assert new_default.resolve() not in restored_paths
+
+    newest = reborn.get_engine("newest", agent="cowork")
+    assert newest is not None
+    assert new_default.resolve() in {r.path for r in newest.roots}
+    assert newest.permissions._under_writable_root(str(new_default / "allowed.txt"))
+
+
+def test_default_roots_validate_deduplicate_and_remain_session_removable(tmp_path):
+    mgr = _cowork_manager(tmp_path)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    missing = mgr.set_default_roots(
+        [{"path": str(tmp_path / "missing"), "writable": False}]
+    )
+    assert missing["ok"] is False
+    assert mgr.get_settings()["default_roots"] == []
+
+    saved = mgr.set_default_roots(
+        [
+            {"path": str(shared), "writable": False},
+            {"path": str(shared / "."), "writable": True},
+        ]
+    )
+    assert saved["ok"] is True
+    assert saved["default_roots"] == [
+        {
+            "path": str(shared.resolve()),
+            "writable": True,
+            "label": "shared",
+            "primary": False,
+            "exists": True,
+        }
+    ]
+
+    sid = "can-remove-default"
+    engine = mgr.get_engine(sid, agent="cowork")
+    assert engine is not None
+    assert shared.resolve() in {r.path for r in engine.roots}
+    assert mgr.remove_root(sid, str(shared))["ok"] is True
+    assert shared.resolve() not in {r.path for r in engine.roots}
+    mgr.save(sid, engine)
+    restored = _cowork_manager(tmp_path).get_engine(sid, agent="cowork")
+    assert restored is not None
+    assert shared.resolve() not in {r.path for r in restored.roots}
+
+    # Removing an inherited folder is session-local; the account default remains
+    # available to subsequently created sessions.
+    assert mgr.get_settings()["default_roots"][0]["path"] == str(shared.resolve())
+    another = mgr.get_engine("another", agent="cowork")
+    assert another is not None
+    assert shared.resolve() in {r.path for r in another.roots}
+
+    # The Access rail can remove a default before the first turn builds an engine.
+    sid_before_turn = "remove-before-first-turn"
+    assert str(shared.resolve()) in {
+        root["path"] for root in mgr.get_roots(sid_before_turn)
+    }
+    assert mgr.remove_root(sid_before_turn, str(shared))["ok"] is True
+    built_later = mgr.get_engine(sid_before_turn, agent="cowork")
+    assert built_later is not None
+    assert shared.resolve() not in {r.path for r in built_later.roots}
+
+
 # -- Slice D: request_directory (interactive grant) ----------------------------
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -159,6 +159,37 @@ def test_scratch_base_setting_persists_and_drives_provisioning(tmp_path, monkeyp
     assert Path(scratch) == (base / "sess-xyz").resolve() and Path(scratch).is_dir()
 
 
+def test_default_roots_rest_roundtrip_and_persistence(tmp_path, monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from coworker.server.app import create_app
+    from coworker.server.manager import SessionManager
+
+    monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))
+    data_dir = tmp_path / "data"
+    client = TestClient(create_app(SessionManager(data_dir=data_dir)))
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    assert client.get("/v1/settings").json()["default_roots"] == []
+    response = client.post(
+        "/v1/settings/default-roots",
+        json={"roots": [{"path": str(shared), "writable": False}]},
+    ).json()
+    assert response["ok"] is True
+    assert response["default_roots"][0]["path"] == str(shared.resolve())
+    assert response["default_roots"][0]["writable"] is False
+
+    reborn = SessionManager(data_dir=data_dir)
+    assert reborn.get_settings()["default_roots"] == response["default_roots"]
+
+    rejected = client.post(
+        "/v1/settings/default-roots", json={"roots": "not-a-list"}
+    ).json()
+    assert rejected["ok"] is False
+    assert client.get("/v1/settings").json()["default_roots"] == response["default_roots"]
+
+
 def test_ollama_models_gated_on_liveness(tmp_path, monkeypatch):
     """`ollama:*` entries show only while a local Ollama answers — keyless must not mean
     always-present (a stray ollama:<junk> pref would otherwise render forever)."""


### PR DESCRIPTION
## Problem

Folder grants are currently session-scoped, so people who use the same working directories across conversations must add them again every time. There is no account-level starting set, even though each session already owns a persisted read-only/read-write root snapshot.

## Solution

- add an optional default_roots preference and a validated REST setter that canonicalizes directories, deduplicates aliases, and preserves read-only/read-write access
- copy existing defaults into newly built multi-root Cowork sessions while leaving every existing session snapshot unchanged
- preserve per-session add, toggle, remove, restart, and pre-first-turn behavior for inherited folders
- add a Default folders editor to Settings > General > Files using the existing folder picker and root access controls

## Why this approach

The session root list remains the permission owner. Account defaults are copied only when a session has no persisted record; they are not a live global grant. This prevents a later Settings change from silently expanding an existing conversation. Missing configured paths stay visible in Settings but are not granted to new engines.

Code/project sessions retain their existing explicit-workspace boundary; the defaults apply to the multi-root Cowork surfaces that expose additional folders.

## Verification

- `.venv/bin/pytest tests/test_multiroot.py tests/test_settings.py -q` — 21 passed
- `.venv/bin/pytest -q` — 1174 passed, 1 skipped
- `npm test` in `surfaces/gui` — 111 passed
- `npm run e2e` in `surfaces/gui` — 168 passed
- `npm run build` in `surfaces/gui` — production build passed
- `git diff --check` — clean

## Risk and compatibility

No persisted session or database migration is required. Older prefs without default_roots resolve to an empty list. Existing sessions retain their stored roots, and invalid or missing directories are never added to a new engine.

## Screenshot

![Default folders in Settings](https://raw.githubusercontent.com/zhouzhuozhzh-maker/openworker/pr-assets/pr-assets/issue-437-default-folders.png)

Fixes #437