### PR TITLE
fix: make Bedrock verification and tests tolerate missing optional boto3

### DIFF
--- a/coworker/providers/registry.py
+++ b/coworker/providers/registry.py
@@ -756,16 +756,10 @@ def _verify_bedrock(fields: dict[str, Any], timeout: float) -> dict[str, Any]:
     def get(key: str) -> Optional[str]:
         return (fields.get(key) or "").strip() or None
 
-    try:
-        import boto3
-        from botocore.config import Config
-    except ImportError:
-        return {
-            "ok": False,
-            "error": "boto3 is not installed — `pip install 'openworker[bedrock]'`.",
-        }
     # Exactly one auth method is exercised — the one the form has selected. Per-method
-    # required fields are checked here so the Test button says what's missing.
+    # required fields are checked here so the Test button says what's missing. Do this
+    # before importing boto3 so the test suite (and users) get a helpful missing-field
+    # message even when the optional `bedrock` extra is not installed.
     method = get("auth_method") or "api_key"
     if method == "api_key" and not (
         get("bedrock_api_key") or os.environ.get("AWS_BEARER_TOKEN_BEDROCK")
@@ -775,6 +769,14 @@ def _verify_bedrock(fields: dict[str, Any], timeout: float) -> dict[str, Any]:
         get("aws_access_key_id") and get("aws_secret_access_key")
     ):
         return {"ok": False, "error": "Enter an access key ID and secret access key."}
+    try:
+        import boto3
+        from botocore.config import Config
+    except ImportError:
+        return {
+            "ok": False,
+            "error": "boto3 is not installed — `pip install 'openworker[bedrock]'`.",
+        }
     try:
         if method == "api_key":
             # The key rides the env var (boto3's only bearer channel); bearer then wins

--- a/tests/test_bedrock_provider.py
+++ b/tests/test_bedrock_provider.py
@@ -219,6 +219,7 @@ def test_converse_stream_accumulates_text_and_tool():
 
 
 def test_no_credentials_error_becomes_friendly():
+    pytest.importorskip("botocore")
     from botocore.exceptions import NoCredentialsError
 
     class _Raises:
@@ -341,7 +342,7 @@ def test_auth_method_narrows_out_other_methods_fields(monkeypatch):
 def test_converse_client_publishes_api_key_as_bearer_env(monkeypatch):
     import os
 
-    import boto3
+    boto3 = pytest.importorskip("boto3")
 
     from coworker.providers.bedrock_provider import _BedrockConverseClient
 
@@ -461,7 +462,7 @@ class _FakeBedrockControl:
 
 
 def _patch_session(monkeypatch, control: Any, captured: dict):
-    import boto3
+    boto3 = pytest.importorskip("boto3")
 
     class _FakeSession:
         def __init__(self, **kwargs):
@@ -503,7 +504,12 @@ def test_verify_bedrock_per_method_required_fields(monkeypatch):
         fields={"region": "us-east-1", "auth_method": "iam", "aws_access_key_id": "AKIA"},
     )
     assert not out["ok"] and "secret access key" in out["error"]
-    # Blank profile is fine — it means the default credential chain.
+
+
+def test_verify_bedrock_blank_profile_uses_default_chain(monkeypatch):
+    """A blank profile is fine — it means the default credential chain."""
+    from coworker.providers.registry import verify_provider_key
+
     captured: dict = {}
     _patch_session(monkeypatch, _FakeBedrockControl(), captured)
     out = verify_provider_key(
@@ -553,6 +559,7 @@ def test_verify_bedrock_api_key_rides_the_bearer_env(monkeypatch):
 
 
 def test_verify_bedrock_maps_client_errors(monkeypatch):
+    pytest.importorskip("botocore")
     from botocore.exceptions import ClientError
 
     from coworker.providers.registry import verify_provider_key
@@ -582,6 +589,7 @@ def test_verify_bedrock_maps_modeled_client_error_subclasses(monkeypatch):
     # Live boto3 raises MODELED subclasses (class name "AccessDeniedException", not
     # "ClientError"). The old name-based check sent these to the generic "Couldn't reach"
     # fallback and hid the specific guidance (owner report 2026-08-17, real Bedrock key).
+    pytest.importorskip("botocore")
     from botocore.exceptions import ClientError
 
     from coworker.providers.registry import verify_provider_key


### PR DESCRIPTION
## Summary
The default dev environment (`packaging/setup_dev_env.sh`) installs only `[messaging,dev]`, but `tests/test_bedrock_provider.py` assumes `boto3`/`botocore` are present, and `_verify_bedrock` reported a missing-package error before checking whether the user supplied the required per-method fields.

Changes:
- In `coworker/providers/registry.py`, move per-method required-field validation (`api_key` or `iam`) ahead of the `boto3`/`botocore` import so users/tests get a useful missing-field message even without the optional `bedrock` extra installed.
- In `tests/test_bedrock_provider.py`, guard boto3/botocore-dependent tests with `pytest.importorskip`, and split the required-fields test so the no-key assertions still run when the optional dependency is absent.

This lets `pytest tests` pass in the default contributor environment (9 bedrock tests skipped cleanly when `boto3` is absent) while exercising the full bedrock suite when the `[bedrock]` extra is installed.