### PR TITLE
security: reject non-https persona git_url before cloning (ext:: RCE / option injection)

### DIFF
--- a/coworker/personas/loading.py
+++ b/coworker/personas/loading.py
@@ -69,13 +69,35 @@ def capability_set(m: PersonaManifest) -> set[str]:
     return caps
 
 
+def validate_git_url(url: str) -> str:
+    """Reject persona URLs that git would treat as a command instead of a fetch.
+
+    Install is meant to be a *light* trust event (a persona ships no executable code), but
+    ``git clone`` runs arbitrary code before that consent gate if the URL is hostile:
+    ``ext::sh -c <cmd>`` executes via the ext transport, and a URL starting with ``-`` is
+    parsed as an option (``--upload-pack=<cmd>``). Allow only ``https://`` so neither reaches
+    git. Returns the URL unchanged when valid; raises ValueError otherwise.
+    """
+    if not isinstance(url, str) or not url.startswith("https://"):
+        raise ValueError("persona git_url must be an https:// URL")
+    return url
+
+
 def git_clone(
     url: str, dest: Path
 ) -> None:  # pragma: no cover - exercised via injection
     """Shallow-clone a persona repo. Injectable so tests don't touch the network."""
+    validate_git_url(url)
     dest.parent.mkdir(parents=True, exist_ok=True)
     subprocess.run(
-        ["git", "clone", "--depth", "1", url, str(dest)],
+        # protocol.*.allow pins the transport to https (blocks ext::/file:/etc. even via a
+        # redirect); "--" ends option parsing so a "-"-leading URL can't become a git flag.
+        [
+            "git",
+            "-c", "protocol.allow=never",
+            "-c", "protocol.https.allow=always",
+            "clone", "--depth", "1", "--", url, str(dest),
+        ],
         check=True,
         capture_output=True,
     )
@@ -95,6 +117,10 @@ def clone_persona_repo(
     url: str, base: Path, *, clone: Callable[[str, Path], None] = git_clone
 ) -> Path:
     """Clone (or reuse) a persona repo under ``base`` and return its directory."""
+    # Validate here too, not just in git_clone: this is the chokepoint every install path
+    # reaches, so a hostile URL is rejected before cache_dir_for/clone even when the caller
+    # injects its own clone. A trusted injected clone (tests) still passes on valid https.
+    validate_git_url(url)
     dest = cache_dir_for(url, base)
     if not dest.is_dir():
         clone(url, dest)

--- a/tests/test_persona_loading.py
+++ b/tests/test_persona_loading.py
@@ -82,6 +82,28 @@ def test_install_from_git_uses_injected_clone(tmp_path):
     assert "acme-ops" in reg.ids()
 
 
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "ext::sh -c 'touch /tmp/pwned'",  # ext transport → command execution at clone time
+        "--upload-pack=touch /tmp/pwned",  # leading "-" → parsed as a git option
+        "-oProxyCommand=touch /tmp/pwned",
+        "file:///etc/passwd",  # non-https transport
+        "git://example.com/x",
+    ],
+)
+def test_install_from_git_rejects_hostile_urls_before_cloning(tmp_path, hostile):
+    reg = PersonaRegistry(state_path=tmp_path / "personas.json")
+    calls: list[str] = []
+
+    def spy_clone(url, dest):  # must never run for a rejected URL
+        calls.append(url)
+
+    with pytest.raises(ValueError):
+        reg.install_from_git(hostile, cache_base=tmp_path / "cache", clone=spy_clone)
+    assert calls == []
+
+
 def test_invalid_third_party_manifest_fails_loud(tmp_path):
     bad = "---\nid: broken\ntools: [does_not_exist]\n---\nbody\n"
     reg = PersonaRegistry(state_path=tmp_path / "personas.json")


### PR DESCRIPTION
Fixes #521.

`POST /v1/personas/install` passed the caller-supplied `git_url` straight to `git clone` with no scheme allowlist, no `--` end-of-options separator, and no `protocol.*` restriction. Git executes arbitrary code **at clone time — before** the install consent gate the module's docstring promises:

- `ext::sh -c '<cmd>'` — the `ext` remote helper runs the "URL" as a command
- `--upload-pack=<cmd>` / `-oProxyCommand=<cmd>` — a `-`-leading URL is parsed as a git option

Standalone this is Medium; it's High in practice because it chains with the same-origin artifact-preview XSS (#518): injected script + stolen API token → this endpoint → RCE.

## Change

- New `validate_git_url()` allows only `https://`. It runs at the `clone_persona_repo` chokepoint, so a hostile URL is rejected **before any clone runs** — even when a caller injects its own clone callable.
- `git_clone` additionally hardens the subprocess as defense-in-depth: `-c protocol.allow=never -c protocol.https.allow=always` pins the transport (blocks `ext::`/`file:`/`git:` even via a redirect), and `--` ends option parsing.
- The `/v1/personas/install` handler already wraps the call in `try/except Exception` → returns `{ok: false, error}`, so rejection surfaces as a clean error, not a 500.

## Tests

New parametrized `test_install_from_git_rejects_hostile_urls_before_cloning` asserts `ext::sh -c …`, `--upload-pack=…`, `-oProxyCommand=…`, `file://`, and `git://` all raise `ValueError` and the clone callable is **never invoked**. Existing `test_install_from_git_uses_injected_clone` (valid https) still passes. Persona suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLxsdFGXjdztTRNHjNgPXP