### PR TITLE
feat(providers): curate Qwen3.8-Max-Preview as vision-capable

### DIFF
--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -105,6 +105,16 @@ MATRIX: dict[str, ModelEntry] = {
     "kimi:kimi-k2.6": ModelEntry("Kimi K2.6 · Moonshot", _AGENTIC, 256_000),
     "minimax:MiniMax-M2.5": ModelEntry("MiniMax M2.5 · MiniMax"),
     "qwen:qwen3-max": ModelEntry("Qwen3 Max · Alibaba", _AGENTIC, 256_000),
+    # Qwen3.8-Max-Preview (Alibaba): multimodal (text + images + video + documents) with a
+    # 1M-token window per the vendor spec; without a matrix entry the qwen prefix heuristic
+    # strips its vision. Context entered 2026-08-02 from Alibaba's model card.
+    "qwen:qwen3.8-max-preview": ModelEntry(
+        "Qwen3.8 Max Preview · Alibaba",
+        ModelCapabilities(
+            tools=True, vision=True, parallel_tool_calls=True, streaming=True
+        ),
+        1_000_000,
+    ),
     "xai:grok-4.3": ModelEntry("Grok 4.3 · xAI", _AGENTIC, 256_000),
     "mistral:mistral-large-latest": ModelEntry(
         "Mistral Large · Mistral", _AGENTIC, 128_000

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -388,6 +388,16 @@ def test_matrix_answers_capabilities_for_reseller_ids():
         assert caps.tools and caps.parallel_tool_calls and caps.streaming
 
 
+def test_qwen38_max_preview_matrix_entry_is_vision_capable():
+    """Qwen3.8-Max-Preview is multimodal; a curated matrix entry keeps the qwen prefix
+    heuristic from stripping its image input."""
+    caps = capabilities_for("qwen:qwen3.8-max-preview")
+    assert caps.tools and caps.vision and caps.parallel_tool_calls and caps.streaming
+    from coworker.providers.matrix import model_context_windows
+
+    assert model_context_windows()["qwen:qwen3.8-max-preview"] == 1_000_000
+
+
 def test_matrix_labels_and_custom_model_fallback():
     from coworker.providers.matrix import MATRIX, model_labels
 


### PR DESCRIPTION
The qwen prefix heuristic in capabilities.py hardcodes vision=False, so Qwen3.8-Max-Preview — multimodal per Alibaba's model card — had its image attachments silently stripped before the request reached the model. A curated matrix entry restores vision and gives the GUI an accurate 1M-token context meter.

Fixes #401.