### PR TITLE
fix(tests): import ExceptionGroup from backport for Python 3.10 compatibility

### DIFF
--- a/tests/test_mcp_connectors.py
+++ b/tests/test_mcp_connectors.py
@@ -21,6 +21,14 @@ from coworker.mcp.config import put_global_server, read_global
 from coworker.secrets import SecretStore
 from coworker.server.manager import SessionManager
 
+# ExceptionGroup is a builtin on Python 3.11+; on 3.10 it lives in the exceptiongroup
+# backport, which pytest already depends on. Keep test code aligned with
+# requires-python = ">=3.10".
+try:
+    from builtins import ExceptionGroup
+except ImportError:
+    from exceptiongroup import ExceptionGroup
+
 
 def _state(tmp_path, monkeypatch):
     monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))


### PR DESCRIPTION
## Summary
`tests/test_mcp_connectors.py` used bare `ExceptionGroup`, which only exists as a builtin on Python 3.11+. The repo declares `requires-python = ">=3.10"`, and the default dev environment currently runs on Python 3.10, so the test file threw `NameError` at import/execution time.

Changes:
- Add a compatibility import at the top of `tests/test_mcp_connectors.py` that tries `builtins.ExceptionGroup` first, then falls back to the `exceptiongroup` backport (already a transitive dependency via pytest).

This makes `pytest tests` runnable on Python 3.10 without requiring an upgrade to 3.11+.