### PR TITLE
fix: gate github_clone and github_pull behind approval

### DIFF
--- a/coworker/connectors/tool_defs.py
+++ b/coworker/connectors/tool_defs.py
@@ -144,14 +144,14 @@ TOOL_DEFS: tuple[ConnectorToolDef, ...] = (
         "github",
         "github_clone",
         "Clone a repo",
-        "read",
+        "write",
         "Clone a repository into a session folder to explore the code.",
     ),
     ConnectorToolDef(
         "github",
         "github_pull",
         "Update a clone",
-        "read",
+        "write",
         "Fast-forward an existing clone to the latest commits.",
     ),
     ConnectorToolDef(

--- a/tests/test_send_target_resolution.py
+++ b/tests/test_send_target_resolution.py
@@ -36,6 +36,10 @@ def test_integration_tools_reads_are_free_writes_gate(tmp_path):
     assert (
         tools["github_create_issue"].__aisuite_tool_metadata__.requires_approval is True
     )
+    # github_clone and github_pull write to disk (clone creates a directory, pull
+    # fast-forwards an existing repo), so they must gate despite being GitHub tools.
+    assert tools["github_clone"].__aisuite_tool_metadata__.requires_approval is True
+    assert tools["github_pull"].__aisuite_tool_metadata__.requires_approval is True
 
 
 def test_browser_automation_reads_are_free_interactions_gate():


### PR DESCRIPTION
Both `github_clone` and `github_pull` were registered with `kind="read"` in `TOOL_DEFS`, which caused `approval_for_tool()` to return `False` and override the `approval=True` flag set at the call site in `integration_tools.py`.

The permission engine reads `requires_approval` from the tool metadata to classify risk: `False` maps to `RiskClass.READ`, which `is_consequential()` returns `False` for, so the engine auto-allows the call without ever prompting the user. Yet both tools write to disk — `github_clone` creates a new directory and populates it with a full repository, and `github_pull` fast-forwards an existing clone to the latest upstream commits. Their own schema descriptions say "Requires user approval," and the `_attach` call passes `approval=True`, but none of that matters because the registry kind wins.

What makes this particularly hard to notice is that the connector list API (`tool_dicts` in `tool_defs.py`) always sets `requires_approval: True` in its response, so the UI shows both tools as gated. The runtime silently disagrees — the UI says "approval required," the engine says "low risk, go ahead."

This is the same class of bug as #399 (`browser_open_url` registered as `kind="read"`), just in a different connector. The fix is the same: reclassify both tools as `kind="write"` so the §36 kind→approval mapping correctly gates them.

**Changes:**
- `coworker/connectors/tool_defs.py`: `github_clone` and `github_pull` changed from `kind="read"` to `kind="write"`
- `tests/test_send_target_resolution.py`: regression test asserting both tools now have `requires_approval is True`

All 1015 tests pass, ruff clean.