### PR TITLE
toolchain: add linux_arm64 builds for gitleaks, trivy and osv-scanner

### DIFF
--- a/coworker/toolchain.py
+++ b/coworker/toolchain.py
@@ -117,6 +117,11 @@ MANAGED: dict[str, ManagedTool] = {
                 sha256="551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb",
                 member="gitleaks",
             ),
+            "linux_arm64": Download(
+                url="https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_arm64.tar.gz",
+                sha256="e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080",
+                member="gitleaks",
+            ),
         },
     ),
     "trivy": ManagedTool(
@@ -139,6 +144,11 @@ MANAGED: dict[str, ManagedTool] = {
                 sha256="2ae6fe3ee734b7fdf11335663e18c75ea12dccc76062f09f164a3b0f8be4371a",
                 member="trivy",
             ),
+            "linux_arm64": Download(
+                url="https://github.com/aquasecurity/trivy/releases/download/v0.74.0/trivy_0.74.0_Linux-ARM64.tar.gz",
+                sha256="b94ce1976bbf3c15b514b605ee88be7c6d94a29be2302847ff01cb794d47aad5",
+                member="trivy",
+            ),
         },
     ),
     "osv-scanner": ManagedTool(
@@ -157,6 +167,10 @@ MANAGED: dict[str, ManagedTool] = {
             "linux_amd64": Download(
                 url="https://github.com/google/osv-scanner/releases/download/v2.5.0/osv-scanner_linux_amd64",
                 sha256="edcfc41d257db36148f065055655fe3fcfc434b0b423ea67468a84c207524e0c",
+            ),
+            "linux_arm64": Download(
+                url="https://github.com/google/osv-scanner/releases/download/v2.5.0/osv-scanner_linux_arm64",
+                sha256="fe152e1a546af223e6c557cc3111a8bb3e5dc02fcbf7dbe95d26567c0f0041f2",
             ),
         },
     ),


### PR DESCRIPTION
`MANAGED` lists `gitleaks`, `trivy` and `osv-scanner`, but each `downloads` map carries
only `darwin_arm64`, `darwin_amd64` and `linux_amd64`. `_platform_key()` maps `aarch64` →
`arm64`, so on Linux ARM64:

```
platform: Linux aarch64
MANAGED: ['gitleaks', 'osv-scanner', 'trivy']
  describe(gitleaks) -> None
  describe(trivy) -> None
  describe(osv-scanner) -> None
```

With `describe()` returning `None`, `_run_tool_request` takes the
`elif _toolchain.describe(name) is None` branch added in 1e564d5 and returns
*"'gitleaks' is not in the pinned tool catalog"* **without ever emitting
`TOOL_REQUESTED`**. The install card is unreachable, and an agent that needs one of these
scanners is told the tool cannot be installed — on a platform where all three are, in
fact, published.

That is the silent-gap failure OPE-85 exists to prevent: *"A missing tool must become a
visible decision, never an invisible gap."* On ARM64 Linux it is currently an invisible
gap.

## Also fails three tests on that platform

```
tests/test_tool_request.py::test_emits_tool_requested_and_reports_install
tests/test_tool_request.py::test_declining_tells_the_agent_to_fall_back_openly
tests/test_tool_request.py::test_decline_recheck_finds_a_copy_the_user_installed_themselves
```

Each asserts a `TOOL_REQUESTED` event that the catalog gap prevents from being emitted.
They pass on x64, which is why CI has not surfaced this — the matrix does not currently
build on ARM64 Linux (cf. #218).

## The change

Purely additive: one `linux_arm64` entry per tool, no logic touched.

Every checksum below was produced by downloading the asset and running it on `aarch64` —
none is copied from a release page:

| Tool | Version | `file` output | `--version` |
|---|---|---|---|
| gitleaks | 8.30.1 | `ELF 64-bit LSB executable, ARM aarch64` | `8.30.1` |
| trivy | 0.74.0 | `ELF 64-bit LSB executable, ARM aarch64` | `Version: 0.74.0` |
| osv-scanner | 2.5.0 | `ELF 64-bit LSB executable, ARM aarch64` | `osv-scanner version: 2.5.0` |

Asset naming differs per project and is preserved exactly as each publishes it —
`gitleaks_8.30.1_linux_arm64.tar.gz`, `trivy_0.74.0_Linux-ARM64.tar.gz`, and a bare
`osv-scanner_linux_arm64` binary. osv-scanner ships an unarchived binary, so its entry has
no `member=`, consistent with its existing `darwin_*`/`linux_amd64` entries.

## After

```
describe(gitleaks) -> 8.30.1   describe(trivy) -> 0.74.0   describe(osv-scanner) -> 2.5.0
```

Backend suite on aarch64: **4189 passed, 1 skipped, 0 failed** (was `3 failed`).

Tested on Linux aarch64 (Ubuntu, Python 3.12). No change in behaviour on any existing
platform — the three new keys are only reachable when `_platform_key()` returns
`linux_arm64`.
