### PR TITLE
fix(cloud): gallery install event respects the telemetry toggle

### DIFF
--- a/coworker/cloud.py
+++ b/coworker/cloud.py
@@ -644,7 +644,10 @@ def gallery_manifest(secrets: SecretStore, config: Config, slug: str) -> Optiona
 
 
 def gallery_install_event(secrets: SecretStore, config: Config, slug: str) -> None:
-    """Best-effort product telemetry (slug/version only, no content)."""
+    """Best-effort product telemetry (slug/version only, no content). Hard no-op unless
+    signed in AND the toggle is on — same gate as emit_session_created (#398)."""
+    if not telemetry_enabled(secrets):
+        return
     token = fresh_access_token(secrets, config)
     if not token:
         return

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -443,6 +443,44 @@ def test_emit_is_content_free_and_hashes_session_id(secrets, config, monkeypatch
     }
 
 
+def test_gallery_install_event_sends_nothing_when_opted_out(secrets, config, monkeypatch):
+    """The install event must respect the telemetry toggle — it fired regardless of it
+    before #398, so a user who turned telemetry off was still POSTed to on install."""
+    _signed_in(secrets)
+    cloud.set_telemetry_enabled(secrets, False)
+
+    def boom(*a, **k):
+        raise AssertionError("opted-out users must send no gallery install telemetry")
+
+    monkeypatch.setattr(cloud.httpx, "post", boom)
+    cloud.gallery_install_event(secrets, config, "sales")
+
+
+def test_gallery_install_event_sends_nothing_signed_out(secrets, config, monkeypatch):
+    _signed_in_marker = secrets.get(cloud.CLOUD_AUTH_PROFILE)
+    assert _signed_in_marker is None  # start signed out
+
+    def boom(*a, **k):
+        raise AssertionError("signed-out users must send no gallery install telemetry")
+
+    monkeypatch.setattr(cloud.httpx, "post", boom)
+    cloud.gallery_install_event(secrets, config, "sales")
+
+
+def test_gallery_install_event_posts_when_enabled(secrets, config, monkeypatch):
+    _signed_in(secrets)
+    sent = {}
+
+    def fake_post(url, **kwargs):
+        sent["url"] = url
+        sent["body"] = kwargs["json"]
+        return FakeResponse(200, {"ok": True})
+
+    monkeypatch.setattr(cloud.httpx, "post", fake_post)
+    cloud.gallery_install_event(secrets, config, "sales")
+    assert sent["url"] == "https://cloud.test/v1/personas/gallery/sales/install-events"
+
+
 # --- gallery solo page ------------------------------------------------------
 
 


### PR DESCRIPTION
gallery_install_event() checked only sign-in and POSTed install telemetry even after the user turned telemetry off — the one code path that ignored the toggle. It now uses the same telemetry_enabled() gate as emit_session_created().

Fixes #398.