### PR TITLE
fix: correct DeepSeek V4 context windows

### DIFF
--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -96,11 +96,13 @@ MATRIX: dict[str, ModelEntry] = {
         ),
     ),
     "zai:glm-5.2": ModelEntry("GLM-5.2 · Z AI", _AGENTIC, 128_000),
+    # DeepSeek's native API exposes the full 1M context for both V4 variants
+    # (verified against the official model table 2026-08-10).
     "deepseek:deepseek-v4-flash": ModelEntry(
-        "DeepSeek V4 Flash · DeepSeek", _AGENTIC, 128_000
+        "DeepSeek V4 Flash · DeepSeek", _AGENTIC, 1_000_000
     ),
     "deepseek:deepseek-v4-pro": ModelEntry(
-        "DeepSeek V4 Pro · DeepSeek", _AGENTIC, 128_000
+        "DeepSeek V4 Pro · DeepSeek", _AGENTIC, 1_000_000
     ),
     "kimi:kimi-k2.6": ModelEntry("Kimi K2.6 · Moonshot", _AGENTIC, 256_000),
     "minimax:MiniMax-M2.5": ModelEntry("MiniMax M2.5 · MiniMax"),
@@ -128,7 +130,10 @@ MATRIX: dict[str, ModelEntry] = {
         "Kimi K2.6 · via Together", _AGENTIC, 256_000
     ),
     "together:deepseek-ai/DeepSeek-V4-Pro": ModelEntry(
-        "DeepSeek V4 Pro · via Together", _AGENTIC, 128_000
+        # Together's serverless deployment exposes 512K, not the model-level 1M.
+        "DeepSeek V4 Pro · via Together",
+        _AGENTIC,
+        512_000,
     ),
     "together:meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": ModelEntry(
         "Llama 4 Maverick · via Together", _AGENTIC, 1_000_000
@@ -140,7 +145,7 @@ MATRIX: dict[str, ModelEntry] = {
         "Kimi K2.6 · via Fireworks", _AGENTIC, 256_000
     ),
     "fireworks:accounts/fireworks/models/deepseek-v4-pro": ModelEntry(
-        "DeepSeek V4 Pro · via Fireworks", _AGENTIC, 128_000
+        "DeepSeek V4 Pro · via Fireworks", _AGENTIC, 1_048_576
     ),
     "fireworks:accounts/fireworks/models/llama4-maverick-instruct-basic": ModelEntry(
         "Llama 4 Maverick · via Fireworks", _AGENTIC, 1_000_000
@@ -152,7 +157,7 @@ MATRIX: dict[str, ModelEntry] = {
         "Kimi K2.6 · via OpenRouter", _AGENTIC, 256_000
     ),
     "openrouter:deepseek/deepseek-v4-pro": ModelEntry(
-        "DeepSeek V4 Pro · via OpenRouter", _AGENTIC, 128_000
+        "DeepSeek V4 Pro · via OpenRouter", _AGENTIC, 1_048_576
     ),
     "openrouter:meta-llama/llama-4-maverick": ModelEntry(
         "Llama 4 Maverick · via OpenRouter", _AGENTIC, 1_000_000

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -354,3 +354,16 @@ def test_model_context_windows_covers_verified_entries_only():
     assert windows["anthropic:claude-fable-5"] == 1_000_000
     assert "together:thinkingmachines/Inkling" not in windows  # unverified stays absent
     assert all(isinstance(v, int) and v > 0 for v in windows.values())
+
+
+def test_deepseek_v4_context_windows_match_provider_limits():
+    windows = model_context_windows()
+    expected = {
+        "deepseek:deepseek-v4-flash": 1_000_000,
+        "deepseek:deepseek-v4-pro": 1_000_000,
+        "together:deepseek-ai/DeepSeek-V4-Pro": 512_000,
+        "fireworks:accounts/fireworks/models/deepseek-v4-pro": 1_048_576,
+        "openrouter:deepseek/deepseek-v4-pro": 1_048_576,
+    }
+
+    assert {model: windows[model] for model in expected} == expected


### PR DESCRIPTION
Fixes #389.

## Summary

- correct the native DeepSeek V4 Flash and V4 Pro context windows from 128K to the official 1M limit
- record deployment-specific limits for the curated reseller routes: 512K on Together serverless and 1,048,576 on Fireworks and OpenRouter
- add a regression test that pins all five curated DeepSeek V4 context-window values

Using provider-specific limits matters here: DeepSeek exposes the full 1M context natively, while Together's serverless deployment currently exposes 512K. Treating every route as the model-level maximum would make the context meter and compaction trigger overestimate what that endpoint accepts.

Sources checked 2026-08-10:

- DeepSeek: https://api-docs.deepseek.com/quick_start/pricing/
- Together: https://docs.together.ai/docs/serverless/models
- Fireworks: https://fireworks.ai/models/fireworks/deepseek-v4-pro
- OpenRouter: https://openrouter.ai/api/v1/models

## Testing

```text
pytest tests/test_token_usage.py tests/test_providers.py tests/test_compaction_engine.py -q
48 passed in 2.09s
```

No screenshot is applicable: this changes model metadata consumed by the existing context meter and compaction logic, with no UI layout change.
