### PR TITLE
ci: Pin GitHub Actions to Immutable SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,9 @@ jobs:
           cache: npm
           cache-dependency-path: surfaces/gui/package-lock.json
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
         with:
           workspaces: surfaces/gui/src-tauri
 
@@ -188,7 +188,7 @@ jobs:
             echo "::warning::no updater signatures in dist/ — release ships WITHOUT auto-update manifest"
           fi
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:
           draft: true
           files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,9 @@ jobs:
           cache: npm
           cache-dependency-path: surfaces/gui/package-lock.json
 
-      - uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203 # stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
-      - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: surfaces/gui/src-tauri
 
@@ -188,7 +188,7 @@ jobs:
             echo "::warning::no updater signatures in dist/ — release ships WITHOUT auto-update manifest"
           fi
 
-      - uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           draft: true
           files: dist/*


### PR DESCRIPTION
Hey! 👋 I was exploring Openworker and ran the repository through an architecture and security scanner we are building called [VibeMass](https://vibemass.com). 

I noticed a couple of minor infrastructure and visibility tweaks, so I wanted to fix them for you!

### 1. Security Fix: Mutable GitHub Action Tags
Currently, your `.github/workflows/release.yml` workflow uses mutable tags like `@stable` and `@v2`. If any of those upstream repositories are ever compromised, an attacker could silently inject malware into your build and release process. 
**Fix:** I’ve pinned the `rust-toolchain`, `rust-cache`, and `action-gh-release` actions to their exact 40-character commit SHAs to guarantee supply chain security.

### 2. Architecture Heads-Up (No Action Required)
As a side note, the scanner's architecture agent flagged a couple of "God Modules" that might become bottlenecks for you as the project scales. Specifically:
- `surfaces/gui/src-tauri/src/lib.rs`: This is getting quite large and handles many disparate responsibilities (IPC, state, system integrations), and includes some `.unwrap()` calls on mutexes that could risk crashing the Tauri app.
- `coworker/connectors/email_tools.py`: A very large monolithic module for all email logic.

You might want to consider breaking those down into smaller modules when you get a chance, just to keep your development velocity high!

Let me know if you have any questions. Awesome project! 🚀
