### PR TITLE
security: negated denials ("no, don't approve") no longer resolve as allow

### DIFF
--- a/tests/test_inbox_routing.py
+++ b/tests/test_inbox_routing.py
@@ -161,6 +161,15 @@ def test_denied_and_approved_word_forms(tmp_path):
     assert store.get(b.id).resolution == "allow"
 
 
+def test_negated_denial_is_not_parsed_as_allow(tmp_path):
+    """A denial phrased with an allow word ("no, don't approve") must never release the item."""
+    store = InboxStore(tmp_path / "inbox.json")
+    for phrasing in ("no, don't approve", "not allowed", "no, do not allow this"):
+        item = store.add_approval("s1", "Deploy?", inbox="ops")
+        resolve_from_reply(f"{phrasing} [ow:{item.id}]", store.resolve)
+        assert store.get(item.id).resolution != "allow"
+
+
 def test_emoji_reactions_still_resolve(tmp_path):
     store = InboxStore(tmp_path / "inbox.json")
     a = store.add_approval("s1", "Deploy?", inbox="ops")


### PR DESCRIPTION
> **Rebased on main (2026-09-01).** Upstream commit 746db87 ("Parse inbox reply intent from the leading word") already fixes the root cause on main, so the code change here has been dropped. This PR now only adds the regression test `test_negated_denial_is_not_parsed_as_allow` covering the exact phrasings from #520 ("no, don't approve", "not allowed", "no, do not allow this"), so #520 can be closed with a test pinning it.

---

Fixes #520.

`resolve_from_reply` tested `_ALLOW_WORDS` before `_DENY_WORDS`, so a refusal phrased around an allow word resolved the one-shot approval as **allow** and released the suspended agent to run the very action the approver refused:

- `[ow:<id>] no, don't approve` → matched `\bapprove\b` first → **allow**
- `[ow:<id>] not allowed` → contains no deny word at all → **allow** (this case isn't covered by the deny-first ordering suggested in #520 — it needs negator handling)

## Change

- Deny words now win on mixed phrasings (deny-first, per the issue's suggested fix).
- An allow word preceded by a negator (`not` / `never` / `-n't`) counts as a refusal, closing the `"not allowed"` class as well.
- Free-text answers to questions are unaffected (`north-east node` still resolves as free text — existing test keeps passing).

## Tests

New `test_negated_denial_is_not_parsed_as_allow` covers the three phrasings from the issue's acceptance criteria (`no, don't approve`, `not allowed`, `no, do not allow this`) — all must never resolve as allow. Full `tests/` suite run locally: the only failures are the pre-existing environmental ones on `main` (slack relay / mcp connector websocket timeouts), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLxsdFGXjdztTRNHjNgPXP