### PR TITLE
Add DGX Spark Linux ARM64 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ It runs on your machine and doesn't lock you into any model: bring your own API 
 [**⬇ Windows 10/11 (x64)**](https://download.openworker.com/windows)
 <sub>builds are not yet code-signed, so SmartScreen will warn; signing is in progress</sub>
 
+**NVIDIA DGX Spark (Linux ARM64):** follow the [DGX Spark setup and build guide](docs/dgx-spark.md)
+to run the browser UI, connect a GPU-backed local model, or build a native `.deb`.
+
 Open the app, add a model key (or point it at Ollama), and ask for something real.
 
 ## How it works
@@ -91,7 +94,7 @@ desktop app uses an in-memory launch token instead and never writes it to disk.
 
 To run the full desktop app instead of the browser UI, replace step 3 with `npm run tauri dev` (from `surfaces/gui/`) - the Tauri shell launches the window and supervises the server itself.
 
-Tests: `.venv/bin/pytest` (server), `npm test` and `npm run e2e` in `surfaces/gui` (GUI unit + hermetic end-to-end). Desktop bundles are built with `packaging/build_dmg.sh` / `packaging/build_windows.ps1`.
+Tests: `.venv/bin/pytest` (server), `npm test` and `npm run e2e` in `surfaces/gui` (GUI unit + hermetic end-to-end). Desktop bundles are built with `packaging/build_dmg.sh`, `packaging/build_windows.ps1`, or `packaging/build_linux.sh` (Linux, including DGX Spark ARM64).
 
 ## Repository layout
 

--- a/coworker/toolchain.py
+++ b/coworker/toolchain.py
@@ -117,6 +117,11 @@ MANAGED: dict[str, ManagedTool] = {
                 sha256="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb",
                 member="gitleaks",
             ),
+            "linux_arm64": Download(
+                url="https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_arm64.tar.gz",
+                sha256="e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080",
+                member="gitleaks",
+            ),
         },
     ),
     "trivy": ManagedTool(
@@ -139,6 +144,11 @@ MANAGED: dict[str, ManagedTool] = {
                 sha256="2ae6fe3ee734b7fdf11335663e18c75ea12dccc76062f09f164a3b0f8be4371a",
                 member="trivy",
             ),
+            "linux_arm64": Download(
+                url="https://github.com/aquasecurity/trivy/releases/download/v0.74.0/trivy_0.74.0_Linux-ARM64.tar.gz",
+                sha256="b94ce1976bbf3c15b514b605ee88be7c6d94a29be2302847ff01cb794d47aad5",
+                member="trivy",
+            ),
         },
     ),
     "osv-scanner": ManagedTool(
@@ -157,6 +167,10 @@ MANAGED: dict[str, ManagedTool] = {
             "linux_amd64": Download(
                 url="https://github.com/google/osv-scanner/releases/download/v2.5.0/osv-scanner_linux_amd64",
                 sha256="edcfc41d257db36148f065055655fe3fcfc434b0b423ea67468a84c207524e0c",
+            ),
+            "linux_arm64": Download(
+                url="https://github.com/google/osv-scanner/releases/download/v2.5.0/osv-scanner_linux_arm64",
+                sha256="fe152e1a546af223e6c557cc3111a8bb3e5dc02fcbf7dbe95d26567c0f0041f2",
             ),
         },
     ),

--- a/docs/dgx-spark.md
+++ b/docs/dgx-spark.md
@@ -1,0 +1,78 @@
+# Running OpenWorker on NVIDIA DGX Spark
+
+DGX Spark is a Linux ARM64 system. OpenWorker's agent and UI run on the CPU; a local model
+server such as Ollama or vLLM uses the Blackwell GPU and exposes an API to OpenWorker.
+
+## Prerequisites
+
+On DGX OS (Ubuntu 24.04), install the browser-build requirements:
+
+```shell
+sudo apt update
+sudo apt install -y build-essential curl git python3 python3-dev python3-venv
+```
+
+Install Node.js 20 or newer, then confirm `node --version` and `npm --version` work. For a
+native desktop `.deb`, also install Rust with rustup and Tauri's Linux libraries:
+
+```shell
+sudo apt install -y \
+  libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev \
+  libssl-dev libgtk-3-dev libasound2-dev pkg-config
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+## Set up and run
+
+From the repository root:
+
+```shell
+bash packaging/setup_dgx_spark.sh
+bash packaging/run_dgx_spark.sh /path/to/your/project
+```
+
+Open `http://127.0.0.1:1420` on the Spark. If the Spark is remote, keep both services bound to
+loopback and forward them over SSH:
+
+```shell
+ssh -L 1420:127.0.0.1:1420 -L 8765:127.0.0.1:8765 USER@SPARK_HOST
+```
+
+Then open `http://127.0.0.1:1420` on your laptop. The loopback-only design is intentional:
+OpenWorker can run shell commands and access files, so its control API is not exposed directly
+to the LAN.
+
+## Use the Spark GPU with Ollama
+
+NVIDIA documents Ollama as a supported local inference path on DGX Spark. Install it, pull an
+agent-capable model, and check that its OpenAI-compatible endpoint is live:
+
+```shell
+curl -fsSL https://ollama.com/install.sh | sh
+ollama pull qwen3.6:35b-a3b-nvfp4
+curl http://127.0.0.1:11434/v1/models
+```
+
+In OpenWorker, open **Settings → Model providers → Ollama**, use
+`http://127.0.0.1:11434`, then add the exact model tag
+`ollama:qwen3.6:35b-a3b-nvfp4`. Model availability changes over time; use a smaller
+tool-capable model if that tag is unavailable or if another workload is consuming unified
+memory.
+
+An existing vLLM server also works through OpenWorker's OpenAI provider: enter the server's
+OpenAI-compatible `/v1` URL as the custom base URL, use any non-empty placeholder API key if
+the server has authentication disabled, and add the exact served model ID.
+
+## Build and install the desktop app
+
+After setup and the native build prerequisites:
+
+```shell
+bash packaging/build_linux.sh
+sudo apt install ./surfaces/gui/src-tauri/target/release/bundle/deb/*.deb
+```
+
+This package is built natively for the machine running the script, so a DGX Spark produces an
+ARM64 package. Voice Input remains unavailable on Linux; chat, files, shell tools, connectors,
+automations, and local model access are available.
+

--- a/packaging/build_linux.sh
+++ b/packaging/build_linux.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Build a native Linux package. On DGX Spark this produces an ARM64 .deb containing the
+# React/Tauri desktop shell and a self-contained PyInstaller server sidecar.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+GUI="$ROOT/surfaces/gui"
+PYINSTALLER="$ROOT/.venv/bin/pyinstaller"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "ERROR: Linux packages must be built natively on Linux." >&2
+  exit 1
+fi
+for command in rustc npm; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "ERROR: required command '$command' was not found. See docs/dgx-spark.md." >&2
+    exit 1
+  fi
+done
+if [ ! -x "$PYINSTALLER" ]; then
+  echo "ERROR: PyInstaller is missing. Run: bash packaging/setup_dgx_spark.sh" >&2
+  exit 1
+fi
+if [ ! -d "$GUI/node_modules" ]; then
+  echo "ERROR: GUI dependencies are missing. Run: bash packaging/setup_dgx_spark.sh" >&2
+  exit 1
+fi
+
+TRIPLE="$(rustc -vV | sed -n 's/host: //p')"
+
+echo "==> [1/3] PyInstaller: bundling openworker-server ($TRIPLE)"
+"$PYINSTALLER" --noconfirm --clean \
+  --distpath "$HERE/dist" --workpath "$HERE/build" "$HERE/openworker-server.spec"
+
+echo "==> [2/3] Staging the server sidecar"
+mkdir -p "$GUI/src-tauri/binaries"
+rm -rf "$GUI/src-tauri/binaries/sidecar"
+cp -a "$HERE/dist/openworker-server" "$GUI/src-tauri/binaries/sidecar"
+chmod +x "$GUI/src-tauri/binaries/sidecar/openworker-server"
+
+echo "==> [3/3] Tauri: building a native .deb"
+(cd "$GUI" && npm run tauri build -- --bundles deb)
+
+echo
+echo "Done. Package:"
+find "$GUI/src-tauri/target/release/bundle/deb" -maxdepth 1 -type f -name '*.deb' -print
+

--- a/packaging/run_dgx_spark.sh
+++ b/packaging/run_dgx_spark.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Run OpenWorker's server and browser UI together on DGX Spark.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GUI="$ROOT/surfaces/gui"
+SERVER="$ROOT/.venv/bin/openworker-server"
+WORKSPACE="${1:-$HOME}"
+SERVER_PID=""
+
+if [ ! -x "$SERVER" ] || [ ! -d "$GUI/node_modules" ]; then
+  echo "ERROR: setup is incomplete. Run: bash packaging/setup_dgx_spark.sh" >&2
+  exit 1
+fi
+
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+echo "==> Starting OpenWorker server for workspace: $WORKSPACE"
+"$SERVER" --cwd "$WORKSPACE" --host 127.0.0.1 --port 8765 &
+SERVER_PID=$!
+
+# Vite reads the freshly-created launch token when it starts. Waiting for health also gives a
+# clear early failure instead of launching a UI that can never authenticate to its server.
+for _ in $(seq 1 100); do
+  if curl -fsS http://127.0.0.1:8765/v1/health >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    wait "$SERVER_PID"
+    exit 1
+  fi
+  sleep 0.1
+done
+if ! curl -fsS http://127.0.0.1:8765/v1/health >/dev/null 2>&1; then
+  echo "ERROR: OpenWorker server did not become ready on port 8765." >&2
+  exit 1
+fi
+
+echo "==> Open http://127.0.0.1:1420"
+echo "    Over SSH, forward both ports:"
+echo "    ssh -L 1420:127.0.0.1:1420 -L 8765:127.0.0.1:8765 <user>@<spark>"
+(cd "$GUI" && npm run dev -- --host 127.0.0.1)
+

--- a/packaging/setup_dgx_spark.sh
+++ b/packaging/setup_dgx_spark.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Prepare a DGX Spark checkout for the browser UI and native desktop builds.
+#
+# This intentionally installs only repository-local Python and Node dependencies. System
+# packages stay an explicit apt step (documented in docs/dgx-spark.md) so this script never
+# asks for sudo or changes the DGX OS installation behind the user's back.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GUI="$ROOT/surfaces/gui"
+VENV="$ROOT/.venv"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "ERROR: DGX Spark setup must run on Linux (found $(uname -s))." >&2
+  exit 1
+fi
+case "$(uname -m)" in
+  aarch64|arm64) ;;
+  *)
+    echo "ERROR: DGX Spark requires ARM64/aarch64 (found $(uname -m))." >&2
+    exit 1
+    ;;
+esac
+
+for command in python3 node npm git; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "ERROR: required command '$command' was not found. See docs/dgx-spark.md." >&2
+    exit 1
+  fi
+done
+
+python3 -c 'import sys; assert sys.version_info >= (3, 10), "Python 3.10+ is required"'
+node -e 'const major=Number(process.versions.node.split(".")[0]); if (major < 20) { console.error("Node 20+ is required"); process.exit(1) }'
+
+echo "==> Creating the Python environment"
+python3 -m venv "$VENV"
+"$VENV/bin/python" -m pip install --upgrade pip
+"$VENV/bin/pip" install -e "$ROOT[messaging,dev,bedrock]" pyinstaller typer
+"$VENV/bin/python" -c 'import aisuite, coworker'
+
+echo "==> Installing the GUI dependencies"
+(cd "$GUI" && npm ci)
+
+echo
+echo "DGX Spark setup is ready."
+echo "  Browser UI: bash packaging/run_dgx_spark.sh"
+echo "  Desktop .deb: bash packaging/build_linux.sh"
+

--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -14,7 +14,7 @@
 //! passes `OPENAI_API_KEY` through. A Finder-launched app has no shell env — there the key
 //! comes from the SecretStore (Settings tab), see `coworker.providers.resolve_api_key`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 #[cfg(target_os = "windows")]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -90,7 +90,12 @@ fn sidecar_env() -> std::collections::HashMap<String, String> {
         return out;
     }
 
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    let default_shell = if cfg!(target_os = "macos") {
+        "/bin/zsh"
+    } else {
+        "/bin/bash"
+    };
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| default_shell.to_string());
     let script = format!("echo {START}; env; echo {END}");
     let spawned = Command::new(&shell)
         .args(["-ilc", &script])
@@ -151,7 +156,11 @@ fn sidecar_env() -> std::collections::HashMap<String, String> {
         .cloned()
         .or_else(|| std::env::var("PATH").ok())
         .unwrap_or_default();
-    let mut parts: Vec<String> = base.split(':').filter(|s| !s.is_empty()).map(String::from).collect();
+    let mut parts: Vec<String> = base
+        .split(':')
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect();
     for dir in KNOWN_TOOL_DIRS {
         if !parts.iter().any(|p| p == dir) && std::path::Path::new(dir).is_dir() {
             parts.push((*dir).to_string());
@@ -169,14 +178,14 @@ fn sidecar_env() -> std::collections::HashMap<String, String> {
 
 /// Path to the server entrypoint. Resolution order:
 ///   1. `COWORKER_SERVER_BIN` env override.
-///   2. The bundled onedir sidecar shipped via Tauri `resources` (production): the
-///      `sidecar/` folder lands in Contents/Resources on macOS and in the install dir
-///      (next to the app exe) on Windows.
+///   2. The bundled onedir sidecar shipped via Tauri `resources` (production). The caller's
+///      resource directory handles every bundle layout, including `/usr/lib/<app>` in a
+///      Linux `.deb`; executable-relative candidates cover macOS, Windows, and older builds.
 ///   3. Legacy onefile slot: `openworker-server[.exe]` next to the app binary (pre-onedir
 ///      builds used Tauri externalBin).
 ///   4. Dev fallback: the repo venv, relative to this crate (`src-tauri` → repo-root `.venv`;
 ///      `bin/` on POSIX, `Scripts\` on Windows).
-fn server_bin() -> PathBuf {
+fn server_bin(resource_dir: Option<&Path>) -> PathBuf {
     if let Ok(p) = std::env::var("COWORKER_SERVER_BIN") {
         return PathBuf::from(p);
     }
@@ -185,6 +194,12 @@ fn server_bin() -> PathBuf {
     } else {
         "openworker-server"
     };
+    if let Some(dir) = resource_dir {
+        let bundled = dir.join("sidecar").join(exe_name);
+        if bundled.exists() {
+            return bundled;
+        }
+    }
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
             // macOS: Contents/MacOS/<app> → Contents/Resources/sidecar/; Windows: resources
@@ -264,7 +279,8 @@ fn write_keep_awake_pref(enabled: bool) {
 
 // -- keep-awake: hold off idle + system sleep so the scheduler keeps firing -------------------
 // Cross-platform behind a uniform `start_keep_awake() -> Option<KeepAwakeGuard>`; dropping the
-// guard releases the hold. macOS uses the built-in `caffeinate`; Windows uses the
+// guard releases the hold. macOS uses the built-in `caffeinate`; Linux uses
+// `systemd-inhibit`; Windows uses the
 // SetThreadExecutionState API (a dedicated thread holds ES_CONTINUOUS so the state survives
 // regardless of which Tauri worker thread toggled it); other platforms are a no-op.
 
@@ -334,14 +350,40 @@ fn start_keep_awake() -> Option<KeepAwakeGuard> {
     })
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(target_os = "linux")]
+struct KeepAwakeGuard(Child);
+
+#[cfg(target_os = "linux")]
+impl Drop for KeepAwakeGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn start_keep_awake() -> Option<KeepAwakeGuard> {
+    Command::new("systemd-inhibit")
+        .args([
+            "--what=sleep:idle",
+            "--why=OpenWorker scheduled tasks",
+            "--mode=block",
+            "sleep",
+            "infinity",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()
+        .map(KeepAwakeGuard)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 struct KeepAwakeGuard;
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 fn start_keep_awake() -> Option<KeepAwakeGuard> {
-    // No portable built-in inhibitor on Linux; keep-awake is a no-op (the toggle still reflects
-    // state so the UI behaves, but the OS sleep policy is left to the user).
-    Some(KeepAwakeGuard)
+    None
 }
 
 // -- native commands (invoked from the SPA via window.__TAURI__.core.invoke) -----------------
@@ -645,7 +687,11 @@ async fn download_update(
     // (Guard scope stays sync: a std MutexGuard must not live across an await.)
     {
         let slot = pending.0.lock().unwrap();
-        if slot.as_ref().map(|(v, _)| v == &update.version).unwrap_or(false) {
+        if slot
+            .as_ref()
+            .map(|(v, _)| v == &update.version)
+            .unwrap_or(false)
+        {
             return Ok(());
         }
     }
@@ -746,7 +792,8 @@ pub fn run() {
         ])
         .setup(move |app| {
             // 1. Start the Python server sidecar on the chosen port (inherits our env).
-            let mut server_cmd = Command::new(server_bin());
+            let resource_dir = app.path().resource_dir().ok();
+            let mut server_cmd = Command::new(server_bin(resource_dir.as_deref()));
             server_cmd
                 .args(["--host", "127.0.0.1", "--port", &port.to_string()])
                 // The user's real shell environment (PATH to their tools, AWS_PROFILE,

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -76,7 +76,12 @@ def test_trivy_is_pinned_for_every_platform_we_ship():
     """tfsec is deprecated upstream (folded into trivy); `trivy config` is the IaC scanner
     the cloud-posture bundle drives, so its pin must exist wherever the app runs."""
     tool = toolchain.MANAGED["trivy"]
-    assert set(tool.downloads) >= {"darwin_arm64", "darwin_amd64", "linux_amd64"}
+    assert set(tool.downloads) >= {
+        "darwin_arm64",
+        "darwin_amd64",
+        "linux_amd64",
+        "linux_arm64",
+    }
     for dl in tool.downloads.values():
         assert dl.member == "trivy"  # release assets are tarballs, not bare binaries
     assert "tfsec" not in toolchain.MANAGED


### PR DESCRIPTION
## Summary

- add DGX Spark setup and browser launcher scripts with a loopback-safe SSH workflow
- add native Linux `.deb` packaging for ARM64 hosts
- make the Tauri shell resolve Linux bundled resources and inhibit sleep with systemd
- add pinned Linux ARM64 scanner downloads and DGX local-model guidance

## Validation

- `.venv/bin/pytest tests/test_toolchain.py -q` (10 passed)
- `npm run build`
- `cargo check --manifest-path surfaces/gui/src-tauri/Cargo.toml`
- `bash -n packaging/setup_dgx_spark.sh packaging/run_dgx_spark.sh packaging/build_linux.sh`

The Linux package is built natively, so final `.deb` installation validation requires a DGX Spark or another Linux ARM64 host.