### PR TITLE
MCP OAuth: refuse discovery URLs that target the local network

### DIFF
--- a/coworker/mcp/client.py
+++ b/coworker/mcp/client.py
@@ -157,10 +157,20 @@ class MCPManager:
                             self._secrets,
                             interactive=interactive,
                         )
-                    read, write, *_ = await stack.enter_async_context(
-                        streamablehttp_client(
-                            server.url, headers=server.headers or None, auth=auth
+                    http_kwargs: dict[str, Any] = {
+                        "headers": server.headers or None,
+                        "auth": auth,
+                    }
+                    if auth is not None:
+                        # Request hook sees every hop, including redirects the SDK
+                        # follows without re-entering Auth (issue #527).
+                        from .ssrf import mcp_httpx_client_factory
+
+                        http_kwargs["httpx_client_factory"] = mcp_httpx_client_factory(
+                            server.url
                         )
+                    read, write, *_ = await stack.enter_async_context(
+                        streamablehttp_client(server.url, **http_kwargs)
                     )
                 else:
                     if not server.command:

--- a/coworker/mcp/oauth.py
+++ b/coworker/mcp/oauth.py
@@ -7,6 +7,7 @@ streamable-HTTP transport. We supply its three integration points:
   - token persistence  → the SecretStore (profile `mcp-oauth:<server>`; 0600 file,
     never the mcp.json config, which is plain text and paste-shareable)
   - redirect           → open the system browser at the authorize URL
+                          (http(s) only; destinations are origin-checked, #527)
   - callback           → the sidecar's loopback `GET /mcp/oauth/callback` resolves a
     single-slot pending future (one interactive sign-in at a time — the flow is
     user-driven, so concurrency is meaningless)
@@ -29,6 +30,13 @@ from mcp.client.auth import OAuthClientProvider, TokenStorage
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 
 from ..secrets import SecretStore
+from .ssrf import (
+    UnsafeMcpUrl,
+    check_metadata,
+    refuse_destination,
+    refuse_metadata,
+    require_http_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +71,13 @@ class SecretStoreTokenStorage(TokenStorage):
 
     def _merge(self, patch: dict[str, Any]) -> None:
         self._secrets.put(_profile(self._name), {**self._data(), **patch})
+
+    def _drop_metadata(self) -> None:
+        """Forget cached AS metadata (poisoned or incompatible) without touching tokens."""
+        data = dict(self._data())
+        if data.pop("oauth_metadata", None) is None:
+            return
+        self._secrets.put(_profile(self._name), data)
 
     async def get_tokens(self) -> Optional[OAuthToken]:
         data = self._data()
@@ -201,6 +216,13 @@ def deliver_callback(code: str, state: Optional[str]) -> bool:
 
 async def _open_browser(url: str) -> None:
     global last_authorize_url, _expected_state
+    # Last-line scheme gate: even a future caller that skips refuse_destination
+    # must not hand file:// / javascript: / custom schemes to webbrowser.open.
+    # Destination (loopback/metadata) checks need the MCP server origin and live
+    # in the redirect_handler closure build_auth installs.
+    reason = require_http_url(url)
+    if reason:
+        raise UnsafeMcpUrl(f"refusing authorize page: {reason}")
     last_authorize_url = url
     _expected_state = _state_from_url(url)
     import webbrowser
@@ -213,6 +235,9 @@ async def _refuse_browser(url: str) -> None:
     """Non-interactive redirect handler: never open a browser, but keep the URL so
     the GUI's "reopen sign-in page" affordance still works after the refusal."""
     global last_authorize_url
+    reason = require_http_url(url)
+    if reason:
+        raise UnsafeMcpUrl(f"refusing authorize page: {reason}")
     last_authorize_url = url
     raise InteractiveAuthRequired(
         "sign-in required — reconnect this server from its page"
@@ -261,9 +286,19 @@ class _MetadataSeededProvider(OAuthClientProvider):
             try:
                 from mcp.shared.auth import OAuthMetadata
 
-                self.context.oauth_metadata = OAuthMetadata.model_validate(raw)
+                md = OAuthMetadata.model_validate(raw)
             except Exception:
-                pass  # stale/incompatible cache: discovery will refill it
+                md = None  # stale/incompatible cache: discovery will refill it
+            if md is not None:
+                # Cached token_endpoint is used on the *next* refresh POST, before
+                # the SDK rediscovers — so poison here is a durable SSRF. Drop it.
+                if check_metadata(md, self.context.server_url):
+                    logger.warning(
+                        "mcp oauth: dropping cached metadata with unsafe endpoints"
+                    )
+                    self._ocw_storage._drop_metadata()
+                else:
+                    self.context.oauth_metadata = md
         if self.context.oauth_metadata is None and self._ocw_storage._data().get(
             "tokens"
         ):
@@ -279,23 +314,55 @@ class _MetadataSeededProvider(OAuthClientProvider):
 
                 pr = urlparse(self.context.server_url)
                 url = f"{pr.scheme}://{pr.netloc}/.well-known/oauth-authorization-server"
-                async with httpx.AsyncClient(timeout=10) as c:
+                refuse_destination(
+                    url, self.context.server_url, what="OAuth well-known"
+                )
+                # follow_redirects=False: a 302 to metadata would otherwise skip the
+                # destination check. Non-200 just falls through to SDK discovery.
+                async with httpx.AsyncClient(timeout=10, follow_redirects=False) as c:
                     r = await c.get(url, headers={"Accept": "application/json"})
                 if r.status_code == 200:
-                    self.context.oauth_metadata = OAuthMetadata.model_validate(r.json())
+                    md = OAuthMetadata.model_validate(r.json())
+                    refuse_metadata(
+                        md, self.context.server_url, what="OAuth well-known metadata"
+                    )
+                    self.context.oauth_metadata = md
                     self._persist_metadata()
             except Exception:
                 pass
 
     def _persist_metadata(self) -> None:
         md = self.context.oauth_metadata
-        if md is not None:
-            try:
-                self._ocw_storage._merge(
-                    {"oauth_metadata": md.model_dump(mode="json", exclude_none=True)}
+        if md is None:
+            return
+        if check_metadata(md, self.context.server_url):
+            logger.warning("mcp oauth: refusing to persist unsafe metadata")
+            self.context.oauth_metadata = None
+            self._ocw_storage._drop_metadata()
+            return
+        try:
+            self._ocw_storage._merge(
+                {"oauth_metadata": md.model_dump(mode="json", exclude_none=True)}
+            )
+        except Exception:
+            logger.debug("could not persist oauth metadata", exc_info=True)
+
+    async def async_auth_flow(self, request: Any) -> Any:
+        """Vet every URL the SDK yields (PRM, AS metadata, DCR, token) before
+        httpx sends it. Redirect hops are a separate gap — those never re-enter
+        Auth — and are closed by `mcp_httpx_client_factory`'s request hook."""
+        flow = super().async_auth_flow(request)
+        try:
+            sent = await flow.asend(None)
+            while True:
+                refuse_destination(
+                    str(sent.url), self.context.server_url, what="OAuth request"
                 )
-            except Exception:
-                logger.debug("could not persist oauth metadata", exc_info=True)
+                sent = await flow.asend((yield sent))
+        except StopAsyncIteration:
+            return
+        finally:
+            await flow.aclose()
 
     async def _handle_token_response(self, response: Any) -> None:
         await super()._handle_token_response(response)
@@ -331,11 +398,21 @@ def build_auth(
             "token_endpoint_auth_method": "none",
         }
     )
+
+    async def redirect_handler(url: str) -> None:
+        # Authorize URL comes from AS metadata, not from server_url. Scheme-gate
+        # plus destination check before webbrowser.open / last_authorize_url.
+        refuse_destination(url, server_url, what="authorize page")
+        if interactive:
+            await _open_browser(url)
+        else:
+            await _refuse_browser(url)
+
     return _MetadataSeededProvider(
         server_url=server_url,
         client_metadata=metadata,
         storage=SecretStoreTokenStorage(server_name, secrets),
-        redirect_handler=_open_browser if interactive else _refuse_browser,
+        redirect_handler=redirect_handler,
         callback_handler=_wait_for_callback if interactive else _refuse_callback,
     )
 

--- a/coworker/mcp/ssrf.py
+++ b/coworker/mcp/ssrf.py
@@ -1,0 +1,157 @@
+"""SSRF controls for outbound MCP HTTP (OAuth discovery, token POSTs, redirects).
+
+The user-chosen MCP server URL is trusted as an *origin* — local MCP servers are
+real, and a LAN host the user pasted is a LAN host they meant to talk to. Every
+other URL the client is steered at is untrusted: `WWW-Authenticate
+resource_metadata`, `authorization_servers`, `registration_endpoint`,
+`token_endpoint`, redirects the SDK follows (`follow_redirects=True`), and the
+authorize page handed to `webbrowser.open`.
+
+Untrusted destinations must be `http(s)` and must not resolve to the machine's
+own network. The address policy is `coworker.web.guard` (loopback, RFC1918,
+link-local / cloud metadata, CGNAT, multicast, reserved). Cross-origin public
+hosts are allowed so federated authorization servers (Okta, Entra, Atlassian)
+keep working.
+
+Same-origin comparison is scheme + host + effective port. A local MCP that
+redirects to a *different* port on loopback is refused — that is the same
+confused-deputy shape as a metadata document pointing at 169.254.169.254.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+from urllib.parse import urlsplit
+
+import httpx
+
+from ..web.guard import check_url
+
+logger = logging.getLogger(__name__)
+
+# Endpoints the SDK (or we) actually fetch or POST credentials to. Extra URL
+# fields on the AS metadata document are validated too so a future SDK bump
+# cannot start calling them unvetted.
+_METADATA_URL_ATTRS = (
+    "authorization_endpoint",
+    "token_endpoint",
+    "registration_endpoint",
+    "revocation_endpoint",
+    "introspection_endpoint",
+    "jwks_uri",
+)
+
+
+class UnsafeMcpUrl(RuntimeError):
+    """The MCP HTTP client refused a destination (SSRF / non-http scheme)."""
+
+
+def _origin(url: str) -> Optional[tuple[str, str, int]]:
+    """(scheme, hostname, port) or None when the URL is not a usable http(s) origin."""
+    parts = urlsplit(url)
+    if parts.scheme not in ("http", "https") or not parts.hostname:
+        return None
+    port = parts.port
+    if port is None:
+        port = 443 if parts.scheme == "https" else 80
+    return (parts.scheme.lower(), parts.hostname.lower(), port)
+
+
+def require_http_url(url: str) -> Optional[str]:
+    """None if `url` is http(s) with a host, else a refusal reason.
+
+    Used as the last-line gate on `webbrowser.open` (no server origin in that
+    helper) and as the first clause of `check_destination`.
+    """
+    parts = urlsplit(url)
+    if parts.scheme not in ("http", "https"):
+        return "url must start with http:// or https://"
+    if not parts.hostname:
+        return "url has no host"
+    return None
+
+
+def check_destination(url: str, server_url: str) -> Optional[str]:
+    """None if the MCP HTTP client may call `url`, else a human refusal reason.
+
+    Same origin as `server_url` is always allowed (the user picked it). Any other
+    destination is run through `guard.check_url`.
+    """
+    reason = require_http_url(url)
+    if reason:
+        return reason
+    server_origin = _origin(server_url)
+    dest_origin = _origin(url)
+    if server_origin is not None and dest_origin == server_origin:
+        return None
+    return check_url(url)
+
+
+def refuse_destination(url: str, server_url: str, *, what: str = "URL") -> None:
+    """Raise `UnsafeMcpUrl` when `url` is not a safe destination; no-op otherwise."""
+    reason = check_destination(url, server_url)
+    if reason:
+        logger.warning("mcp http: refusing %s %s (%s)", what, url, reason)
+        raise UnsafeMcpUrl(f"refusing {what}: {reason}")
+
+
+def metadata_endpoints(md: Any) -> list[str]:
+    """Advertised http(s) endpoints on an OAuthMetadata (model or dict)."""
+    urls: list[str] = []
+    for key in _METADATA_URL_ATTRS:
+        val = md.get(key) if isinstance(md, dict) else getattr(md, key, None)
+        if val is None:
+            continue
+        urls.append(str(val))
+    return urls
+
+
+def check_metadata(md: Any, server_url: str) -> Optional[str]:
+    """None if every advertised endpoint is a safe destination, else a reason."""
+    for url in metadata_endpoints(md):
+        reason = check_destination(url, server_url)
+        if reason:
+            return f"{url}: {reason}"
+    return None
+
+
+def refuse_metadata(md: Any, server_url: str, *, what: str = "OAuth metadata") -> None:
+    reason = check_metadata(md, server_url)
+    if reason:
+        logger.warning("mcp http: refusing %s (%s)", what, reason)
+        raise UnsafeMcpUrl(f"refusing {what}: {reason}")
+
+
+def mcp_httpx_client_factory(server_url: str):
+    """httpx client factory for `streamablehttp_client`.
+
+    The SDK enables `follow_redirects=True` and never re-enters Auth on a
+    Location hop, so a public metadata URL that 302s to loopback would skip an
+    auth-flow-only check. A request hook sees every hop, including redirects,
+    and raises before the socket is opened.
+    """
+
+    async def _vet_request(request: httpx.Request) -> None:
+        refuse_destination(str(request.url), server_url, what="MCP HTTP request")
+
+    def factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
+        kwargs: dict[str, Any] = {
+            "follow_redirects": True,
+            "event_hooks": {"request": [_vet_request]},
+        }
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        else:
+            kwargs["timeout"] = httpx.Timeout(30.0, read=300.0)
+        if headers is not None:
+            kwargs["headers"] = headers
+        if auth is not None:
+            kwargs["auth"] = auth
+        return httpx.AsyncClient(**kwargs)
+
+    return factory

--- a/tests/test_mcp_oauth_ssrf.py
+++ b/tests/test_mcp_oauth_ssrf.py
@@ -1,0 +1,361 @@
+"""MCP OAuth destination checks (issue #527).
+
+A malicious MCP server's metadata can advertise token/registration/authorize
+URLs on loopback, RFC1918, or link-local (cloud metadata). The SDK fetches those
+verbatim; we refuse before the socket opens. Same-origin as the user-chosen
+server stays allowed so local MCP and same-host well-known still work; federated
+public authorization servers stay allowed via guard.check_url.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import httpx
+import pytest
+from mcp.client.auth import OAuthClientProvider
+
+from coworker.mcp import oauth as mcp_oauth
+from coworker.mcp.ssrf import (
+    UnsafeMcpUrl,
+    check_destination,
+    check_metadata,
+    mcp_httpx_client_factory,
+    refuse_destination,
+)
+from coworker.secrets import SecretStore
+from coworker.web import guard
+
+SERVER = "https://mcp.example.com/mcp"
+
+
+def _resolves_to(monkeypatch, ip: str):
+    monkeypatch.setattr(
+        guard.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 80))],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_authorize_url():
+    mcp_oauth.last_authorize_url = None
+    mcp_oauth._expected_state = None
+    yield
+    mcp_oauth.last_authorize_url = None
+    mcp_oauth._expected_state = None
+
+
+# -- destination policy --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://mcp.example.com/mcp",
+        "https://mcp.example.com:443/.well-known/oauth-protected-resource",
+        "https://mcp.example.com/register",
+        "https://MCP.EXAMPLE.COM/token",
+    ],
+)
+def test_same_origin_as_user_chosen_server_is_allowed(url):
+    assert check_destination(url, SERVER) is None
+
+
+def test_same_origin_loopback_is_allowed():
+    """Users (and tests) connect to local MCP servers; that origin is trusted."""
+    assert (
+        check_destination("http://127.0.0.1:3000/token", "http://127.0.0.1:3000/mcp")
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "url,needle",
+    [
+        ("http://169.254.169.254/latest/meta-data/", "link-local"),
+        ("http://127.0.0.1:11434/api/tags", "loopback"),
+        ("http://10.0.0.5/admin", "private"),
+        ("http://192.168.1.1/", "private"),
+        ("http://100.64.0.1/", "CGNAT"),
+        ("file:///etc/passwd", "http:// or https://"),
+        ("javascript:alert(1)", "http:// or https://"),
+        ("ftp://example.com/x", "http:// or https://"),
+    ],
+)
+def test_cross_origin_private_and_non_http_are_refused(url, needle):
+    reason = check_destination(url, SERVER)
+    assert reason and needle in reason
+
+
+def test_cross_origin_loopback_from_public_server_is_refused():
+    """Local MCP is allowed only when the *user* picked that origin."""
+    reason = check_destination("http://127.0.0.1:3000/token", SERVER)
+    assert reason and "loopback" in reason
+
+
+def test_federated_public_authorization_server_is_allowed(monkeypatch):
+    _resolves_to(monkeypatch, "93.184.216.34")
+    assert check_destination("https://login.microsoftonline.com/oauth2/v2.0/token", SERVER) is None
+
+
+def test_hostname_resolving_to_metadata_is_refused(monkeypatch):
+    _resolves_to(monkeypatch, "169.254.169.254")
+    reason = check_destination("https://metadata.example.com/token", SERVER)
+    assert reason
+
+
+def test_different_loopback_port_is_refused():
+    """A local MCP redirecting to another loopback port is the same confused deputy."""
+    reason = check_destination("http://127.0.0.1:3001/token", "http://127.0.0.1:3000/mcp")
+    assert reason and "loopback" in reason
+
+
+def test_refuse_destination_raises_before_caller_can_send():
+    with pytest.raises(UnsafeMcpUrl, match="link-local"):
+        refuse_destination(
+            "http://169.254.169.254/latest/meta-data/", SERVER, what="token endpoint"
+        )
+
+
+# -- metadata documents --------------------------------------------------------
+
+
+def test_metadata_with_metadata_ip_token_endpoint_is_unsafe():
+    md = {
+        "issuer": "https://mcp.example.com",
+        "authorization_endpoint": "https://mcp.example.com/authorize",
+        "token_endpoint": "http://169.254.169.254/latest/meta-data/",
+    }
+    reason = check_metadata(md, SERVER)
+    assert reason and "169.254.169.254" in reason
+
+
+def test_metadata_same_origin_endpoints_are_safe():
+    md = {
+        "issuer": "https://mcp.example.com",
+        "authorization_endpoint": "https://mcp.example.com/authorize",
+        "token_endpoint": "https://mcp.example.com/token",
+        "registration_endpoint": "https://mcp.example.com/register",
+    }
+    assert check_metadata(md, SERVER) is None
+
+
+@pytest.mark.asyncio
+async def test_cached_metadata_with_unsafe_token_endpoint_is_dropped(tmp_path):
+    """Refresh POSTs the cached token_endpoint before rediscovery — poison must
+    not survive load."""
+    secrets = SecretStore(tmp_path / "s.json")
+    secrets.put(
+        "mcp-oauth:evil",
+        {
+            "tokens": {"access_token": "A", "refresh_token": "R"},
+            "oauth_metadata": {
+                "issuer": "https://mcp.example.com",
+                "authorization_endpoint": "https://mcp.example.com/authorize",
+                "token_endpoint": "http://169.254.169.254/latest/meta-data/",
+            },
+        },
+    )
+    auth = mcp_oauth.build_auth(
+        "evil", SERVER, secrets, interactive=False
+    )
+    await auth._initialize()
+    assert auth.context.oauth_metadata is None
+    assert "oauth_metadata" not in (secrets.get("mcp-oauth:evil") or {})
+
+
+@pytest.mark.asyncio
+async def test_cached_same_origin_metadata_still_seeds(tmp_path):
+    secrets = SecretStore(tmp_path / "s.json")
+    md = {
+        "issuer": "https://data.example",
+        "authorization_endpoint": "https://data.example/api/auth/authorize",
+        "token_endpoint": "https://data.example/api/auth/token",
+    }
+    secrets.put("mcp-oauth:dlai", {"oauth_metadata": md})
+    auth = mcp_oauth.build_auth(
+        "dlai", "https://data.example/api/mcp", secrets, interactive=False
+    )
+    await auth._initialize()
+    assert str(auth.context.oauth_metadata.token_endpoint) == md["token_endpoint"]
+
+
+@pytest.mark.asyncio
+async def test_cached_federated_public_metadata_still_seeds(tmp_path, monkeypatch):
+    """Atlassian/Granola-style: AS lives on another public host."""
+    _resolves_to(monkeypatch, "93.184.216.34")
+    secrets = SecretStore(tmp_path / "s.json")
+    md = {
+        "issuer": "https://login.microsoftonline.com",
+        "authorization_endpoint": "https://login.microsoftonline.com/authorize",
+        "token_endpoint": "https://login.microsoftonline.com/token",
+    }
+    secrets.put("mcp-oauth:jira", {"oauth_metadata": md})
+    auth = mcp_oauth.build_auth(
+        "jira", "https://mcp.atlassian.com/v1/mcp", secrets, interactive=False
+    )
+    await auth._initialize()
+    assert str(auth.context.oauth_metadata.token_endpoint) == md["token_endpoint"]
+
+
+def test_persist_drops_unsafe_metadata_instead_of_writing_it(tmp_path):
+    from mcp.shared.auth import OAuthMetadata
+
+    secrets = SecretStore(tmp_path / "s.json")
+    secrets.put("mcp-oauth:evil", {"tokens": {"access_token": "A"}})
+    auth = mcp_oauth.build_auth("evil", SERVER, secrets, interactive=False)
+    auth.context.oauth_metadata = OAuthMetadata.model_validate(
+        {
+            "issuer": "https://mcp.example.com",
+            "authorization_endpoint": "https://mcp.example.com/authorize",
+            "token_endpoint": "http://169.254.169.254/latest/meta-data/",
+        }
+    )
+    auth._persist_metadata()
+    assert auth.context.oauth_metadata is None
+    assert "oauth_metadata" not in (secrets.get("mcp-oauth:evil") or {})
+
+
+# -- authorize URL / browser ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redirect_handler_refuses_file_scheme_and_does_not_open(tmp_path, monkeypatch):
+    opened: list[str] = []
+    monkeypatch.setattr("webbrowser.open", lambda u: opened.append(u))
+    secrets = SecretStore(tmp_path / "s.json")
+    auth = mcp_oauth.build_auth("granola", SERVER, secrets, interactive=True)
+    with pytest.raises(UnsafeMcpUrl, match="http:// or https://"):
+        await auth.context.redirect_handler("file:///etc/passwd")
+    assert opened == []
+    assert mcp_oauth.last_authorize_url is None
+
+
+@pytest.mark.asyncio
+async def test_redirect_handler_refuses_metadata_ip(tmp_path, monkeypatch):
+    opened: list[str] = []
+    monkeypatch.setattr("webbrowser.open", lambda u: opened.append(u))
+    secrets = SecretStore(tmp_path / "s.json")
+    auth = mcp_oauth.build_auth("granola", SERVER, secrets, interactive=True)
+    with pytest.raises(UnsafeMcpUrl, match="link-local"):
+        await auth.context.redirect_handler(
+            "http://169.254.169.254/latest/meta-data/"
+        )
+    assert opened == []
+    assert mcp_oauth.last_authorize_url is None
+
+
+@pytest.mark.asyncio
+async def test_open_browser_scheme_gate_even_without_server_url(monkeypatch):
+    opened: list[str] = []
+    monkeypatch.setattr("webbrowser.open", lambda u: opened.append(u))
+    with pytest.raises(UnsafeMcpUrl):
+        await mcp_oauth._open_browser("file:///tmp/x")
+    assert opened == []
+    assert mcp_oauth.last_authorize_url is None
+
+
+@pytest.mark.asyncio
+async def test_refuse_browser_does_not_store_file_url():
+    with pytest.raises(UnsafeMcpUrl):
+        await mcp_oauth._refuse_browser("file:///tmp/x")
+    assert mcp_oauth.last_authorize_url is None
+
+
+# -- SDK auth-flow wrap: refuse before httpx sees the request ------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_flow_refuses_metadata_discovery_url_before_yield(tmp_path, monkeypatch):
+    """The SDK yields a Request for resource_metadata taken from WWW-Authenticate.
+    We must raise *before* yielding so httpx never sends it."""
+
+    async def evil_flow(self, request):
+        yield httpx.Request("GET", "http://169.254.169.254/latest/meta-data/")
+
+    monkeypatch.setattr(OAuthClientProvider, "async_auth_flow", evil_flow)
+    secrets = SecretStore(tmp_path / "s.json")
+    auth = mcp_oauth.build_auth("evil", SERVER, secrets, interactive=False)
+    flow = auth.async_auth_flow(httpx.Request("POST", SERVER))
+    with pytest.raises(UnsafeMcpUrl, match="link-local"):
+        await flow.asend(None)
+    await flow.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_flow_allows_same_origin_yield(tmp_path, monkeypatch):
+    async def ok_flow(self, request):
+        yield httpx.Request("GET", "https://mcp.example.com/.well-known/oauth-protected-resource")
+
+    monkeypatch.setattr(OAuthClientProvider, "async_auth_flow", ok_flow)
+    secrets = SecretStore(tmp_path / "s.json")
+    auth = mcp_oauth.build_auth("ok", SERVER, secrets, interactive=False)
+    flow = auth.async_auth_flow(httpx.Request("POST", SERVER))
+    sent = await flow.asend(None)
+    assert str(sent.url).startswith("https://mcp.example.com/")
+    await flow.aclose()
+
+
+# -- httpx request hook (redirect hops that never re-enter Auth) ---------------
+
+
+@pytest.mark.asyncio
+async def test_factory_installs_a_request_hook_that_refuses_metadata_urls():
+    client = mcp_httpx_client_factory(SERVER)()
+    hooks = client.event_hooks.get("request") or []
+    assert hooks, "factory must install a request hook"
+    hook = hooks[0]
+    await hook(httpx.Request("GET", "https://mcp.example.com/mcp"))  # same origin
+    with pytest.raises(UnsafeMcpUrl, match="link-local"):
+        await hook(httpx.Request("GET", "http://169.254.169.254/latest/meta-data/"))
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_hook_blocks_redirect_to_metadata_before_transport_sees_it():
+    """follow_redirects=True would otherwise GET Location without Auth seeing it."""
+    hops: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hops.append(str(request.url))
+        if "169.254" in str(request.url):
+            pytest.fail("metadata request reached the transport")
+        return httpx.Response(
+            302, headers={"Location": "http://169.254.169.254/latest/meta-data/"}
+        )
+
+    async def hook(request: httpx.Request) -> None:
+        refuse_destination(str(request.url), SERVER, what="MCP HTTP request")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        follow_redirects=True,
+        event_hooks={"request": [hook]},
+    ) as client:
+        with pytest.raises(UnsafeMcpUrl, match="link-local"):
+            await client.get(
+                "https://mcp.example.com/.well-known/oauth-protected-resource"
+            )
+    assert hops == [
+        "https://mcp.example.com/.well-known/oauth-protected-resource"
+    ]
+    assert not any("169.254" in h for h in hops)
+
+
+@pytest.mark.asyncio
+async def test_factory_client_allows_same_origin_request():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="ok")
+
+    factory = mcp_httpx_client_factory(SERVER)
+    probe = factory()
+    hook = probe.event_hooks["request"][0]
+    await probe.aclose()
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        follow_redirects=True,
+        event_hooks={"request": [hook]},
+    ) as client:
+        r = await client.get("https://mcp.example.com/mcp")
+        assert r.status_code == 200


### PR DESCRIPTION
Fixes #527. The MCP SDK follows `resource_metadata`, `authorization_servers`, `registration_endpoint`, and `token_endpoint` from remote JSON with no destination check, and hands the authorize URL to `webbrowser.open` unvetted. A malicious or compromised MCP server could steer those requests at loopback, RFC1918, or cloud metadata, or open a `file://` page.

The user-chosen MCP URL stays trusted as an origin (local MCP servers are real). Every other URL the client is steered at must be http(s) and must not resolve to the machine's own network — same address policy as `web_fetch`. Federated public authorization servers (Okta, Entra, Atlassian) keep working.

**Design highlights**
- Auth-flow wrap: every URL the SDK yields is refused before httpx sends it.
- Request hook on the OAuth httpx client: catches `follow_redirects=True` hops that never re-enter Auth.
- Authorize page: scheme-gated and origin-checked before `webbrowser.open`; `file://` never lands in `last_authorize_url`.
- Cached AS metadata: a poisoned `token_endpoint` is dropped on load and never persisted, so silent refresh cannot POST the code to metadata.

**Testing:** unit tests for same-origin / loopback / metadata / CGNAT / non-http, federated public AS, cache drop and persist refusal, browser scheme gate, auth-flow refuse-before-yield, and redirect hops that never reach the transport.