### PR TITLE
security: validate session_id so transcript paths can't escape conv_dir (Windows traversal)

### DIFF
--- a/coworker/conversations.py
+++ b/coworker/conversations.py
@@ -533,12 +533,18 @@ class ConversationStore:
             self._conn.commit()
 
     def delete(self, session_id: str) -> bool:
+        # Resolve (and validate) the path BEFORE any DB or filesystem mutation so a hostile
+        # id can't unlink a .jsonl outside conv_dir — path.unlink() below runs regardless of
+        # the DB rowcount, which made it an arbitrary-delete primitive.
+        try:
+            path = self._file(session_id)
+        except ValueError:
+            return False
         with self._lock:
             cur = self._conn.execute(
                 "DELETE FROM sessions WHERE session_id = ?", (session_id,)
             )
             self._conn.commit()
-        path = self._file(session_id)
         if path.exists():
             path.unlink()
         return cur.rowcount > 0

--- a/tests/test_conversation_store_paths.py
+++ b/tests/test_conversation_store_paths.py
@@ -1,0 +1,57 @@
+"""ConversationStore transcript paths must stay inside conv_dir.
+
+A client-minted session_id flows straight into ConversationStore._file() from the REST/WS
+routes. Starlette's {session_id} param excludes "/" but not "\\" — a path separator on Windows
+— so "..%5C..%5C.." would escape conv_dir and delete()'s unconditional unlink becomes an
+arbitrary-delete primitive. These tests pin the store-level guard (platform-independent).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from coworker.conversations import ConversationStore
+from coworker.sessions import SessionRecord
+
+HOSTILE_IDS = [
+    "../secret",  # posix separator escapes on Linux/macOS
+    "..\\..\\secret",  # backslash escapes on Windows
+    "sub/evil",  # any embedded separator
+    "a.b",  # "." is disallowed — keeps f"{sid}.jsonl" a single filename
+    "",
+    "x" * 129,  # over the length bound
+]
+
+
+@pytest.mark.parametrize("sid", HOSTILE_IDS)
+def test_file_rejects_ids_that_could_escape_conv_dir(tmp_path, sid):
+    store = ConversationStore(tmp_path)
+    with pytest.raises(ValueError):
+        store._file(sid)
+
+
+def test_delete_with_traversal_id_touches_nothing_and_returns_false(tmp_path):
+    store = ConversationStore(tmp_path)
+    # A transcript-looking file one level above conv_dir (tmp_path/secret.jsonl).
+    secret = tmp_path / "secret.jsonl"
+    secret.write_text("keep me", encoding="utf-8")
+
+    # conv_dir is tmp_path/conversations, so "../secret" resolves to the file above — the
+    # exact arbitrary-delete the unconditional unlink allowed before the fix.
+    assert store.delete("../secret") is False
+    assert secret.exists()  # not unlinked
+
+
+def test_valid_session_id_still_round_trips(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.save(
+        SessionRecord(
+            session_id="__task__task-abc123",
+            workspace=str(tmp_path),
+            model="m",
+            mode="interactive",
+        )
+    )
+    assert store.load("__task__task-abc123") is not None
+    assert store.delete("__task__task-abc123") is True
+    assert store.load("__task__task-abc123") is None


### PR DESCRIPTION
> **Rebased on main (2026-09-01).** Upstream commit 03c4a16 ("Reject path-traversal session ids in the conversation store") already added the `_file()` charset check on main, so that part has been dropped. What remains: `delete()` now validates the id **before** the DB mutation and returns `False` on a hostile id instead of raising after the row delete, plus `tests/test_conversation_store_paths.py` covering the backslash/Windows case and the delete-touches-nothing guarantee from #523.

---

Fixes #523.

`ConversationStore._file` built transcript paths by a raw join of the client-minted `session_id`: `conv_dir / f"{sid}.jsonl"`. Starlette's `{session_id}` route param excludes `/` but **not** `\`, and `\` is a path separator on Windows — so a percent-encoded `..%5C..%5C..` survives routing and `pathlib.WindowsPath` escapes `conv_dir`. `delete()` then called `path.unlink()` **unconditionally** (it runs regardless of the DB rowcount), giving arbitrary deletion of any `.jsonl`-suffixed file; the same id feeds `_append`/`save` as a write primitive. Reachable from the authenticated localhost API (and from the artifact-preview XSS, #518).

## Change

- Validate the id at the `_file` chokepoint — the one path every REST + WS entry (read/count/append/save/delete) funnels through — against `^[A-Za-z0-9_-]{1,128}$`. Every id the app mints matches: `uuid4().hex`, worker `hex[:12]`, `__task__task-…`, `__run__run-…`. The charset admits no separator or `.`, so `f"{sid}.jsonl"` is always a plain filename; a resolved-parent check backs it up as defense in depth.
- `delete()` now resolves (and thus validates) the path **before** any DB delete or `unlink`, returning `False` on an invalid id — a hostile `DELETE` touches neither the DB nor the filesystem.

## Tests

New `tests/test_conversation_store_paths.py`:
- `_file` raises `ValueError` for `../secret`, `..\\..\\secret`, `sub/evil`, `a.b`, empty, and over-length ids.
- `delete("../secret")` returns `False` and leaves a transcript file one level above `conv_dir` **untouched** (the arbitrary-delete reproduction).
- A valid id (`__task__task-abc123`) still saves/loads/deletes normally.

Verified the suite **fails on `main`** (7 failures incl. the arbitrary-delete case) and passes with the fix. Existing ConversationStore-dependent tests (mention router, memory, attachments, server, persona) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLxsdFGXjdztTRNHjNgPXP