### PR TITLE
Add advanced OAuth client settings for custom MCP servers

### DIFF
--- a/coworker/mcp/config.py
+++ b/coworker/mcp/config.py
@@ -36,7 +36,8 @@ class MCPServerDef:
     include_tools: Optional[list[str]] = None
     exclude_tools: Optional[list[str]] = None
     requires_approval: bool = True
-    # "oauth" → browser OAuth 2.1 + PKCE with Dynamic Client Registration (mcp/oauth.py).
+    # "oauth" → browser OAuth 2.1 + PKCE, using DCR or a pre-registered client
+    # configured through the local secret store (mcp/oauth.py).
     # HTTP transport only; tokens live in the SecretStore, never in this file.
     auth: Optional[str] = None
 

--- a/coworker/mcp/oauth.py
+++ b/coworker/mcp/oauth.py
@@ -11,9 +11,11 @@ streamable-HTTP transport. We supply its three integration points:
     single-slot pending future (one interactive sign-in at a time — the flow is
     user-driven, so concurrency is meaningless)
 
-DCR means there is no client id/secret registered anywhere up front — nothing for the
-ocw-connect broker to hold, so unlike the managed connectors this flow is fully local.
-First server: Granola (https://mcp.granola.ai/mcp).
+Servers that support DCR need no credentials up front. Servers that require a
+pre-registered OAuth application can instead take a client id/secret from the UI;
+those credentials live beside the tokens in the SecretStore, never in mcp.json.
+The whole flow remains local. First curated server: Granola
+(https://mcp.granola.ai/mcp).
 """
 
 from __future__ import annotations
@@ -38,6 +40,7 @@ CALLBACK_PATH = "/mcp/oauth/callback"
 FLOW_TIMEOUT_SECONDS = 300
 
 CLIENT_NAME = "OpenWorker"
+TOKEN_AUTH_METHODS = {"none", "client_secret_basic", "client_secret_post"}
 
 
 def redirect_base() -> str:
@@ -114,6 +117,66 @@ class SecretStoreTokenStorage(TokenStorage):
 
     async def set_client_info(self, info: OAuthClientInformationFull) -> None:
         self._merge({"client_info": info.model_dump(mode="json", exclude_none=True)})
+
+
+def configure_client(
+    server_name: str,
+    secrets: SecretStore,
+    *,
+    client_id: str,
+    client_secret: str = "",
+    token_endpoint_auth_method: str = "",
+) -> None:
+    """Store a pre-registered OAuth client without exposing it through mcp.json/REST.
+
+    Replacing client credentials invalidates any tokens minted for the old client, so
+    only authorization-server discovery metadata is retained. A secret defaults to
+    HTTP Basic token-endpoint auth; a public client defaults to ``none``. Providers
+    that require the secret in the form body can explicitly select
+    ``client_secret_post`` in Advanced settings.
+    """
+    client_id = client_id.strip()
+    client_secret = client_secret.strip()
+    if not client_id:
+        raise ValueError("OAuth client ID is required")
+    method = token_endpoint_auth_method.strip() or (
+        "client_secret_basic" if client_secret else "none"
+    )
+    if method not in TOKEN_AUTH_METHODS:
+        raise ValueError("unsupported OAuth token authentication method")
+    if method != "none" and not client_secret:
+        raise ValueError(
+            "OAuth client secret is required for the selected authentication method"
+        )
+    if method == "none" and client_secret:
+        raise ValueError("OAuth public clients cannot use a client secret")
+
+    info = OAuthClientInformationFull.model_validate(
+        {
+            "client_id": client_id,
+            "client_secret": client_secret or None,
+            "redirect_uris": [redirect_base() + CALLBACK_PATH],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": method,
+            "client_name": CLIENT_NAME,
+        }
+    )
+    old = secrets.get(_profile(server_name)) or {}
+    profile: dict[str, Any] = {
+        "client_source": "preregistered",
+        "client_info": info.model_dump(mode="json", exclude_none=True),
+    }
+    if old.get("oauth_metadata"):
+        profile["oauth_metadata"] = old["oauth_metadata"]
+    secrets.put(_profile(server_name), profile)
+
+
+def has_preregistered_client(server_name: str, secrets: SecretStore) -> bool:
+    data = secrets.get(_profile(server_name)) or {}
+    return data.get("client_source") == "preregistered" and bool(
+        (data.get("client_info") or {}).get("client_id")
+    )
 
 
 class InteractiveAuthRequired(RuntimeError):
@@ -345,5 +408,21 @@ def has_tokens(server_name: str, secrets: SecretStore) -> bool:
 
 
 def sign_out(server_name: str, secrets: SecretStore) -> bool:
-    """Forget tokens AND the DCR registration; next connect runs a fresh flow."""
+    """Forget tokens; keep a user-supplied client, but discard a DCR registration."""
+    data = secrets.get(_profile(server_name)) or {}
+    if data.get("client_source") == "preregistered" and data.get("client_info"):
+        had_tokens = bool(data.get("tokens"))
+        keep = {
+            "client_source": "preregistered",
+            "client_info": data["client_info"],
+        }
+        if data.get("oauth_metadata"):
+            keep["oauth_metadata"] = data["oauth_metadata"]
+        secrets.put(_profile(server_name), keep)
+        return had_tokens
+    return secrets.delete(_profile(server_name))
+
+
+def forget_server(server_name: str, secrets: SecretStore) -> bool:
+    """Delete tokens and every client registration when the server itself is removed."""
     return secrets.delete(_profile(server_name))

--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -1183,7 +1183,16 @@ def create_app(manager: SessionManager) -> FastAPI:
         config = body.get("config")
         if not name or not isinstance(config, dict):
             return {"ok": False, "error": "name and config required"}
-        return manager.add_mcp(name, config)
+        oauth_client = body.get("oauth_client")
+        if oauth_client is not None and not isinstance(oauth_client, dict):
+            return {"ok": False, "error": "oauth_client must be an object"}
+        return manager.add_mcp(name, config, oauth_client)
+
+    @app.get("/v1/mcp/oauth-info")
+    def mcp_oauth_info() -> dict[str, Any]:
+        from ..mcp import oauth as mcp_oauth
+
+        return {"redirect_uri": mcp_oauth.redirect_base() + mcp_oauth.CALLBACK_PATH}
 
     @app.patch("/v1/mcp/{name}")
     def mcp_patch(name: str, body: dict) -> dict[str, Any]:

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -1389,6 +1389,9 @@ class SessionManager:
                     ),
                     "requires_approval": bool(raw.get("requires_approval", True)),
                     "auth": "oauth" if is_oauth else None,
+                    "oauth_client_configured": mcp_oauth.has_preregistered_client(
+                        name, self.secrets
+                    ),
                     "status": status,
                     "auth_hint": name in self._mcp_auth_hints,
                     "last_test_at": self._prefs.get("mcp_last_test", {}).get(name),
@@ -1507,7 +1510,28 @@ class SessionManager:
         removed = mcp_oauth.sign_out(name, self.secrets)
         return {"ok": True, "had_tokens": removed}
 
-    def add_mcp(self, name: str, config: dict[str, Any]) -> dict[str, Any]:
+    def add_mcp(
+        self,
+        name: str,
+        config: dict[str, Any],
+        oauth_client: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        if oauth_client:
+            from ..mcp import oauth as mcp_oauth
+
+            try:
+                mcp_oauth.configure_client(
+                    name,
+                    self.secrets,
+                    client_id=str(oauth_client.get("client_id") or ""),
+                    client_secret=str(oauth_client.get("client_secret") or ""),
+                    token_endpoint_auth_method=str(
+                        oauth_client.get("token_endpoint_auth_method") or ""
+                    ),
+                )
+            except ValueError as exc:
+                return {"ok": False, "error": str(exc)}
+            config = {**config, "auth": "oauth"}
         put_global_server(name, config)
         return {"ok": True, "name": name}
 
@@ -1537,7 +1561,7 @@ class SessionManager:
                     conn.shutdown.set()
             from ..mcp import oauth as mcp_oauth
 
-            mcp_oauth.sign_out(name, self.secrets)
+            mcp_oauth.forget_server(name, self.secrets)
         return {"ok": ok, "name": name}
 
     async def mcp_tools(self, name: str) -> dict[str, Any]:

--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -2122,6 +2122,9 @@ export async function mockApi(page: import("@playwright/test").Page) {
     }
     // MCP servers — mutable so the OAuth quick-add (granola) flow reflects through the
     // UI: add → needs_auth, connect → authorizing, next poll → connected (6 tools).
+    if (p.endsWith("/v1/mcp/oauth-info") && m === "GET") {
+      return json({ redirect_uri: "http://127.0.0.1:8765/mcp/oauth/callback" });
+    }
     if (p.endsWith("/v1/mcp") && m === "GET") {
       for (const s2 of mcpServers) {
         if (s2.status === "authorizing" && s2._flip) {
@@ -2149,6 +2152,7 @@ export async function mockApi(page: import("@playwright/test").Page) {
         transport: b.config?.url ? "http" : "stdio",
         requires_approval: true,
         auth: b.config?.auth === "oauth" ? "oauth" : null,
+        oauth_client_configured: !!b.oauth_client?.client_id,
         status: b.config?.auth === "oauth" ? "needs_auth" : "configured",
         auth_hint: false,
         last_test_at: null,

--- a/surfaces/gui/e2e/mcp-add-test.spec.ts
+++ b/surfaces/gui/e2e/mcp-add-test.spec.ts
@@ -54,6 +54,29 @@ test("guarded server: 401 → Needs sign-in chip → OAuth switch on the detail 
   await expect(detail).toContainText("Live", { timeout: 10_000 });
 });
 
+test("advanced OAuth credentials are accepted without exposing the secret", async ({ page }) => {
+  await openConnectors(page);
+  await page.getByTestId("add-custom-server").click();
+  const modal = page.getByTestId("add-mcp-modal");
+  await modal.getByTestId("mcp-add-name").fill("private-crm");
+  await modal.getByTestId("mcp-add-url").fill("https://mcp.private.example/mcp");
+  await modal.getByTestId("mcp-add-advanced-toggle").click();
+  await expect(modal.getByTestId("mcp-add-redirect-uri")).toContainText(
+    "/mcp/oauth/callback",
+  );
+  await modal.getByTestId("mcp-add-client-id").fill("client-123");
+  await modal.getByTestId("mcp-add-client-secret").fill("secret-456");
+  await modal.getByTestId("mcp-add-token-auth").selectOption("client_secret_post");
+  await modal.getByRole("button", { name: "Add & sign in" }).click();
+
+  const row = page.getByTestId("mcp-row-private-crm");
+  await expect(row).toContainText("Live", { timeout: 10_000 });
+  await row.click();
+  const detail = page.getByTestId("mcp-detail-private-crm");
+  await expect(detail.getByTestId("mcp-oauth-client-configured")).toBeVisible();
+  await expect(detail).not.toContainText("secret-456");
+});
+
 test("JSON tab adds stdio as Not tested; detail Test flips it to Live", async ({ page }) => {
   await openConnectors(page);
   await page.getByTestId("add-custom-server").click();

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -457,6 +457,9 @@ export interface McpServer {
   // "needs_auth" (no tokens yet) | "authorizing" (browser sign-in in flight)
   status: string;
   auth?: "oauth" | null;
+  // A pre-registered client id/secret exists in the local SecretStore. Values are
+  // deliberately never returned to the UI after save.
+  oauth_client_configured?: boolean;
   // http server whose anonymous connect hit a 401/403 — offer OAuth sign-in.
   auth_hint?: boolean;
   // Epoch seconds of the last successful explicit Test (persisted server-side).
@@ -471,11 +474,26 @@ export async function getMcpServers(): Promise<McpServer[]> {
   return (await res.json()).servers ?? [];
 }
 
-export async function addMcpServer(name: string, config: Record<string, any>) {
+export interface McpOAuthClientInput {
+  client_id: string;
+  client_secret?: string;
+  token_endpoint_auth_method?: "client_secret_basic" | "client_secret_post" | "none" | "";
+}
+
+export async function getMcpOAuthInfo(): Promise<{ redirect_uri: string }> {
+  const res = await fetch(`${httpBase()}/v1/mcp/oauth-info`);
+  return res.json();
+}
+
+export async function addMcpServer(
+  name: string,
+  config: Record<string, any>,
+  oauthClient?: McpOAuthClientInput,
+) {
   const res = await fetch(`${httpBase()}/v1/mcp`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name, config }),
+    body: JSON.stringify({ name, config, ...(oauthClient ? { oauth_client: oauthClient } : {}) }),
   });
   return res.json();
 }

--- a/surfaces/gui/src/components/connectors/CustomMcp.tsx
+++ b/surfaces/gui/src/components/connectors/CustomMcp.tsx
@@ -3,6 +3,7 @@ import {
   addMcpServer,
   connectMcp,
   deleteMcpServer,
+  getMcpOAuthInfo,
   getMcpTools,
   patchMcpServer,
   signoutMcp,
@@ -197,6 +198,11 @@ export function AddMcpModal({
   const [name, setName] = useState("");
   const [url, setUrl] = useState("");
   const [text, setText] = useState(EXAMPLE);
+  const [advanced, setAdvanced] = useState(false);
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [tokenAuth, setTokenAuth] = useState<"" | "client_secret_basic" | "client_secret_post" | "none">("");
+  const [redirectUri, setRedirectUri] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -204,6 +210,13 @@ export function AddMcpModal({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
+
+  useEffect(() => {
+    if (!advanced || redirectUri) return;
+    getMcpOAuthInfo()
+      .then((info) => setRedirectUri(info.redirect_uri || ""))
+      .catch(() => setRedirectUri(""));
+  }, [advanced, redirectUri]);
 
   const saveUrl = async () => {
     setError(null);
@@ -217,7 +230,27 @@ export function AddMcpModal({
       setError("Enter the server's full URL (https://…).");
       return;
     }
-    await addMcpServer(n, { type: "http", url: u });
+    const id = clientId.trim();
+    if (clientSecret && !id) {
+      setError("Enter the OAuth client ID that belongs with this secret.");
+      return;
+    }
+    const oauthClient = id
+      ? {
+          client_id: id,
+          client_secret: clientSecret,
+          token_endpoint_auth_method: tokenAuth,
+        }
+      : undefined;
+    const result = await addMcpServer(
+      n,
+      { type: "http", url: u, ...(oauthClient ? { auth: "oauth" } : {}) },
+      oauthClient,
+    );
+    if (!result.ok) {
+      setError(result.error || "Could not save this MCP server.");
+      return;
+    }
     // Probe anonymously right away — the row shows Testing…, then Live, an
     // error, or Needs sign-in (401 → the OAuth switch on the detail page).
     await connectMcp(n);
@@ -298,6 +331,67 @@ export function AddMcpModal({
               className={INPUT + " font-mono text-[12px]"}
               data-testid="mcp-add-url"
             />
+            <button
+              type="button"
+              className="text-[12px] text-muted hover:text-ink flex items-center gap-1.5 w-fit"
+              onClick={() => setAdvanced((v) => !v)}
+              data-testid="mcp-add-advanced-toggle"
+              aria-expanded={advanced}
+            >
+              <span className="text-[10px]">{advanced ? "▾" : "▸"}</span>
+              Advanced OAuth settings
+            </button>
+            {advanced && (
+              <div
+                className="rounded-lg border border-line bg-paper/50 px-3 py-3 space-y-2.5"
+                data-testid="mcp-add-advanced"
+              >
+                <div className="text-[12px] text-muted">
+                  For servers that require a pre-registered OAuth application. Leave blank to
+                  use automatic client registration.
+                </div>
+                <input
+                  value={clientId}
+                  onChange={(e) => setClientId(e.target.value)}
+                  placeholder="OAuth client ID"
+                  spellCheck={false}
+                  autoComplete="off"
+                  className={INPUT + " font-mono text-[12px]"}
+                  data-testid="mcp-add-client-id"
+                />
+                <input
+                  type="password"
+                  value={clientSecret}
+                  onChange={(e) => setClientSecret(e.target.value)}
+                  placeholder="OAuth client secret (optional for public clients)"
+                  spellCheck={false}
+                  autoComplete="new-password"
+                  className={INPUT + " font-mono text-[12px]"}
+                  data-testid="mcp-add-client-secret"
+                />
+                <select
+                  value={tokenAuth}
+                  onChange={(e) => setTokenAuth(e.target.value as typeof tokenAuth)}
+                  className={INPUT}
+                  data-testid="mcp-add-token-auth"
+                >
+                  <option value="">Token authentication: automatic</option>
+                  <option value="client_secret_basic">Client secret: HTTP Basic</option>
+                  <option value="client_secret_post">Client secret: request body</option>
+                  <option value="none">Public client: no secret</option>
+                </select>
+                <div className="text-[11px] text-faint leading-relaxed">
+                  Register this callback URL with the OAuth provider:
+                  <code
+                    className="block mt-1 font-mono text-[11px] text-muted break-all select-all"
+                    data-testid="mcp-add-redirect-uri"
+                  >
+                    {redirectUri || "Loading callback URL…"}
+                  </code>
+                  The secret is saved only in OpenWorker's local secret store, never in MCP JSON.
+                </div>
+              </div>
+            )}
           </>
         ) : (
           <>
@@ -313,7 +407,7 @@ export function AddMcpModal({
         )}
         <div className="flex items-center gap-3">
           <button className={PILL_ACCENT} onClick={tab === "url" ? saveUrl : saveJson}>
-            {tab === "url" ? "Add & test" : "Add"}
+            {tab === "url" ? (clientId.trim() ? "Add & sign in" : "Add & test") : "Add"}
           </button>
           <button className="text-[13px] text-muted hover:text-ink" onClick={onClose}>
             cancel
@@ -461,6 +555,11 @@ export function McpServerDetail({
       <div className={GRP}>
         <div className="px-4 py-3">
           <div className="text-[12px] font-semibold text-muted mb-1.5">Configuration</div>
+          {server.oauth_client_configured && (
+            <div className="text-[12px] text-muted mb-2" data-testid="mcp-oauth-client-configured">
+              OAuth client credentials saved in the local secret store.
+            </div>
+          )}
           <pre className="font-mono text-[12px] text-muted whitespace-pre-wrap break-all">
             {JSON.stringify(server.config, null, 2)}
           </pre>

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -85,6 +85,69 @@ def test_token_storage_roundtrip(tmp_path, monkeypatch):
     assert not mcp_oauth.has_tokens("granola", secrets)
 
 
+def test_preregistered_client_is_secret_stored_and_survives_signout(tmp_path, monkeypatch):
+    _state(tmp_path, monkeypatch)
+    secrets = SecretStore()
+    mcp_oauth.configure_client(
+        "private",
+        secrets,
+        client_id="client-123",
+        client_secret="secret-456",
+        token_endpoint_auth_method="client_secret_post",
+    )
+    secrets.put(
+        "mcp-oauth:private",
+        {
+            **(secrets.get("mcp-oauth:private") or {}),
+            "tokens": {"access_token": "at"},
+        },
+    )
+
+    storage = mcp_oauth.SecretStoreTokenStorage("private", secrets)
+    info = asyncio.run(storage.get_client_info())
+    assert info.client_id == "client-123"
+    assert info.client_secret == "secret-456"
+    assert info.token_endpoint_auth_method == "client_secret_post"
+    assert str(info.redirect_uris[0]).endswith("/mcp/oauth/callback")
+    assert mcp_oauth.has_preregistered_client("private", secrets)
+
+    assert mcp_oauth.sign_out("private", secrets) is True
+    assert not mcp_oauth.has_tokens("private", secrets)
+    assert mcp_oauth.has_preregistered_client("private", secrets)
+    assert mcp_oauth.forget_server("private", secrets) is True
+    assert secrets.get("mcp-oauth:private") is None
+
+
+def test_preregistered_client_defaults_and_validation(tmp_path, monkeypatch):
+    _state(tmp_path, monkeypatch)
+    secrets = SecretStore()
+
+    mcp_oauth.configure_client("public", secrets, client_id="public-id")
+    info = asyncio.run(
+        mcp_oauth.SecretStoreTokenStorage("public", secrets).get_client_info()
+    )
+    assert info.token_endpoint_auth_method == "none"
+    assert info.client_secret is None
+
+    with pytest.raises(ValueError, match="client ID"):
+        mcp_oauth.configure_client("bad", secrets, client_id="")
+    with pytest.raises(ValueError, match="client secret"):
+        mcp_oauth.configure_client(
+            "bad",
+            secrets,
+            client_id="id",
+            token_endpoint_auth_method="client_secret_basic",
+        )
+    with pytest.raises(ValueError, match="public clients"):
+        mcp_oauth.configure_client(
+            "bad",
+            secrets,
+            client_id="id",
+            client_secret="must-not-be-stored",
+            token_endpoint_auth_method="none",
+        )
+
+
 # -- callback plumbing -----------------------------------------------------------
 
 
@@ -151,6 +214,38 @@ def test_list_mcp_oauth_statuses(tmp_path, monkeypatch):
     assert client.post("/v1/mcp/granola/signout").json()["ok"] is True
     assert not mcp_oauth.has_tokens("granola", manager.secrets)
     assert client.get("/v1/mcp").json()["servers"][0]["status"] == "needs_auth"
+
+
+def test_add_mcp_stores_oauth_secret_outside_config(tmp_path, monkeypatch):
+    _state(tmp_path, monkeypatch)
+    manager = SessionManager(data_dir=tmp_path / "data")
+    client = TestClient(create_app(manager))
+
+    response = client.post(
+        "/v1/mcp",
+        json={
+            "name": "private",
+            "config": {"type": "http", "url": "https://mcp.example/mcp"},
+            "oauth_client": {
+                "client_id": "client-id",
+                "client_secret": "client-secret",
+            },
+        },
+    ).json()
+    assert response["ok"] is True
+
+    raw = json.loads((tmp_path / "state" / "mcp.json").read_text())
+    saved = raw["mcpServers"]["private"]
+    assert saved["auth"] == "oauth"
+    assert "client_id" not in json.dumps(saved)
+    assert "client-secret" not in json.dumps(saved)
+
+    row = client.get("/v1/mcp").json()["servers"][0]
+    assert row["oauth_client_configured"] is True
+    assert "client-secret" not in json.dumps(row)
+    assert client.get("/v1/mcp/oauth-info").json()["redirect_uri"].endswith(
+        "/mcp/oauth/callback"
+    )
 
 
 def test_connect_endpoint_starts_background_flow(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- add Advanced OAuth client ID and client secret settings to the custom remote MCP dialog
- show the exact local callback URL that must be registered with the OAuth provider
- support `client_secret_basic`, `client_secret_post`, and public OAuth clients
- store credentials only in the local secret store, excluding them from `mcp.json` and REST responses
- preserve pre-registered client credentials across sign-out and remove them when the connector is deleted

## Validation

- `.venv/bin/pytest tests/test_mcp_oauth.py tests/test_mcp.py -q` (35 passed)
- `npm run build`
- `npx playwright test e2e/mcp-add-test.spec.ts` (5 passed)