### PR TITLE
Post-merge fixes: MCP notices, rail defaults, viewer header, access footer

### DIFF
--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1193,6 +1193,9 @@ class SessionManager:
             try:
                 conn = await self.mcp.ensure(server)
                 self._mcp_errors.pop(server.name, None)
+                # Recovery resets the notice dedupe: if this server breaks again
+                # later, the next session gets a fresh transcript notice.
+                self._clear_mcp_notified(server.name)
             except Exception as exc:
                 if mcp_oauth.is_auth_required(exc):
                     # Stored tokens no longer refresh (vendor rotated/expired
@@ -1218,9 +1221,19 @@ class SessionManager:
                     logger.warning(
                         "mcp %s failed to connect: %s", server.name, msg[:500]
                     )
-                self._mcp_session_failures.setdefault(session_id, []).append(
-                    server.name
-                )
+                # Transcript notice on state CHANGE, not state (owner ruling
+                # 2026-08-21): a continuously-broken server stamps only the first
+                # session after it breaks (or breaks differently) — the Connectors
+                # page carries the standing error. Personas that DECLARE the server
+                # in their manifest keep the every-session notice: for them the
+                # missing tools are material every time (the 2026-08-20 drill case).
+                declared = persona_mcp is not None and server.name in persona_mcp
+                if declared or self._should_notify_mcp_failure(
+                    server.name, self._mcp_errors.get(server.name, "")
+                ):
+                    self._mcp_session_failures.setdefault(session_id, []).append(
+                        server.name
+                    )
                 continue
             callables = build_callables(
                 server,
@@ -1238,6 +1251,21 @@ class SessionManager:
                     )
             out.extend(callables)
         return out
+
+    def _should_notify_mcp_failure(self, name: str, error: str) -> bool:
+        """True once per failure episode: the first session after `name` starts
+        failing (or its error text changes) notices; unchanged-broken stays quiet.
+        Persisted in prefs so an app relaunch doesn't re-stamp the same complaint."""
+        notified = self._prefs.setdefault("mcp_notified_errors", {})
+        if notified.get(name) == error:
+            return False
+        notified[name] = error
+        self._save_prefs()
+        return True
+
+    def _clear_mcp_notified(self, name: str) -> None:
+        if self._prefs.get("mcp_notified_errors", {}).pop(name, None) is not None:
+            self._save_prefs()
 
     def pop_mcp_failures(self, session_id: str) -> list[tuple[str, Optional[str]]]:
         """Drain (name, error) for servers that failed while preparing this session's
@@ -1337,6 +1365,7 @@ class SessionManager:
                 # survive an app restart, so it lives in prefs, not memory.
                 self._prefs.setdefault("mcp_last_test", {})[name] = int(time.time())
                 self._save_prefs()
+                self._clear_mcp_notified(name)
                 return {"ok": True, "tools": len(conn.tools)}
             except Exception as exc:
                 if (
@@ -1425,6 +1454,7 @@ class SessionManager:
             self._mcp_auth_hints.discard(name)
             if self._prefs.get("mcp_last_test", {}).pop(name, None) is not None:
                 self._save_prefs()
+            self._clear_mcp_notified(name)
             # Removing a server must not leave its connection running until the next
             # restart, nor its OAuth tokens + DCR registration in the secret store —
             # "Remove" is the user saying this server is GONE (owner review 2026-08-21).

--- a/packaging/build_dmg.sh
+++ b/packaging/build_dmg.sh
@@ -35,6 +35,10 @@
 # Experimental (use-at-your-own-risk) connectors are EXCLUDED from this build by default —
 # the spec strips coworker.connectors.experimental. Self-builders can opt in with:
 #   COWORKER_EXPERIMENTAL=1 ./build_dmg.sh
+# VENV PREREQS (a fresh worktree's venv, discovered the hard way 2026-08-21):
+#   .venv/bin/pip install -e ".[dev,messaging,browser,bedrock]" pyinstaller typer
+# (`typer` because PyInstaller's submodule collection imports mcp.cli, which
+# sys.exit(1)s without it.)
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"

--- a/surfaces/gui/e2e/access-section.spec.ts
+++ b/surfaces/gui/e2e/access-section.spec.ts
@@ -91,6 +91,11 @@ test("per-session mute round-trips; the summary follows", async ({ page }) => {
   const body = page.getByRole("region", { name: "Session access" });
   // Muting Slack for this session drops it from the live summary (the fixture flips
   // enabled on POST and the section reloads).
-  await body.getByTitle("Enabled for this session — tap to mute here").nth(1).click();
+  await body
+    .getByTitle(
+      "On for this session. Off mutes it for this session only — the connector stays connected.",
+    )
+    .nth(1)
+    .click();
   await expect(section.getByTestId("access-summary")).toHaveText("Browser, GitHub · 1 folder");
 });

--- a/surfaces/gui/e2e/artifacts.spec.ts
+++ b/surfaces/gui/e2e/artifacts.spec.ts
@@ -71,3 +71,19 @@ test("Artifacts section renders for a folder-gated coworker too (universal scrat
   await page.getByTestId("rail-toggle-artifacts").click();
   await expect(page.locator(".artifact-row", { hasText: "security-review.html" })).toBeVisible();
 });
+
+test("Show sidebar sticks while the artifact viewer is open", async ({ page }) => {
+  // Owner-hit 2026-08-21: opening the viewer auto-collapses the nav (one-shot
+  // courtesy), but clicking "Show sidebar" then instantly re-collapsed it — the
+  // notify effect replayed "open" on a callback identity change. The user's
+  // explicit toggle must win.
+  await openReport(page);
+  await expect(page.getByRole("button", { name: "Show sidebar" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Show sidebar" }).click();
+  await page.waitForTimeout(400); // give a regression time to re-collapse
+  await expect(page.getByRole("button", { name: "Show sidebar" })).toHaveCount(0);
+  await expect(page.getByText("New session").first()).toBeVisible();
+  // The viewer stays open too — expanding the nav is navigation, not dismissal.
+  await expect(page.getByTestId("artifact-frame")).toBeVisible();
+});

--- a/surfaces/gui/e2e/artifacts.spec.ts
+++ b/surfaces/gui/e2e/artifacts.spec.ts
@@ -36,7 +36,11 @@ test("HTML artifact offers Open in browser as the unsandboxed escape hatch", asy
   page,
 }) => {
   await openReport(page);
+  // UX-038: the open action lives in the labeled ⋯ menu now.
+  await page.getByTestId("artifact-more").click();
   await expect(page.getByTestId("artifact-open-browser")).toBeVisible();
+  await expect(page.getByTestId("artifact-copy-contents")).toBeVisible();
+  await expect(page.getByTestId("artifact-copy-path")).toBeVisible();
 });
 
 test("a transcript chip opens the viewer on the FIRST click even with the rail hidden", async ({
@@ -86,4 +90,17 @@ test("Show sidebar sticks while the artifact viewer is open", async ({ page }) =
   await expect(page.getByText("New session").first()).toBeVisible();
   // The viewer stays open too — expanding the nav is navigation, not dismissal.
   await expect(page.getByTestId("artifact-frame")).toBeVisible();
+});
+
+test("viewer breadcrumb goes back and ✕ closes (UX-038)", async ({ page }) => {
+  await openReport(page);
+  // The breadcrumb parent is the back action — returns to the rail sections.
+  await page.getByTestId("artifact-crumb-back").click();
+  await expect(page.getByTestId("rail-toggle-artifacts")).toBeVisible();
+
+  // Reopen (the section is still expanded from openReport), then ✕ closes the same way.
+  await page.locator(".artifact-row", { hasText: "security-review.html" }).click();
+  await expect(page.getByTestId("artifact-frame")).toBeVisible();
+  await page.getByTestId("artifact-close").click();
+  await expect(page.getByTestId("rail-toggle-artifacts")).toBeVisible();
 });

--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -354,6 +354,16 @@ const PROVIDERS = [
 
 /** Install the API + WebSocket mocks on a page. Returns handles for assertions/seed data. */
 export async function mockApi(page: import("@playwright/test").Page) {
+  // The rail defaults to HIDDEN (UX-038 follow-up). Existing specs were written
+  // against a visible rail, so run them in the "user opened it" state; the
+  // default + persistence themselves are pinned by rail-default.spec.ts.
+  await page.addInitScript(() => {
+    try {
+      if (!localStorage.getItem("ocw-e2e-rail-default")) {
+        localStorage.setItem("coworker:rail-hidden:v1", "0");
+      }
+    } catch { /* ignore */ }
+  });
   const subscriptions: any[] = [
     // One existing subscription (a non-pinned session) so the Slack page's per-workspace
     // "Listening" row has an entry. Relay-mode channels are team-qualified (slack:T…/C…).

--- a/surfaces/gui/e2e/rail-default.spec.ts
+++ b/surfaces/gui/e2e/rail-default.spec.ts
@@ -1,0 +1,45 @@
+// UX-038 follow-up (owner ruling 2026-08-21): the right rail starts hidden and the
+// topbar toggle's choice survives a restart. Deep links (artifact chips) force-show
+// transiently without overwriting the stored preference.
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+async function clearRailPref(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await page.evaluate(() => {
+    localStorage.setItem("ocw-e2e-rail-default", "1"); // opt out of the fixture seed
+    localStorage.removeItem("coworker:rail-hidden:v1");
+  });
+  await page.reload();
+}
+
+test("rail is hidden by default; the toggle persists across restarts", async ({ page }) => {
+  await clearRailPref(page);
+  await expect(page.getByTestId("rail-toggle-artifacts")).toHaveCount(0);
+
+  // Show it — the choice must survive a reload ("restart").
+  await page.getByRole("button", { name: "Show side panel" }).click();
+  await expect(page.getByTestId("rail-toggle-artifacts")).toBeVisible();
+  await page.reload();
+  await expect(page.getByTestId("rail-toggle-artifacts")).toBeVisible();
+
+  // Hide it — that persists too.
+  await page.getByRole("button", { name: "Hide side panel" }).click();
+  await page.reload();
+  await expect(page.getByTestId("rail-toggle-artifacts")).toHaveCount(0);
+});
+
+test("an artifact chip force-shows the rail without overwriting the hidden preference", async ({ page }) => {
+  await clearRailPref(page);
+  // "show the report" makes the fixture echo carry an [artifact:] chip.
+  await page.getByPlaceholder(/Ask the coworker/).fill("show the report");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  // The transcript's artifact chip opens the viewer even though the rail is hidden.
+  await page.getByTestId("artifact-chip").click();
+  await expect(page.getByTestId("artifact-frame")).toBeVisible();
+
+  // The stored preference is untouched: a reload starts hidden again.
+  await page.reload();
+  await expect(page.getByTestId("rail-toggle-artifacts")).toHaveCount(0);
+});

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -117,6 +117,7 @@ function normalizeTodos(raw: unknown): TodoItem[] {
 // consults the real persona's requires_folder once available).
 const gatesWorkspaceFallback = (a: string) => a === "code";
 const LAST_SESSION_KEY = "coworker:last-session-by-agent:v1";
+const RAIL_HIDDEN_KEY = "coworker:rail-hidden:v1";
 const NAV_COLLAPSED_KEY = "coworker:nav-collapsed:v1";
 
 type LastSession = { sessionId: string; workspace: string; updatedAt: number };
@@ -283,7 +284,16 @@ export function App() {
   const [boardDetailId, setBoardDetailId] = useState<number | null>(null);
   // # team chat overlay — opened from the team entry's chat row.
   const [chatTeam, setChatTeam] = useState<string | null>(null);
-  const [railHidden, setRailHidden] = useState(false);
+  // UX-038 follow-up (owner ruling 2026-08-21): the rail starts HIDDEN and the
+  // topbar toggle persists per-device. Deep links (artifact/board chips, Access)
+  // still force-show transiently — they never overwrite the stored preference.
+  const [railHidden, setRailHidden] = useState<boolean>(() => {
+    try { return localStorage.getItem(RAIL_HIDDEN_KEY) !== "0"; } catch { return true; }
+  });
+  const setRailHiddenPersist = useCallback((v: boolean) => {
+    setRailHidden(v);
+    try { localStorage.setItem(RAIL_HIDDEN_KEY, v ? "1" : "0"); } catch { /* best effort */ }
+  }, []);
   // Left-nav collapse (⌘B): when collapsed the sidebar leaves the grid so content reclaims the
   // width; hovering the left edge peeks it back as a floating overlay. Persisted per-device.
   const [navCollapsed, setNavCollapsed] = useState<boolean>(() => {
@@ -1786,7 +1796,7 @@ export function App() {
           {/* Right: session-settings icon (§23) + panel toggle. Model/mode/persona chrome is
               gone — the facts live in the subtitle, the controls in the composer (§22). */}
           <div className="main-topbar-side main-topbar-actions" onPointerDown={beginWindowDrag}>
-            {agent === "cowork" && railHidden && artifactCount > 0 && (
+            {railHidden && artifactCount > 0 && (
               <button
                 className="topbar-artifacts-btn"
                 onMouseDown={(e) => e.stopPropagation()}
@@ -1804,7 +1814,7 @@ export function App() {
               <button
                 className="topbar-icon-btn"
                 onMouseDown={(e) => e.stopPropagation()}
-                onClick={() => setRailHidden((h) => !h)}
+                onClick={() => setRailHiddenPersist(!railHidden)}
                 aria-label={railHidden ? "Show side panel" : "Hide side panel"}
                 title={railHidden ? "Show side panel" : "Hide side panel"}
               >

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -304,16 +304,22 @@ export function App() {
   }, [navCollapsed, setNavCollapsedPersist]);
   // #3: collapse the nav while a full artifact preview is open, restore it on close (unless the
   // user manually toggled meanwhile). The collapse is transient — it never overwrites the pref.
+  // STABLE identity (no deps): depending on navCollapsed changed this callback's identity on
+  // every nav toggle, which re-ran the rail's notify effect with the viewer still open and
+  // re-collapsed the nav the instant the user expanded it (owner-hit 2026-08-21). The current
+  // collapse state is read through the functional updater instead.
   const onArtifactPreview = useCallback((open: boolean) => {
     if (open) {
-      if (navBeforePreview.current === null) navBeforePreview.current = navCollapsed;
       setNavPeek(false);
-      setNavCollapsed(true);
+      setNavCollapsed((cur) => {
+        if (navBeforePreview.current === null) navBeforePreview.current = cur;
+        return true;
+      });
     } else if (navBeforePreview.current !== null) {
       setNavCollapsed(navBeforePreview.current);
       navBeforePreview.current = null;
     }
-  }, [navCollapsed]);
+  }, []);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "b") {

--- a/surfaces/gui/src/components/AccessSection.tsx
+++ b/surfaces/gui/src/components/AccessSection.tsx
@@ -317,16 +317,11 @@ export function AccessSection({
                       <Toggle
                         checked={c.enabled}
                         onChange={(next) => toggleSession(c.connector, next)}
-                        title="Enabled for this session — tap to mute here"
+                        title="On for this session. Off mutes it for this session only — the connector stays connected."
                       />
                     </div>
                   ))}
                 </div>
-                {connected.length > 0 && (
-                  <p className="text-[10.5px] text-faint mt-1 leading-snug">
-                    Off mutes it for <b>this session only</b> — the connector stays connected.
-                  </p>
-                )}
                 {/* §32 addendum (owner ask 2026-07-13; FB-012): the catalog's long tail,
                     in-session. A quiet row that becomes a typeahead: full list on focus,
                     filter as you type. */}
@@ -379,22 +374,27 @@ export function AccessSection({
                     </div>
                   </div>
                 ) : (
-                  <button
-                    className="mt-1 text-[12px] text-accent hover:underline text-left"
-                    onClick={() => setAdding(true)}
-                    data-testid="access-add-source"
-                  >
-                    + Add a source…
-                  </button>
+                  /* UX-038 (owner ruling: option C): ONE footer row, both verbs — the
+                     in-session add flow (with its lands-enabled-here guarantee) and the
+                     global-page jump. The mute explainer lives on the toggles' tooltip. */
+                  <div className="mt-1.5 flex items-center gap-1.5 text-[12px]">
+                    <button
+                      className="text-accent hover:underline text-left"
+                      onClick={() => setAdding(true)}
+                      data-testid="access-add-source"
+                    >
+                      + Add a source
+                    </button>
+                    <span className="text-faint">·</span>
+                    <button
+                      className="text-accent font-medium hover:underline text-left"
+                      data-testid="access-manage"
+                      onClick={() => onOpenIntegrations?.()}
+                    >
+                      Manage →
+                    </button>
+                  </div>
                 )}
-                {/* Lives with its list (tester ask 2026-07-26): each group's manage link sits
-                    directly under that group, not pooled at the section's bottom. */}
-                <button
-                  className="mt-1.5 block text-[12px] text-accent font-medium hover:underline text-left"
-                  onClick={() => onOpenIntegrations?.()}
-                >
-                  Manage all connectors (global) →
-                </button>
               </div>
 
               {recommended.length > 0 && (

--- a/surfaces/gui/src/components/RightRail.preview.test.tsx
+++ b/surfaces/gui/src/components/RightRail.preview.test.tsx
@@ -1,0 +1,59 @@
+// The rail's preview notification must be edge-triggered: a new onPreviewChange
+// identity (App re-renders whenever the nav toggles) must NOT replay "open" while
+// the viewer sits open — that re-collapsed a sidebar the user had just expanded
+// (owner-hit 2026-08-21).
+import { act, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RightRail } from "./RightRail";
+import { OPEN_ARTIFACT_EVENT } from "./Markdown";
+
+vi.mock("../api", async () => {
+  const actual: any = await vi.importActual("../api");
+  return {
+    ...actual,
+    getArtifacts: vi.fn().mockResolvedValue([]),
+    getRoots: vi.fn().mockResolvedValue([]),
+    getJournalCases: vi.fn().mockResolvedValue([]),
+    readArtifact: vi.fn().mockResolvedValue({ ok: true, path: "r.md", kind: "markdown", content: "x" }),
+    revealArtifact: vi.fn().mockResolvedValue({ ok: true }),
+  };
+});
+
+function rail(onPreviewChange: (open: boolean) => void) {
+  return (
+    <RightRail
+      active
+      sessionId="s1"
+      refreshKey={0}
+      toolNames={[]}
+      todo={[]}
+      running={false}
+      onPreviewChange={onPreviewChange}
+    />
+  );
+}
+
+describe("RightRail preview notification", () => {
+  it("fires only on open/close transitions, not on callback identity changes", async () => {
+    const first = vi.fn();
+    const { rerender } = render(rail(first));
+    await act(async () => {});
+    expect(first).not.toHaveBeenCalled(); // closed at mount: no "closed" replay either
+
+    // Open the viewer via a transcript chip event.
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent(OPEN_ARTIFACT_EVENT, { detail: { path: "r.md" } }),
+      );
+    });
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(first).toHaveBeenLastCalledWith(true);
+
+    // App re-renders with a NEW callback identity (e.g. the user expanded the nav).
+    const second = vi.fn();
+    rerender(rail(second));
+    await act(async () => {});
+    // The viewer never transitioned, so the new callback must not be told "open".
+    expect(second).not.toHaveBeenCalled();
+  });
+});

--- a/surfaces/gui/src/components/RightRail.tsx
+++ b/surfaces/gui/src/components/RightRail.tsx
@@ -176,8 +176,16 @@ export function RightRail({
   }, [selected?.path, sessionId]);
 
   // Notify the app when a preview opens/closes (drives the left-nav auto-collapse).
+  // Edge-triggered on the ACTUAL transition — a callback-identity change must never
+  // replay "open" while the viewer sits open (that re-collapsed a nav the user had
+  // just expanded; owner-hit 2026-08-21).
+  const prevPreviewOpen = useRef(false);
   useEffect(() => {
-    onPreviewChange?.(!!selected);
+    const open = !!selected;
+    if (open !== prevPreviewOpen.current) {
+      prevPreviewOpen.current = open;
+      onPreviewChange?.(open);
+    }
   }, [!!selected, onPreviewChange]);
 
   const reloadSelected = () => {

--- a/surfaces/gui/src/components/RightRail.tsx
+++ b/surfaces/gui/src/components/RightRail.tsx
@@ -576,18 +576,60 @@ function ArtifactViewer({
   onOpenEntry?: (path: string) => void;
 }) {
   const [reloadKey, setReloadKey] = useState(0);
+  // UX-038: the ambiguous icon cluster collapsed into ONE labeled ⋯ menu; the
+  // breadcrumb parent is the back action and ✕ closes. Copy CONTENTS is the
+  // primary copy — the path copy (a 2026-07-12 tester fix) lives under it, labeled.
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!menuOpen) return;
+    const close = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) setMenuOpen(false);
+    };
+    window.addEventListener("mousedown", close);
+    return () => window.removeEventListener("mousedown", close);
+  }, [menuOpen]);
   const isHtml = content?.kind === "html" && !content.error;
   // Best viewed in a real app: spreadsheets, PDFs, and Office docs (pptx/docx can't preview inline)
   const isApp = content?.kind === "sheet" || content?.kind === "pdf" || content?.kind === "office";
+  // Text-bearing kinds can copy their contents; images/PDFs/sheets have nothing textual to copy.
+  const copyableText = typeof content?.content === "string" && !content?.error;
+  const crumbRoot = artifact.origin === "files" ? "Files" : "Artifacts";
+  const item = (
+    testid: string,
+    icon: Parameters<typeof Icon>[0]["name"],
+    label: string,
+    onClick: () => void,
+  ) => (
+    <button
+      className="artifact-menu-item"
+      data-testid={testid}
+      onClick={() => {
+        setMenuOpen(false);
+        onClick();
+      }}
+    >
+      <Icon name={icon} size={14} />
+      <span>{label}</span>
+    </button>
+  );
 
   return (
     <div className="artifact-viewer">
       <div className="artifact-head">
-        <button className="artifact-icon-btn" onClick={onBack} aria-label="Back to artifacts" title="Back">
-          <Icon name="arrowLeft" size={16} />
-        </button>
         <div className="artifact-heading">
-          <div className="artifact-title"><span>{artifact.origin === "files" ? "Files" : "Artifacts"}</span><span className="artifact-sep">/</span><span>{artifact.name}</span></div>
+          <div className="artifact-title">
+            <button
+              className="artifact-crumb-link"
+              data-testid="artifact-crumb-back"
+              onClick={onBack}
+              title={`Back to ${crumbRoot}`}
+            >
+              {crumbRoot}
+            </button>
+            <span className="artifact-sep">/</span>
+            <span>{artifact.name}</span>
+          </div>
           <div className="artifact-path">{artifact.path}</div>
         </div>
         <div className="rail-actions">
@@ -604,47 +646,48 @@ function ArtifactViewer({
               <Icon name="refresh" size={16} />
             </button>
           )}
-          {isApp && (
+          <div className="artifact-menu-wrap" ref={menuRef}>
             <button
               className="artifact-icon-btn"
-              onClick={() => revealArtifact(sessionId, artifact.path, "open")}
-              aria-label="Open in default app"
-              title="Open in default app"
+              data-testid="artifact-more"
+              aria-label="More actions"
+              title="More"
+              onClick={() => setMenuOpen((v) => !v)}
             >
-              <Icon name="panelOpen" size={16} />
+              <Icon name="moreHorizontal" size={16} />
             </button>
-          )}
-          {isHtml && (
-            // The sandboxed preview is deliberately offline and null-origin; a real
-            // browser tab (system default app, outside app privileges) is the escape
-            // hatch for sharing or printing the page.
-            <button
-              className="artifact-icon-btn"
-              data-testid="artifact-open-browser"
-              onClick={() => revealArtifact(sessionId, artifact.path, "open")}
-              aria-label="Open in browser"
-              title="Open in browser"
-            >
-              <Icon name="panelOpen" size={16} />
-            </button>
-          )}
-          {/* Copy the ABSOLUTE path — the workspace-relative one is useless outside the app
-              (tester catch 2026-07-12: it copied just "slack-connector-debug.md"). */}
+            {menuOpen && (
+              <div className="artifact-menu" data-testid="artifact-menu">
+                {copyableText &&
+                  item("artifact-copy-contents", "copy", "Copy contents", () =>
+                    navigator.clipboard?.writeText(content?.content || ""),
+                  )}
+                {item("artifact-copy-path", "file", "Copy path", () =>
+                  navigator.clipboard?.writeText(artifact.abs_path || artifact.path),
+                )}
+                <div className="artifact-menu-div" />
+                {isHtml &&
+                  item("artifact-open-browser", "panelOpen", "Open in browser", () =>
+                    revealArtifact(sessionId, artifact.path, "open"),
+                  )}
+                {isApp &&
+                  item("artifact-open-app", "panelOpen", "Open in default app", () =>
+                    revealArtifact(sessionId, artifact.path, "open"),
+                  )}
+                {item("artifact-reveal", "folder", "Reveal in Finder", () =>
+                  revealArtifact(sessionId, artifact.path, "reveal"),
+                )}
+              </div>
+            )}
+          </div>
           <button
             className="artifact-icon-btn"
-            onClick={() => navigator.clipboard?.writeText(artifact.abs_path || artifact.path)}
-            aria-label="Copy path"
-            title="Copy full path"
+            data-testid="artifact-close"
+            onClick={onBack}
+            aria-label="Close the viewer"
+            title="Close"
           >
-            <Icon name="copy" size={16} />
-          </button>
-          <button
-            className="artifact-icon-btn"
-            onClick={() => revealArtifact(sessionId, artifact.path, "reveal")}
-            aria-label="Show in folder"
-            title="Show in folder"
-          >
-            <Icon name="folder" size={16} />
+            <Icon name="x" size={16} />
           </button>
         </div>
       </div>

--- a/surfaces/gui/src/styles.css
+++ b/surfaces/gui/src/styles.css
@@ -1929,3 +1929,24 @@ html[data-platform="linux"] ::-webkit-scrollbar-thumb:hover { background-color: 
 @keyframes sleep-pulse { 0%, 100% { opacity: 0.35; } 50% { opacity: 0.85; } }
 .sleep-text { flex: 1; }
 .sleep-strip .btn.sm { padding: 4px 10px; font-size: 12px; }
+
+/* UX-038: viewer header — breadcrumb-as-back, ✕ close, one labeled ⋯ menu. */
+.artifact-crumb-link {
+  border: 0; background: none; padding: 1px 5px; margin-left: -5px; border-radius: 6px;
+  font: inherit; font-weight: 600; color: var(--muted); cursor: pointer;
+}
+.artifact-crumb-link:hover { color: var(--accent); background: var(--paper); }
+.artifact-menu-wrap { position: relative; }
+.artifact-menu {
+  position: absolute; right: 0; top: 34px; z-index: 30; width: 190px; padding: 5px;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 10px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.12);
+}
+.artifact-menu-item {
+  display: flex; width: 100%; align-items: center; gap: 9px; padding: 7px 9px;
+  border: 0; background: none; border-radius: 7px; text-align: left;
+  font-size: 12.5px; color: var(--ink); cursor: pointer;
+}
+.artifact-menu-item:hover { background: var(--paper); }
+.artifact-menu-item svg { color: var(--muted); flex: none; }
+.artifact-menu-div { height: 1px; margin: 5px 4px; background: var(--line); }

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -496,3 +496,86 @@ def test_delete_mcp_shuts_down_connection_and_forgets_tokens(tmp_path):
     assert res["ok"]
     assert conn.shutdown.is_set()
     assert mgr.secrets.get(mcp_oauth.PROFILE_PREFIX + "gone-srv") is None
+
+
+# -- notice dedupe: state CHANGE, not state (owner ruling 2026-08-21) -----------
+
+
+@pytest.mark.asyncio
+async def test_session_notice_fires_once_per_failure_episode(tmp_path, monkeypatch):
+    """A continuously-broken server stamps only the FIRST session after it breaks;
+    a changed error re-notices; recovery then re-breakage re-notices. The
+    Connectors page carries the standing error in between."""
+    from types import SimpleNamespace
+
+    from coworker.server import SessionManager
+
+    mgr = SessionManager(data_dir=tmp_path / "data")
+    server = SimpleNamespace(
+        name="flaky", transport="stdio", url=None, auth=None, enabled=True, include_tools=None, exclude_tools=None, requires_approval=True
+    )
+    monkeypatch.setattr(
+        "coworker.server.manager.load_mcp_servers", lambda *a, **k: [server]
+    )
+
+    fail_with: list[str] = ["boom one"]
+
+    async def ensure(s, **kw):
+        if fail_with:
+            raise RuntimeError(fail_with[0])
+        return SimpleNamespace(tools=[])
+
+    monkeypatch.setattr(mgr.mcp, "ensure", ensure)
+    monkeypatch.setattr(mgr.mcp, "last_stderr", lambda n: None)
+
+    await mgr.prepare_mcp_tools("s1", workspace=str(tmp_path))
+    assert [n for n, _ in mgr.pop_mcp_failures("s1")] == ["flaky"]
+
+    # Same error, next session: quiet (the Connectors page still shows it).
+    await mgr.prepare_mcp_tools("s2", workspace=str(tmp_path))
+    assert mgr.pop_mcp_failures("s2") == []
+    assert mgr._mcp_errors.get("flaky")  # standing error intact
+
+    # Different error: notice again.
+    fail_with[0] = "boom two"
+    await mgr.prepare_mcp_tools("s3", workspace=str(tmp_path))
+    assert [n for n, _ in mgr.pop_mcp_failures("s3")] == ["flaky"]
+
+    # Recovery clears the dedupe; the next breakage notices afresh.
+    fail_with.clear()
+    await mgr.prepare_mcp_tools("s4", workspace=str(tmp_path))
+    assert mgr.pop_mcp_failures("s4") == []
+    fail_with.append("boom three")
+    await mgr.prepare_mcp_tools("s5", workspace=str(tmp_path))
+    assert [n for n, _ in mgr.pop_mcp_failures("s5")] == ["flaky"]
+
+
+@pytest.mark.asyncio
+async def test_notice_dedupe_survives_restart(tmp_path, monkeypatch):
+    """The dedupe is persisted: relaunching the app must not re-stamp the same
+    unchanged complaint into the first session (the owner-hit annoyance)."""
+    from types import SimpleNamespace
+
+    server = SimpleNamespace(
+        name="flaky", transport="stdio", url=None, auth=None, enabled=True, include_tools=None, exclude_tools=None, requires_approval=True
+    )
+    monkeypatch.setattr(
+        "coworker.server.manager.load_mcp_servers", lambda *a, **k: [server]
+    )
+
+    async def ensure(s, **kw):
+        raise RuntimeError("same boom")
+
+    from coworker.server import SessionManager
+
+    mgr = SessionManager(data_dir=tmp_path / "data")
+    monkeypatch.setattr(mgr.mcp, "ensure", ensure)
+    monkeypatch.setattr(mgr.mcp, "last_stderr", lambda n: None)
+    await mgr.prepare_mcp_tools("s1", workspace=str(tmp_path))
+    assert [n for n, _ in mgr.pop_mcp_failures("s1")] == ["flaky"]
+
+    reborn = SessionManager(data_dir=tmp_path / "data")
+    monkeypatch.setattr(reborn.mcp, "ensure", ensure)
+    monkeypatch.setattr(reborn.mcp, "last_stderr", lambda n: None)
+    await reborn.prepare_mcp_tools("s2", workspace=str(tmp_path))
+    assert reborn.pop_mcp_failures("s2") == []


### PR DESCRIPTION
Fixes - MCP startup-failure notices fire on state change instead of every session
The sidebar toggle no longer races the artifact viewer's auto-collapse
Changes to Artifact viewer.
Access footer collapses to one row; the right rail starts hidden and the toggle persists per-device. 
Suites: 1421 py / 115 vitest / 205 e2e.