### PR TITLE
fix(providers): mark image-capable OpenRouter models as vision-capable

### DIFF
--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -148,14 +148,24 @@ MATRIX: dict[str, ModelEntry] = {
     # OpenRouter slugs are lowercase `<lab>/<model>` (checked against their catalog
     # 2026-07-25); same labs as above, one key for all of them.
     "openrouter:z-ai/glm-5.2": ModelEntry("GLM-5.2 · via OpenRouter", _AGENTIC, 128_000),
+    # Kimi K2.6 and Llama 4 Maverick accept image input on OpenRouter (their catalog's
+    # `input_modalities`, checked 2026-08-09); GLM-5.2 and DeepSeek V4 Pro are text-only.
     "openrouter:moonshotai/kimi-k2.6": ModelEntry(
-        "Kimi K2.6 · via OpenRouter", _AGENTIC, 256_000
+        "Kimi K2.6 · via OpenRouter",
+        ModelCapabilities(
+            tools=True, vision=True, parallel_tool_calls=True, streaming=True
+        ),
+        256_000,
     ),
     "openrouter:deepseek/deepseek-v4-pro": ModelEntry(
         "DeepSeek V4 Pro · via OpenRouter", _AGENTIC, 128_000
     ),
     "openrouter:meta-llama/llama-4-maverick": ModelEntry(
-        "Llama 4 Maverick · via OpenRouter", _AGENTIC, 1_000_000
+        "Llama 4 Maverick · via OpenRouter",
+        ModelCapabilities(
+            tools=True, vision=True, parallel_tool_calls=True, streaming=True
+        ),
+        1_000_000,
     ),
     # -- cloud accounts (models running in the user's own AWS/GCP) ----------------
     # Bedrock ids carry a family segment (claude/ → native Anthropic path, other/ →

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -388,6 +388,15 @@ def test_matrix_answers_capabilities_for_reseller_ids():
         assert caps.tools and caps.parallel_tool_calls and caps.streaming
 
 
+def test_openrouter_matrix_marks_image_capable_models():
+    """Kimi K2.6 and Llama 4 Maverick accept image input on OpenRouter (their catalog's
+    input_modalities); GLM-5.2 and DeepSeek V4 Pro are text-only, so vision stays off."""
+    assert capabilities_for("openrouter:moonshotai/kimi-k2.6").vision is True
+    assert capabilities_for("openrouter:meta-llama/llama-4-maverick").vision is True
+    assert capabilities_for("openrouter:z-ai/glm-5.2").vision is False
+    assert capabilities_for("openrouter:deepseek/deepseek-v4-pro").vision is False
+
+
 def test_matrix_labels_and_custom_model_fallback():
     from coworker.providers.matrix import MATRIX, model_labels
 


### PR DESCRIPTION
Kimi K2.6 and Llama 4 Maverick accept image input on OpenRouter per their catalog's `input_modalities`; the matrix marked every OpenRouter model vision=False, so the engine replaced image parts with a placeholder and the models never received them. GLM-5.2 and DeepSeek V4 Pro stay text-only.

Fixes #481.