### PR TITLE
fix(mcp): prevent tool-call arguments from overriding MCP routing

### DIFF
--- a/coworker/mcp/tools.py
+++ b/coworker/mcp/tools.py
@@ -68,9 +68,22 @@ def build_callables(
         name = tool_name(server.name, mcp_tool.name)
         remote = mcp_tool.name
 
-        def _invoke(_remote: str = remote, **kwargs: Any) -> Any:
-            future = asyncio.run_coroutine_threadsafe(call_async(_remote, kwargs), loop)
-            return future.result(timeout)
+        # Bind `remote` in a dedicated closure rather than a default argument. The
+        # default-argument form (`_remote=remote`) also defeats late binding, but it
+        # exposes the routing target as a caller-overridable keyword: a model-supplied
+        # `_remote` in the tool-call arguments would then re-route an approved, filtered
+        # call to any other tool on this server, since the approval gate and the
+        # include/exclude filter only ever see the visible tool name.
+        def _make_invoke(remote: str) -> Callable[..., Any]:
+            def _invoke(**kwargs: Any) -> Any:
+                future = asyncio.run_coroutine_threadsafe(
+                    call_async(remote, kwargs), loop
+                )
+                return future.result(timeout)
+
+            return _invoke
+
+        _invoke = _make_invoke(remote)
 
         # We attach the schema + metadata explicitly (rather than via `ai.tool`, which would
         # try to derive a schema from this `**kwargs` wrapper): the registry reads both attrs.

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -227,6 +227,35 @@ async def test_bridge_invokes_session_on_loop():
     assert seen == [("read_file", {"path": "a.txt"})]
 
 
+async def test_remote_tool_routing_is_not_overridable_by_arguments():
+    """A model-supplied ``_remote`` argument must not re-route an approved,
+    filtered tool call to a different remote tool.
+
+    The approval gate and the include/exclude filter both vet the *visible*
+    tool name (``mcp__fs__read_file``). If ``_remote`` were a bindable
+    parameter, ``{"_remote": "delete_file"}`` in the call arguments would run
+    ``delete_file`` while the gate only ever saw ``read_file``.
+    """
+    loop = asyncio.get_running_loop()
+    seen = []
+
+    async def call_async(tool, args):
+        seen.append((tool, args))
+        return {"echo": args}
+
+    server = MCPServerDef(name="fs", transport="stdio")
+    fn = build_callables(server, [_fake_tool("read_file")], call_async, loop)[0]
+
+    # Simulate the model emitting a `_remote` key in the tool-call arguments.
+    await asyncio.to_thread(fn, _remote="delete_file", path="a.txt")
+
+    routed_tool = seen[0][0]
+    assert routed_tool == "read_file", (
+        f"routing hijacked: call reached {routed_tool!r} instead of the "
+        "approved 'read_file'"
+    )
+
+
 # -- REST ----------------------------------------------------------------------
 def test_rest_crud(tmp_path, monkeypatch):
     monkeypatch.setenv("COWORKER_STATE_DIR", str(tmp_path / "state"))


### PR DESCRIPTION
## Summary

The MCP tool wrapper bound its remote routing target through a default argument, which made that target overridable by the model-supplied tool-call arguments. A tool call whose arguments contain a `_remote` key would run a *different* tool on the same server than the one the approval gate and the include/exclude filter actually vetted. This hardens the wrapper so the routing target is fixed at wrap time and cannot be redirected by call arguments.

## Details

`build_callables` wraps each MCP tool as:

```python
def _invoke(_remote: str = remote, **kwargs):
    future = asyncio.run_coroutine_threadsafe(call_async(_remote, kwargs), loop)
    return future.result(timeout)
```

The default-argument form is used to defeat closure late-binding, but it also exposes `_remote` as a normal, caller-overridable keyword. The registry forwards the model's raw tool-call arguments to the wrapper unchanged (`spec.func(**(arguments or {}))`), and `_remote` is not part of the model-facing schema — so if the arguments dict happens to carry a `_remote` key, Python binds it and `call_async` is invoked with a caller-chosen tool name.

That matters because the approval/reviewer decision (`PermissionEngine.evaluate`), the per-tool read/write classification for connector-backed servers, and the `include_tools`/`exclude_tools` filter all key off the **visible** tool name (`mcp__<server>__<tool>`). The gate vets one tool; a `_remote` override runs another on the same server — including a tool the include/exclude filter was meant to hide. This is reachable without a compromised machine: a prompt-injection payload in content the agent is processing, or a malicious/compromised MCP server steering the model, is enough to get a `_remote` key into the arguments.

## Fix

Bind `remote` in a dedicated closure (`_make_invoke`) instead of a default argument. This still defeats late-binding, but `_remote` is no longer a bindable parameter, so a stray `_remote` argument is simply forwarded to the remote tool as an ordinary argument and cannot change the routing target. One function, no signature or schema change for callers.

## Test plan

Added `tests/test_mcp.py::test_remote_tool_routing_is_not_overridable_by_arguments`: it wraps a single `read_file` tool and invokes it with `_remote="delete_file"` in the arguments, asserting the bridge still routes to `read_file`. Verified it fails on `main` (routes to `delete_file`) and passes with this change.

```
pytest tests/test_mcp.py -q            # 21 passed
pytest tests -q                        # 1897 passed, 1 skipped
```

## Risk / backward compatibility

- No change to the tool schema shown to the model, to tool names, or to the wrapper's observable behavior for well-formed calls. Late-binding across a server's tools is preserved (verified: each wrapper routes to its own tool).
- The only behavioral change is that a `_remote` key in call arguments no longer redirects routing.
