### PR TITLE
verify: surface the transport error's cause, not just its class name

### DIFF
--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -830,7 +830,10 @@ def _verify_bedrock(fields: dict[str, Any], timeout: float) -> dict[str, Any]:
             if code == "ExpiredTokenException":
                 return {"ok": False, "error": "The credentials have expired — generate a new key."}
             return {"ok": False, "error": f"AWS Bedrock returned {code}."}
-        return {"ok": False, "error": f"Couldn't reach AWS Bedrock ({kind})."}
+        return {
+            "ok": False,
+            "error": f"Couldn't reach AWS Bedrock ({_describe_transport_error(exc)})."
+        }
     return {"ok": True}
 
 
@@ -869,7 +872,7 @@ def _verify_vertex(fields: dict[str, Any], timeout: float) -> dict[str, Any]:
         except Exception as exc:
             return {
                 "ok": False,
-                "error": f"Couldn't reach Vertex AI ({exc.__class__.__name__}).",
+                "error": f"Couldn't reach Vertex AI ({_describe_transport_error(exc)}).",
             }
         if resp.status_code < 300:
             return {"ok": True}
@@ -914,7 +917,10 @@ def _verify_vertex(fields: dict[str, Any], timeout: float) -> dict[str, Any]:
             timeout=timeout,
         )
     except Exception as exc:
-        return {"ok": False, "error": f"Couldn't reach Vertex AI ({exc.__class__.__name__})."}
+        return {
+            "ok": False,
+            "error": f"Couldn't reach Vertex AI ({_describe_transport_error(exc)}).",
+        }
     if resp.status_code < 300:
         return {"ok": True}
     if resp.status_code in (401, 403):
@@ -925,6 +931,37 @@ def _verify_vertex(fields: dict[str, Any], timeout: float) -> dict[str, Any]:
     if resp.status_code == 404:
         return {"ok": False, "error": "Project or location not found on Vertex AI."}
     return {"ok": False, "error": f"Vertex AI returned HTTP {resp.status_code}."}
+
+
+def _describe_transport_error(exc: Exception) -> str:
+    """Turn a verify probe's transport failure into one actionable line.
+
+    The bare class name ("ConnectError") cost a real user round-trips of
+    diagnosis while the exception carried the answer all along — TLS
+    verification, DNS, refusal and timeout each read differently (#505).
+    """
+    msg = " ".join(str(exc).split()).rstrip(".")[:200]
+    lowered = msg.lower()
+    for signature, hint in (
+        (
+            "certificate_verify_failed",
+            "TLS certificate verification failed; the app's CA bundle may be missing or stale",
+        ),
+        ("ssl:", "TLS handshake failed"),
+        ("gaierror", "DNS could not resolve the endpoint"),
+        ("nodename", "DNS could not resolve the endpoint"),
+        ("name or service", "DNS could not resolve the endpoint"),
+        ("getaddrinfo", "DNS could not resolve the endpoint"),
+        ("refused", "the endpoint refused the connection"),
+        ("timed out", "the connection timed out"),
+    ):
+        if signature in lowered:
+            if not msg:
+                return f"{exc.__class__.__name__} — {hint}"
+            return f"{exc.__class__.__name__}: {msg} — looks like {hint}"
+    if not msg:
+        return exc.__class__.__name__
+    return f"{exc.__class__.__name__}: {msg}"
 
 
 def verify_provider_key(
@@ -1003,7 +1040,7 @@ def verify_provider_key(
     except Exception as exc:  # DNS/connection/timeout — never let it bubble to a 500
         return {
             "ok": False,
-            "error": f"Couldn't reach {d.title} ({exc.__class__.__name__}).",
+            "error": f"Couldn't reach {d.title} ({_describe_transport_error(exc)}).",
         }
 
     if resp.status_code < 300:

--- a/tests/test_provider_verify.py
+++ b/tests/test_provider_verify.py
@@ -161,3 +161,45 @@ def test_verify_unexpected_status(monkeypatch):
     res = verify_provider_key("anthropic", api_key="sk-ant-x")
     assert res["ok"] is False
     assert "500" in res["error"]
+
+
+# -- verify_provider_key: transport failures carry their cause (#505) ------------
+def test_verify_transport_failure_includes_cause_and_hint(monkeypatch):
+    import httpx
+
+    _patch_get(
+        monkeypatch,
+        raise_exc=httpx.ConnectError(
+            "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: "
+            "unable to get local issuer certificate (_ssl.c:1000)"
+        ),
+    )
+    result = verify_provider_key("openai", api_key="sk-x")
+    assert result["ok"] is False
+    assert "CERTIFICATE_VERIFY_FAILED" in result["error"]
+    assert "CA bundle" in result["error"]
+
+
+def test_verify_dns_failure_names_dns(monkeypatch):
+    import httpx
+
+    _patch_get(monkeypatch, raise_exc=httpx.ConnectError("[Errno -3] nodename nor servname provided"))
+    error = verify_provider_key("openai", api_key="sk-x")["error"]
+    assert "DNS" in error
+    assert "[Errno -3]" in error
+
+
+def test_verify_timeout_says_timed_out(monkeypatch):
+    import httpx
+
+    _patch_get(monkeypatch, raise_exc=httpx.ConnectTimeout("The request timed out."))
+    error = verify_provider_key("openai", api_key="sk-x")["error"]
+    assert "timed out" in error
+
+
+def test_verify_silent_exception_falls_back_to_class_name_only(monkeypatch):
+    class Weird(Exception):
+        pass
+
+    _patch_get(monkeypatch, raise_exc=Weird())
+    assert verify_provider_key("openai", api_key="sk-x") == {"ok": False, "error": "Couldn't reach OpenAI (Weird)."}


### PR DESCRIPTION
Fixes #505

## Summary

Provider key verification now reports **why** a probe could not reach the endpoint instead of only the exception class name, so the next "ConnectError" report is diagnosable from the message alone.

## Problem

`verify_provider_key()` caught transport failures and returned `Couldn't reach {title} (ConnectError).`, discarding `str(exc)`. In #505 the packaged macOS app fails while curl and the browser succeed on the same machine; the exception text would say which of TLS verification / DNS / refusal / timeout it is, but five comments of triage were needed to get near that because the UI never showed it.

## What changed

One helper, `_describe_transport_error(exc)`, used by all four probe handlers (OpenAI-compatible shared handler, Bedrock, Vertex express, Vertex regional):

- class name + one-line cause (whitespace-collapsed, capped at 200 chars),
- short hints for known signatures: `CERTIFICATE_VERIFY_FAILED` → CA bundle missing/stale in packaged builds; gaierror/nodename/getaddrinfo → DNS; refused → endpoint refused; timed out → timeout,
- an exception with no message still renders exactly the old class-name-only string.

Example before: `Couldn't reach OpenAI (ConnectError).`
Example after: `Couldn't reach OpenAI (ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1000) — looks like TLS certificate verification failed; the app's CA bundle may be missing or stale).`

## Verification

- 4 new tests in `tests/test_provider_verify.py` (TLS hint, DNS hint, timeout hint, silent-exception fallback byte-identical to old output).
- Full suite on a provisioned venv: failure set is byte-identical to clean main (69 pre-existing environment-dependent failures); patched tree passes 1744 vs 1739 before.

This change was prepared with AI assistance under human direction and review.
