### PR TITLE
security: redact tool-result previews in the audit log

### DIFF
--- a/coworker/audit.py
+++ b/coworker/audit.py
@@ -20,7 +20,10 @@ _SECRET_KEYS = (
     "app_token",
     "raw",
 )
-_BODY_KEYS = ("body", "content", "html")
+# Field names whose value is free-form content, not metadata — redacted wholesale. Beyond
+# request bodies this now covers tool OUTPUT fields (shell stdout/stderr can be `cat .env`
+# / `printenv`), so a result preview never replays them into the durable log.
+_BODY_KEYS = ("body", "content", "html", "output", "stdout", "stderr")
 
 
 class AuditStore:
@@ -100,7 +103,9 @@ class AuditStore:
                     event.get("status") or "",
                     event.get("approval") or "",
                     json.dumps(args, default=str),
-                    _truncate(str(event.get("result_preview") or "")),
+                    _result_preview(
+                        tool, event.get("result"), event.get("result_preview")
+                    ),
                     _truncate(str(event.get("reason") or "")),
                     _truncate(str(resource or "")),
                     str(event.get("call_id") or ""),
@@ -187,6 +192,25 @@ class AuditStore:
 
     def close(self) -> None:
         self._conn.close()
+
+
+def _result_preview(tool: str, result: Any, fallback: Any) -> str:
+    """Redact a tool RESULT before it's flattened into the durable preview.
+
+    Results carry the same sensitive payloads the args policy already redacts — email
+    bodies, shell output (``cat .env`` / ``printenv``), connector message text — but the
+    stored preview previously got only ``_truncate()``, so it persisted them in plaintext
+    in the local audit DB (and re-served them via AuditStore.list). Apply the same key
+    policy to the structured result before flattening; only fall back to the caller's
+    pre-flattened preview string when there's no structured result to redact.
+    """
+    if isinstance(result, dict):
+        return _truncate(json.dumps(_sanitize_args(tool, result), default=str))
+    if isinstance(result, list):
+        return _truncate(json.dumps(_summarize(result), default=str))
+    if isinstance(result, str):
+        return _truncate(result)
+    return _truncate(str(fallback or ""))
 
 
 def _sanitize_args(tool: str, args: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_audit_redaction.py
+++ b/tests/test_audit_redaction.py
@@ -1,0 +1,98 @@
+"""The audit log must not persist tool-result content in plaintext.
+
+Arguments were redacted (secret keys, request bodies) but result_preview stored the raw tool
+result with only truncation — leaking email bodies and shell output (cat .env / printenv) into
+the durable local audit DB. These tests pin the result-side redaction.
+"""
+
+from __future__ import annotations
+
+from coworker.audit import AuditStore
+
+
+def _row(store: AuditStore, session_id: str) -> dict:
+    rows = [r for r in store.list(session_id=session_id) if r["stage"] == "finished"]
+    assert rows, "no finished audit row was written"
+    return rows[0]
+
+
+def test_email_body_is_redacted_in_the_preview(tmp_path):
+    store = AuditStore(tmp_path / "audit.db")
+    result = {
+        "ok": True,
+        "from": "attacker@example.com",
+        "subject": "hello",
+        "body": "SECRET-EMAIL-CONTENTS reset your password at https://evil",
+    }
+    store.append(
+        {
+            "session_id": "s1",
+            "tool": "email_read",
+            "stage": "finished",
+            "status": "ok",
+            "result": result,
+            "result_preview": str(result),  # what the engine would have flattened
+        }
+    )
+    preview = _row(store, "s1")["result_preview"]
+    assert "SECRET-EMAIL-CONTENTS" not in preview
+    assert "[redacted body]" in preview
+    store.close()
+
+
+def test_shell_output_is_redacted_in_the_preview(tmp_path):
+    store = AuditStore(tmp_path / "audit.db")
+    result = {
+        "command": "printenv",
+        "exit_code": 0,
+        "output": "AWS_SECRET_ACCESS_KEY=AKIA-TOTALLY-SECRET\nHOME=/root",
+    }
+    store.append(
+        {
+            "session_id": "s2",
+            "tool": "run_shell",
+            "stage": "finished",
+            "status": "ok",
+            "result": result,
+            "result_preview": str(result),
+        }
+    )
+    preview = _row(store, "s2")["result_preview"]
+    assert "AKIA-TOTALLY-SECRET" not in preview
+    assert "[redacted body]" in preview
+    store.close()
+
+
+def test_secret_valued_result_key_is_redacted(tmp_path):
+    store = AuditStore(tmp_path / "audit.db")
+    store.append(
+        {
+            "session_id": "s3",
+            "tool": "some_connector_auth",
+            "stage": "finished",
+            "status": "ok",
+            "result": {"ok": True, "access_token": "xoxb-super-secret"},
+            "result_preview": "{'access_token': 'xoxb-super-secret'}",
+        }
+    )
+    preview = _row(store, "s3")["result_preview"]
+    assert "xoxb-super-secret" not in preview
+    assert "[redacted]" in preview
+    store.close()
+
+
+def test_non_sensitive_result_still_visible_for_triage(tmp_path):
+    store = AuditStore(tmp_path / "audit.db")
+    store.append(
+        {
+            "session_id": "s4",
+            "tool": "list_issues",
+            "stage": "finished",
+            "status": "ok",
+            "result": {"ok": True, "count": 3, "url": "https://example.com/x"},
+            "result_preview": "{'ok': True, 'count': 3}",
+        }
+    )
+    preview = _row(store, "s4")["result_preview"]
+    assert "count" in preview and "3" in preview  # metadata survives
+    store.close()


### PR DESCRIPTION
Fixes #525.

The audit log redacts tool **arguments** (secret keys → `[redacted]`, body keys → `[redacted body]`) but stored `result_preview` with `_truncate()` and **no** redaction. Tool results routinely contain exactly what the args policy hides:

- `email_read` → full plaintext `body`
- `run_shell` → raw `output` (`cat .env` / `printenv` → API keys, credentials)
- connector reads → private message text

So secrets persisted in plaintext in the local SQLite audit DB and were re-served via `AuditStore.list()`. This defeats the module's own redaction policy.

## Change

- New `_result_preview(tool, result, fallback)` runs the **structured** result through the same key policy (`_sanitize_args`) **before** flattening — using the raw `result` dict the engine already passes alongside `result_preview`. Falls back to the pre-flattened string only when there's no structured result (approval/mode-change events, which carry neither).
- Extend `_BODY_KEYS` with `output`/`stdout`/`stderr`. Shell results use the key `output`, which the existing body-key set (`body`/`content`/`html`) would have **missed** — so the fix the issue suggests (`_sanitize_args(result)`) alone wouldn't redact `printenv`; this closes that gap.
- Non-sensitive metadata (counts, urls, status) still shows, preserving the preview's operator-triage value.

## Tests

New `tests/test_audit_redaction.py`: email body, shell `output`, and a secret-valued result key must not appear in the stored preview (`[redacted body]` / `[redacted]` instead); a benign result stays visible. Verified the sensitive-case tests **fail on `main`** and pass with the fix; existing audit/reviewer-stats/migration tests and the engine/shell/email suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLxsdFGXjdztTRNHjNgPXP