### PR TITLE
Escape LIKE wildcards when re-keying board cursors

### DIFF
--- a/coworker/teams/store.py
+++ b/coworker/teams/store.py
@@ -999,8 +999,9 @@ class TeamStore:
                 # Cursor keys embed the space as a suffix ("feed:<actor>:<space>",
                 # "sub:<sub>:<space>") — rewrite the suffix, keep consumed positions.
                 cur_rows = self._conn.execute(
-                    "SELECT cursor_key FROM team_cursors WHERE cursor_key LIKE ?",
-                    ("%:" + old,),
+                    "SELECT cursor_key FROM team_cursors"
+                    " WHERE cursor_key LIKE ? ESCAPE '\\'",
+                    ("%" + _like_escape(":" + old),),
                 ).fetchall()
                 for crow in cur_rows:
                     new_key = crow["cursor_key"][: -len(old)] + new
@@ -1043,6 +1044,15 @@ class TeamStore:
                 f" {sorted(role.value for role in roles)} (actor {actor.id} is"
                 f" {actor.role.value})"
             )
+
+
+def _like_escape(text: str) -> str:
+    """Quote LIKE metacharacters so a literal string matches only itself. Space
+    keys are filesystem paths, where `_` (LIKE's single-character wildcard) is
+    ordinary — left raw it also matches a neighbouring space's rows."""
+    for char in ("\\", "%", "_"):
+        text = text.replace(char, "\\" + char)
+    return text
 
 
 def _canonical(payload: dict[str, Any]) -> str:

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -143,6 +143,21 @@ class TestMigration:
         assert store.rekey_space("/old", "/new") is False
         assert store.event_count("/old") == 1  # dormant, untouched
 
+    def test_board_rekey_leaves_lookalike_space_cursors_alone(self, tmp_path):
+        """`_` is ordinary in a path but a LIKE wildcard: a neighbouring space
+        whose key differs only there must keep its consumed position."""
+        store = TeamStore(tmp_path / "b.db")
+        lead = Actor(id="lead", role=Role.LEAD)
+        old, other = "/w/my_app", "/w/myXapp"
+        store.create_item(old, lead, title="one", criteria="c")
+        store.create_item(other, lead, title="two", criteria="c")
+        store.consume_feed(old, "worker", 1)
+        store.consume_feed(other, "worker", 2)
+
+        assert store.rekey_space(old, "git:acme/app") is True
+        assert store._cursor("feed:worker:git:acme/app") == 1
+        assert store._cursor(f"feed:worker:{other}") == 2
+
 
 class TestResolvers:
     def test_binding_beats_derivation(self, tmp_path):


### PR DESCRIPTION
## Summary

`TeamStore.rekey_space` — the path→git space migration that `resolve_board_space` runs
automatically — selects the cursor rows to rewrite with an **unescaped** `LIKE` pattern:

```python
"SELECT cursor_key FROM team_cursors WHERE cursor_key LIKE ?", ("%:" + old,)
...
new_key = crow["cursor_key"][: -len(old)] + new
"UPDATE OR REPLACE team_cursors SET cursor_key = ? WHERE cursor_key = ?"
```

Space keys are filesystem paths (`space_for_workspace` → `str(Path(...).resolve())`), and
`_` is both ordinary in a path and LIKE's single-character wildcard. So migrating
`/w/my_app` also selects `feed:worker:/w/myXapp`. The loop then blindly slices `len(old)`
characters off that key and appends `new`, and `UPDATE OR REPLACE` **deletes** the
colliding legitimate row — an unrelated space silently loses its consumed feed position and
its workers re-receive every event from seq 0.

Fix: escape `\`, `%`, and `_` and match with `ESCAPE '\'`, so the suffix matches only itself.

```diff
-    "SELECT cursor_key FROM team_cursors WHERE cursor_key LIKE ?",
-    ("%:" + old,),
+    "SELECT cursor_key FROM team_cursors WHERE cursor_key LIKE ? ESCAPE '\',
+    ("%" + _like_escape(":" + old),),
```

## Broken vs. fixed

Two spaces differing only at the `_`, each with a consumed cursor, then
`rekey_space("/home/me/my_app", "git:acme/app")`:

```
before: [('feed:worker:/home/me/my_app', 1), ('feed:worker:/home/me/myXapp', 7)]

# on main — the untouched space's cursor is gone, its worker rewinds to 0
after : [('feed:worker:git:acme/app', 1)]
other space cursor: 0

# with this patch
after : [('feed:worker:git:acme/app', 1), ('feed:worker:/home/me/myXapp', 7)]
other space cursor: 7
```

## Testing

- New regression test `test_board_rekey_leaves_lookalike_space_cursors_alone` fails on `main`
  (`assert 0 == 2`) and passes with the fix.
- `pytest tests/test_projects.py tests/test_team_*.py -q` → 127 passed.
- `pytest tests -q` → 1859 passed, 1 skipped. The 3 failures are pre-existing on `main` and
  unrelated: two `ExceptionGroup` NameErrors on Python 3.10 (addressed in #555) and
  `test_session_facts.py`, which fails only because this sandbox rewrites git remote URLs.


---
[Written by Devin](https://app.devin.ai/sessions/acb923d2ac8d4c71a19b6f6874e9b107)
