### PR TITLE
fix: keep oversized tool results out of model context

### DIFF
--- a/coworker/engine.py
+++ b/coworker/engine.py
@@ -36,6 +36,7 @@ _REVIEWER_PAUSED_TEXT = (
 from .permissions import Mode, PermissionEngine
 from .providers import AssistantTurn, ProviderClient, ToolCall
 from .providers.errors import friendly_model_error
+from .tool_results import PreparedToolResult, ToolResultStore
 from .tools import ToolRegistry
 
 
@@ -114,6 +115,9 @@ class TurnEngine:
         self.provider = provider
         self.registry = registry
         self.permissions = permissions
+        self.tool_result_store = ToolResultStore(permissions.workspace_root)
+        if self.registry.get("read_tool_result") is None:
+            self.registry.register(self.tool_result_store.reader_tool())
         self.model = model
         self.approver = approver or _deny_all
         self.max_iterations = max_iterations
@@ -1381,10 +1385,10 @@ class TurnEngine:
                 **({"approval_note": origin["note"]} if origin.get("note") else {}),
                 **({"approval_grant": origin["grant"]} if origin.get("grant") else {}),
             }
-        message = _tool_result_message(tool_call, result)
+        prepared = self._append_tool_result(tool_call, result)
+        message = self.messages[-1]
         if display:
             message["_display"] = display
-        self.messages.append(message)
         hidden = int((display or {}).get("hidden_by_filters") or 0)
         stripped = int((display or {}).get("hidden_fields") or 0)
         if hidden or stripped:
@@ -1414,7 +1418,15 @@ class TurnEngine:
             {
                 "name": tool_call.name,
                 "status": status,
-                "result_preview": _preview(result),
+                "result_preview": _preview(prepared.value),
+                **(
+                    {
+                        "result_ref": prepared.reference,
+                        "original_chars": prepared.original_chars,
+                    }
+                    if prepared.reference
+                    else {}
+                ),
                 **({"display": display} if display else {}),
                 **({"standing_rule": rule} if rule else {}),
                 # (c) quiet provenance chip — same fields the `_display` sidecar persists.
@@ -1448,6 +1460,17 @@ class TurnEngine:
             return
         record = self.session_facts.note(tool_call.name, tool_call.arguments)
         self._audit(tool_call, **record.to_audit())
+
+    def _append_tool_result(
+        self, tool_call: ToolCall, result: Any
+    ) -> PreparedToolResult:
+        """Persist a bounded provider-facing result and invalidate token estimates."""
+        prepared = self.tool_result_store.prepare(tool_call.name, result)
+        self.messages.append(_tool_result_message(tool_call, prepared.value))
+        # The last provider usage was measured before this result existed. Re-estimate the
+        # complete outbound view at the next compaction checkpoint.
+        self._last_context_tokens = None
+        return prepared
 
     def _audit(self, tool_call: ToolCall, **event: Any) -> None:
         if self.audit_sink is None:

--- a/coworker/tool_results.py
+++ b/coworker/tool_results.py
@@ -1,0 +1,361 @@
+"""Bound model-facing tool results without discarding the canonical output.
+
+Tools should be free to return the data their caller requested.  The turn engine, not
+each individual connector, owns the provider context budget.  Small results therefore
+pass through unchanged; large results are written inside the session workspace and are
+replaced with a compact, pageable reference for the model.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import aisuite as ai
+
+
+DEFAULT_INLINE_CHARS = 40_000
+DEFAULT_READ_CHARS = 20_000
+MAX_READ_CHARS = 40_000
+DEFAULT_MAX_RESULT_BYTES = 64 * 1024 * 1024
+DEFAULT_MAX_STORE_BYTES = 512 * 1024 * 1024
+_PREVIEW_HEAD_CHARS = 8_000
+_PREVIEW_TAIL_CHARS = 4_000
+
+
+@dataclass(frozen=True)
+class PreparedToolResult:
+    """The bounded value sent to the model plus its optional durable reference."""
+
+    value: Any
+    original_chars: int
+    reference: Optional[str] = None
+    externalized: bool = False
+
+
+class ToolResultStore:
+    """Externalize oversized tool results into a workspace-private result directory."""
+
+    def __init__(
+        self,
+        workspace: str | Path,
+        *,
+        inline_chars: int = DEFAULT_INLINE_CHARS,
+        max_result_bytes: int = DEFAULT_MAX_RESULT_BYTES,
+        max_store_bytes: int = DEFAULT_MAX_STORE_BYTES,
+    ) -> None:
+        self.workspace = Path(workspace).expanduser().resolve()
+        self.result_dir = self.workspace / ".openworker" / "tool-results"
+        self.inline_chars = max(1, int(inline_chars))
+        self.max_result_bytes = max(1, int(max_result_bytes))
+        self.max_store_bytes = max(self.max_result_bytes, int(max_store_bytes))
+
+    def prepare(self, tool_name: str, result: Any) -> PreparedToolResult:
+        """Return *result* unchanged when small, otherwise persist and reference it."""
+        serialized = _serialize_for_model(result)
+        original_chars = len(serialized)
+        if original_chars <= self.inline_chars:
+            return PreparedToolResult(value=result, original_chars=original_chars)
+
+        # The paging tool is already responsible for bounding its own response. Never
+        # externalize a page again: that would produce a new reference instead of making
+        # progress through the original one.
+        if tool_name == "read_tool_result":
+            return PreparedToolResult(
+                value={
+                    "error": "tool-result page exceeds the inline context limit",
+                    "recoverable": False,
+                },
+                original_chars=original_chars,
+            )
+
+        digest = hashlib.sha256(
+            serialized.encode("utf-8", errors="replace")
+        ).hexdigest()
+        suffix = ".txt" if isinstance(result, str) else ".json"
+        filename = f"{_safe_name(tool_name)}-{digest[:20]}{suffix}"
+        target = self.result_dir / filename
+        reference = target.relative_to(self.workspace).as_posix()
+        stored_text = _serialize_for_storage(result, fallback=serialized)
+        storage_error: Optional[str] = None
+
+        try:
+            self.result_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                self.result_dir.chmod(0o700)
+            except OSError:
+                pass
+            if not target.exists():
+                encoded_bytes = len(stored_text.encode("utf-8"))
+                if encoded_bytes > self.max_result_bytes:
+                    raise OSError(
+                        "tool result exceeds the per-result retention quota "
+                        f"({encoded_bytes} > {self.max_result_bytes} bytes)"
+                    )
+                used_bytes = sum(
+                    path.stat().st_size
+                    for path in self.result_dir.iterdir()
+                    if path.is_file()
+                )
+                if used_bytes + encoded_bytes > self.max_store_bytes:
+                    raise OSError(
+                        "tool-result store exceeds its workspace quota "
+                        f"({used_bytes + encoded_bytes} > {self.max_store_bytes} bytes)"
+                    )
+                _atomic_write_text(target, stored_text)
+        except OSError as exc:
+            reference = ""
+            storage_error = f"{type(exc).__name__}: {exc}"
+
+        value: dict[str, Any] = {
+            "openworker_large_result": True,
+            "summary": _summary(tool_name, result, original_chars),
+            "original_chars": original_chars,
+            "sha256": digest,
+            "preview": _bounded_preview(stored_text),
+        }
+        if reference:
+            value.update(
+                {
+                    "result_ref": reference,
+                    "read_instruction": (
+                        "The complete result is stored locally. Call read_tool_result "
+                        f'with ref="{reference}" and offset=0 to read it in bounded pages.'
+                    ),
+                }
+            )
+        else:
+            value.update(
+                {
+                    "storage_error": storage_error or "result could not be stored",
+                    "read_instruction": (
+                        "Only the bounded preview is available because local persistence "
+                        "failed; do not assume the preview is complete."
+                    ),
+                }
+            )
+
+        return PreparedToolResult(
+            value=value,
+            original_chars=original_chars,
+            reference=reference or None,
+            externalized=bool(reference),
+        )
+
+    def reader_tool(self):
+        """Build the workspace-scoped, bounded reader exposed to the model."""
+        store = self
+
+        def read_tool_result(
+            ref: str,
+            offset: int = 0,
+            max_chars: int = DEFAULT_READ_CHARS,
+        ) -> dict[str, Any]:
+            start = offset if isinstance(offset, int) and offset >= 0 else 0
+            limit = (
+                max_chars
+                if isinstance(max_chars, int) and max_chars > 0
+                else DEFAULT_READ_CHARS
+            )
+            limit = min(limit, MAX_READ_CHARS)
+            target = store._resolve_reference(ref)
+            if target is None:
+                return {"error": "invalid tool-result reference"}
+            if not target.is_file():
+                return {"error": f"tool result not found: {ref}"}
+
+            requested = limit
+            while requested > 0:
+                page = store._read_page(target, start=start, limit=requested)
+                if "error" in page:
+                    return page
+                if len(_serialize_for_model(page)) <= store.inline_chars:
+                    return page
+                requested //= 2
+            return {"error": "tool-result page cannot fit the inline context limit"}
+
+        read_tool_result.__name__ = "read_tool_result"
+        read_tool_result.__doc__ = _READER_SCHEMA["function"]["description"]
+        read_tool_result.__aisuite_tool_metadata__ = ai.ToolMetadata(
+            name="read_tool_result",
+            category="filesystem",
+            risk_level="low",
+            capabilities=["read"],
+            requires_approval=False,
+        )
+        read_tool_result.__coworker_schema__ = _READER_SCHEMA
+        return read_tool_result
+
+    def _resolve_reference(self, ref: str) -> Optional[Path]:
+        if not isinstance(ref, str) or not ref.strip():
+            return None
+        raw = Path(ref).expanduser()
+        target = raw.resolve() if raw.is_absolute() else (self.workspace / raw).resolve()
+        try:
+            target.relative_to(self.result_dir.resolve())
+        except ValueError:
+            return None
+        return target
+
+    def _read_page(self, target: Path, *, start: int, limit: int) -> dict[str, Any]:
+        try:
+            total = target.stat().st_size
+            if start > total:
+                return {"error": "offset is beyond the end of the tool result"}
+            with open(target, "rb") as fh:
+                if 0 < start < total:
+                    fh.seek(start)
+                    current = fh.read(1)
+                    if current and current[0] & 0xC0 == 0x80:
+                        return {"error": "offset is not on a UTF-8 boundary"}
+                fh.seek(start)
+                data = fh.read(limit)
+        except OSError as exc:
+            return {"error": f"tool result read failed: {exc}"}
+
+        complete = start + len(data) >= total
+        if not complete:
+            while data:
+                try:
+                    content = data.decode("utf-8")
+                    break
+                except UnicodeDecodeError as exc:
+                    if exc.reason != "unexpected end of data":
+                        return {"error": "stored tool result is not valid UTF-8"}
+                    data = data[: exc.start]
+            else:
+                return {"error": "page size is too small for the next UTF-8 character"}
+        else:
+            try:
+                content = data.decode("utf-8")
+            except UnicodeDecodeError:
+                return {"error": "stored tool result is not valid UTF-8"}
+
+        next_offset = start + len(data)
+        result: dict[str, Any] = {
+            "result_ref": target.relative_to(self.workspace).as_posix(),
+            "offset": start,
+            "next_offset": next_offset,
+            "total_bytes": total,
+            "complete": next_offset >= total,
+            "content": content,
+        }
+        if next_offset < total:
+            result["read_instruction"] = (
+                f"Call read_tool_result again with offset={next_offset} to continue."
+            )
+        return result
+
+
+_READER_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "read_tool_result",
+        "description": (
+            "Read a bounded page from a large tool result that OpenWorker stored locally. "
+            "Use the result_ref and next_offset returned by prior tool results. Offsets are "
+            "UTF-8 byte offsets; each call is capped so the result cannot flood context."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "ref": {
+                    "type": "string",
+                    "description": "The result_ref supplied by an earlier tool result.",
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "UTF-8 byte offset to start at (default 0).",
+                },
+                "max_chars": {
+                    "type": "integer",
+                    "description": (
+                        f"Maximum bytes to return (default {DEFAULT_READ_CHARS}, "
+                        f"hard cap {MAX_READ_CHARS})."
+                    ),
+                },
+            },
+            "required": ["ref"],
+        },
+    },
+}
+
+
+def _serialize_for_model(result: Any) -> str:
+    if isinstance(result, str):
+        return result
+    try:
+        return json.dumps(result, default=str)
+    except Exception:
+        return str(result)
+
+
+def _serialize_for_storage(result: Any, *, fallback: str) -> str:
+    if isinstance(result, str):
+        return result
+    try:
+        return json.dumps(result, default=str, ensure_ascii=False, indent=2)
+    except Exception:
+        return fallback
+
+
+def _summary(tool_name: str, result: Any, original_chars: int) -> str:
+    detail = type(result).__name__
+    if isinstance(result, dict):
+        keys = [str(key) for key in list(result)[:20]]
+        detail = f"object with keys: {', '.join(keys) or '(none)'}"
+    elif isinstance(result, (list, tuple)):
+        detail = f"{type(result).__name__} with {len(result)} item(s)"
+    elif isinstance(result, str):
+        detail = "text"
+    return (
+        f"{tool_name} returned a large {detail} result ({original_chars} characters). "
+        "A bounded preview is included; the complete value is available by reference."
+    )
+
+
+def _bounded_preview(text: str) -> str:
+    budget = _PREVIEW_HEAD_CHARS + _PREVIEW_TAIL_CHARS
+    if len(text) <= budget:
+        return text
+    omitted = len(text) - budget
+    return (
+        text[:_PREVIEW_HEAD_CHARS]
+        + f"\n\n... [{omitted} characters omitted from preview] ...\n\n"
+        + text[-_PREVIEW_TAIL_CHARS:]
+    )
+
+
+def _safe_name(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value or "tool")).strip("-._")
+    return (safe or "tool")[:80]
+
+
+def _atomic_write_text(target: Path, content: str) -> None:
+    fd, temporary = tempfile.mkstemp(
+        prefix=f".{target.name}.", suffix=".tmp", dir=str(target.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(content)
+        os.replace(temporary, target)
+        try:
+            target.chmod(0o600)
+        except OSError:
+            pass
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise

--- a/tests/test_tool_results.py
+++ b/tests/test_tool_results.py
@@ -1,0 +1,118 @@
+"""Global large-tool-result externalization and bounded retrieval."""
+
+from __future__ import annotations
+
+import json
+
+from coworker.engine import TurnEngine
+from coworker.permissions import PermissionEngine
+from coworker.providers import AssistantTurn, ModelCapabilities, ProviderClient, ToolCall
+from coworker.tool_results import MAX_READ_CHARS, ToolResultStore
+from coworker.tools import ToolRegistry
+
+
+class _UnusedProvider(ProviderClient):
+    def complete(self, *, model, messages, tools=None, **settings):
+        return AssistantTurn(text="unused")
+
+    def capabilities(self, model):
+        return ModelCapabilities()
+
+
+def test_small_results_pass_through_unchanged(tmp_path):
+    store = ToolResultStore(tmp_path, inline_chars=100)
+    value = {"ok": True, "message": "small"}
+
+    prepared = store.prepare("example", value)
+
+    assert prepared.value is value
+    assert prepared.reference is None
+    assert not (tmp_path / ".openworker").exists()
+
+
+def test_large_result_is_externalized_and_pageable(tmp_path):
+    store = ToolResultStore(tmp_path, inline_chars=1_000)
+    value = {"elements": ["界面控件" * 800, "tail marker"]}
+
+    prepared = store.prepare("computer_snapshot", value)
+
+    assert prepared.externalized is True
+    assert prepared.reference
+    assert prepared.value["openworker_large_result"] is True
+    assert prepared.value["result_ref"] == prepared.reference
+    target = tmp_path / prepared.reference
+    assert target.is_file()
+    assert json.loads(target.read_text(encoding="utf-8")) == value
+
+    reader = store.reader_tool()
+    first = reader(prepared.reference, max_chars=64)
+    assert first["offset"] == 0
+    assert first["next_offset"] <= 64
+    assert first["complete"] is False
+    second = reader(prepared.reference, offset=first["next_offset"], max_chars=64)
+    assert second["offset"] == first["next_offset"]
+    assert "�" not in first["content"] + second["content"]
+
+
+def test_result_reader_rejects_escape_and_caps_output(tmp_path):
+    store = ToolResultStore(tmp_path)
+    prepared = store.prepare("shell", "x" * (MAX_READ_CHARS + 100))
+    reader = store.reader_tool()
+
+    escaped = reader("../outside.txt")
+    page = reader(prepared.reference, max_chars=MAX_READ_CHARS * 10)
+
+    assert escaped == {"error": "invalid tool-result reference"}
+    assert len(page["content"]) <= MAX_READ_CHARS
+    assert page["next_offset"] <= MAX_READ_CHARS
+
+
+def test_reader_never_externalizes_a_page_recursively(tmp_path):
+    store = ToolResultStore(tmp_path, inline_chars=1_000)
+    prepared = store.prepare("large", '"\\\n' * 2_000)
+    page = store.reader_tool()(prepared.reference, max_chars=MAX_READ_CHARS)
+
+    projected = store.prepare("read_tool_result", page)
+
+    assert "content" in page
+    assert projected.reference is None
+    assert not (
+        isinstance(projected.value, dict)
+        and projected.value.get("openworker_large_result")
+    )
+
+
+def test_retention_quota_failure_returns_only_a_bounded_preview(tmp_path):
+    store = ToolResultStore(
+        tmp_path,
+        inline_chars=100,
+        max_result_bytes=128,
+        max_store_bytes=256,
+    )
+
+    prepared = store.prepare("large", "x" * 1_000)
+
+    assert prepared.reference is None
+    assert "quota" in prepared.value["storage_error"]
+    assert len(json.dumps(prepared.value)) < 2_000
+
+
+def test_engine_uses_global_result_store_and_invalidates_usage(tmp_path):
+    registry = ToolRegistry()
+    engine = TurnEngine(
+        provider=_UnusedProvider(),
+        registry=registry,
+        permissions=PermissionEngine(workspace_root=tmp_path),
+        model="test:model",
+    )
+    engine.tool_result_store.inline_chars = 100
+    engine._last_context_tokens = 99_999
+    call = ToolCall(id="call-large", name="computer_snapshot", arguments={})
+
+    event = engine._record_result(call, {"tree": "x" * 5_000}, "ok")
+
+    content = json.loads(engine.messages[-1]["content"])
+    assert content["openworker_large_result"] is True
+    assert event.data["result_ref"] == content["result_ref"]
+    assert engine._last_context_tokens is None
+    assert registry.get("read_tool_result") is not None


### PR DESCRIPTION
## Problem

`TurnEngine` currently serializes every successful tool result directly into model
history. A single large browser/computer snapshot, MCP response, database result, or
log can therefore consume the remaining context window before compaction gets a chance
to run. In a reproduced case, one snapshot returned more than 100k characters and the
next provider request failed.

This is a runtime boundary problem rather than a computer-use-specific problem: every
registered tool currently reaches the same unbounded `_tool_result_message` path.

## Changes

- add a global result projection step at `TurnEngine._record_result`
- keep results up to 40k characters inline and unchanged
- retain larger results under the workspace-private
  `.openworker/tool-results/` directory
- send the model a bounded head/tail preview plus `result_ref`, size, and SHA-256
- add low-risk `read_tool_result` for exact, paged retrieval
- constrain retrieval to the retained-output directory, validate UTF-8 page boundaries,
  and size the serialized page so retrieval cannot recursively spill again
- cap retention at 64 MiB per result and 512 MiB per workspace
- invalidate the previous provider token count after every tool result so the next
  compaction checkpoint estimates the newly appended context

Small tool results preserve their current shape and behavior.

## Relationship to #67

#67 addresses the same core problem and includes a broader session-scoped design,
including shell capture, server/UI retrieval, ACL handling, and lifecycle cleanup. At
the time of this PR it is 288 commits behind `main` and has merge conflicts.

This PR is intentionally a smaller current-`main` implementation focused on protecting
the model context for all ordinary tool results. I am happy for maintainers to prefer a
refreshed #67 or combine the approaches; this PR explicitly credits that prior work and
does not claim its broader scope.

## Validation

- focused engine/tool-result suite: **45 passed**
- full backend suite: **1864 passed, 1 skipped**
- 3 URL-address-guard tests fail because this machine resolves `example.com` and
  `short.link` to the `198.18.0.0/15` private benchmark range; the same 3 failures
  reproduce unchanged on `origin/main@7fc3ee6`

No frontend code is changed.
