### PR TITLE
fix(providers): correct DeepSeek V4 context windows to 1M

### DIFF
--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -96,11 +96,14 @@ MATRIX: dict[str, ModelEntry] = {
         ),
     ),
     "zai:glm-5.2": ModelEntry("GLM-5.2 · Z AI", _AGENTIC, 128_000),
+    # DeepSeek V4 Pro and V4 Flash both carry a 1M-token context window per the vendor
+    # spec (checked against the DeepSeek catalog 2026-08-12); the matrix had 128k, which
+    # under-reported the GUI's context-fill meter.
     "deepseek:deepseek-v4-flash": ModelEntry(
-        "DeepSeek V4 Flash · DeepSeek", _AGENTIC, 128_000
+        "DeepSeek V4 Flash · DeepSeek", _AGENTIC, 1_000_000
     ),
     "deepseek:deepseek-v4-pro": ModelEntry(
-        "DeepSeek V4 Pro · DeepSeek", _AGENTIC, 128_000
+        "DeepSeek V4 Pro · DeepSeek", _AGENTIC, 1_000_000
     ),
     "kimi:kimi-k2.6": ModelEntry("Kimi K2.6 · Moonshot", _AGENTIC, 256_000),
     "minimax:MiniMax-M2.5": ModelEntry("MiniMax M2.5 · MiniMax"),
@@ -128,7 +131,7 @@ MATRIX: dict[str, ModelEntry] = {
         "Kimi K2.6 · via Together", _AGENTIC, 256_000
     ),
     "together:deepseek-ai/DeepSeek-V4-Pro": ModelEntry(
-        "DeepSeek V4 Pro · via Together", _AGENTIC, 128_000
+        "DeepSeek V4 Pro · via Together", _AGENTIC, 1_000_000
     ),
     "together:meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": ModelEntry(
         "Llama 4 Maverick · via Together", _AGENTIC, 1_000_000
@@ -140,7 +143,7 @@ MATRIX: dict[str, ModelEntry] = {
         "Kimi K2.6 · via Fireworks", _AGENTIC, 256_000
     ),
     "fireworks:accounts/fireworks/models/deepseek-v4-pro": ModelEntry(
-        "DeepSeek V4 Pro · via Fireworks", _AGENTIC, 128_000
+        "DeepSeek V4 Pro · via Fireworks", _AGENTIC, 1_000_000
     ),
     "fireworks:accounts/fireworks/models/llama4-maverick-instruct-basic": ModelEntry(
         "Llama 4 Maverick · via Fireworks", _AGENTIC, 1_000_000
@@ -152,7 +155,7 @@ MATRIX: dict[str, ModelEntry] = {
         "Kimi K2.6 · via OpenRouter", _AGENTIC, 256_000
     ),
     "openrouter:deepseek/deepseek-v4-pro": ModelEntry(
-        "DeepSeek V4 Pro · via OpenRouter", _AGENTIC, 128_000
+        "DeepSeek V4 Pro · via OpenRouter", _AGENTIC, 1_000_000
     ),
     "openrouter:meta-llama/llama-4-maverick": ModelEntry(
         "Llama 4 Maverick · via OpenRouter", _AGENTIC, 1_000_000

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -354,3 +354,19 @@ def test_model_context_windows_covers_verified_entries_only():
     assert windows["anthropic:claude-fable-5"] == 1_000_000
     assert "together:thinkingmachines/Inkling" not in windows  # unverified stays absent
     assert all(isinstance(v, int) and v > 0 for v in windows.values())
+
+
+def test_deepseek_v4_context_windows():
+    """DeepSeek V4 Pro and V4 Flash carry a 1M-token window across every routed id
+    (direct, OpenRouter, Together, Fireworks) — the matrix must not under-report it."""
+    from coworker.providers.matrix import model_context_windows
+
+    windows = model_context_windows()
+    for mid in (
+        "deepseek:deepseek-v4-flash",
+        "deepseek:deepseek-v4-pro",
+        "openrouter:deepseek/deepseek-v4-pro",
+        "together:deepseek-ai/DeepSeek-V4-Pro",
+        "fireworks:accounts/fireworks/models/deepseek-v4-pro",
+    ):
+        assert windows[mid] == 1_000_000, mid


### PR DESCRIPTION
The matrix listed 128k for DeepSeek V4 Pro and V4 Flash across all routed ids (direct, OpenRouter, Together, Fireworks); the vendor spec is a 1M-token window, so the GUI's context-fill meter was under-reporting. Verified against the DeepSeek catalog (V4 Pro and V4 Flash both 1048576). Fixes #389.