### PR TITLE
models: add Claude Opus 5 for Anthropic

### DIFF
--- a/coworker/providers/matrix.py
+++ b/coworker/providers/matrix.py
@@ -107,8 +107,11 @@ MATRIX: dict[str, ModelEntry] = {
     "openai-codex:gpt-5.1-codex-mini": ModelEntry(
         "GPT-5.1 Codex Mini · ChatGPT plan", _AGENTIC, 400_000
     ),
-    # Fable 5 (2026-06-09) is GA; its Mythos 5 sibling is approved-orgs-only, so it
-    # stays out of a picker meant for the public.
+    # Opus 5 (2026-07-24) and Fable 5 (2026-06-09) are GA with 1M context. Their
+    # Mythos 5 sibling is approved-orgs-only, so it stays out of the public picker.
+    "anthropic:claude-opus-5": ModelEntry(
+        "Claude Opus 5 · Anthropic", _AGENTIC_VISION, 1_000_000
+    ),
     "anthropic:claude-fable-5": ModelEntry(
         "Claude Fable 5 · Anthropic", _AGENTIC_VISION, 1_000_000
     ),

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -541,7 +541,12 @@ def test_thinking_config_is_model_family_aware():
     """API drift (owner-hit 2026-07-23): budget_tokens 400s on the Claude 5/4.7+ family
     ('use thinking.type.adaptive'); older models still need enabled+budget. display
     must be summarized on the new family or the trace text arrives empty."""
-    for model in ("claude-fable-5", "claude-opus-4-8", "claude-sonnet-4-6"):
+    for model in (
+        "claude-opus-5",
+        "claude-fable-5",
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+    ):
         client = _FakeClient(response=_text_response())
         AnthropicProvider(client=client, thinking_budget=8192).complete(
             model=model,

--- a/tests/test_model_errors.py
+++ b/tests/test_model_errors.py
@@ -14,12 +14,14 @@ def test_new_flagships_in_matrix_with_labels():
         "gpt-5.6-sol": "GPT-5.6 Sol · OpenAI",
         "gpt-5.6-terra": "GPT-5.6 Terra · OpenAI",
         "gpt-5.6-luna": "GPT-5.6 Luna · OpenAI",
+        "anthropic:claude-opus-5": "Claude Opus 5 · Anthropic",
         "anthropic:claude-fable-5": "Claude Fable 5 · Anthropic",
     }.items():
         assert MATRIX[mid].label == label
         assert MATRIX[mid].caps.tools and MATRIX[mid].caps.vision
 
     assert "gpt-5.6-sol" in models_for_provider("openai")
+    assert "claude-opus-5" in models_for_provider("anthropic")
     assert "claude-fable-5" in models_for_provider("anthropic")
 
 


### PR DESCRIPTION
## Summary

- add `anthropic:claude-opus-5` to the curated native Anthropic model matrix
- expose its 1M context window and agentic vision capabilities in the GUI
- cover the model label, provider suggestion, and adaptive-thinking path

## Testing

- `python3 -m pytest tests/test_model_errors.py tests/test_anthropic_provider.py::test_thinking_config_is_model_family_aware -q` (6 passed)
- `git diff --check`

## Follow-up

Broader provider catalog discovery is tracked in #594.