### PR TITLE
Add hardware binding spec: OpenWorker Deck (MHS-compatible companion hardware)

### DIFF
--- a/docs/hardware-bindings/assets/agent-gateway-connect.svg
+++ b/docs/hardware-bindings/assets/agent-gateway-connect.svg
@@ -1,0 +1,69 @@
+<svg viewBox="0 0 920 400" width="920" height="400" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="The agent's hardware connect — agent binds the gateway, the gateway reaches field devices">
+  <defs>
+    <marker id="cgA" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#7c5cff"/></marker>
+    <marker id="cgB" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#38e0b0"/></marker>
+  </defs>
+  <style>.t{font-family:'Segoe UI',system-ui,sans-serif}.m{font-family:'Cascadia Code',Consolas,monospace}</style>
+
+  <rect x="20" y="30" width="200" height="120" rx="12" fill="#111623" stroke="#7c5cff" stroke-width="1.5"/>
+  <text x="120" y="58" class="m" font-size="11" fill="#7c5cff" text-anchor="middle" letter-spacing="2">AGENT</text>
+  <text x="120" y="82" class="t" font-size="14" font-weight="700" fill="#e8edf7" text-anchor="middle">OpenWorker coworker</text>
+  <text x="120" y="102" class="t" font-size="11" fill="#93a0ba" text-anchor="middle">any MHS-compatible agent</text>
+  <text x="120" y="122" class="t" font-size="10" fill="#93a0ba" text-anchor="middle">thinks · requests · never touches machines</text>
+
+  <rect x="360" y="16" width="200" height="148" rx="12" fill="#111623" stroke="#38e0b0" stroke-width="2"/>
+  <text x="460" y="44" class="m" font-size="11" fill="#38e0b0" text-anchor="middle" letter-spacing="2">HARDWARE CONNECT</text>
+  <text x="460" y="68" class="t" font-size="14" font-weight="700" fill="#e8edf7" text-anchor="middle">OpenWorker Deck</text>
+  <text x="460" y="88" class="t" font-size="11" fill="#93a0ba" text-anchor="middle">physical gateway · MHS-native</text>
+  <rect x="380" y="100" width="70" height="26" rx="6" fill="#161d2e" stroke="#38e0b0" stroke-opacity="0.4"/>
+  <text x="415" y="117" class="t" font-size="10" fill="#38e0b0" text-anchor="middle">Approve key</text>
+  <rect x="470" y="100" width="80" height="26" rx="6" fill="#161d2e" stroke="#7c5cff" stroke-opacity="0.4"/>
+  <text x="510" y="117" class="t" font-size="10" fill="#7c5cff" text-anchor="middle">encrypted cartridge</text>
+  <text x="460" y="150" class="t" font-size="10" fill="#93a0ba" text-anchor="middle">MQTT broker · TLS 1.3 · sandbox</text>
+
+  <rect x="700" y="16" width="200" height="148" rx="12" fill="#111623" stroke="#232c44"/>
+  <text x="800" y="44" class="m" font-size="11" fill="#93a0ba" text-anchor="middle" letter-spacing="2">FIELD</text>
+  <text x="800" y="66" class="t" font-size="11.5" fill="#e8edf7" text-anchor="middle">field devices</text>
+  <rect x="716" y="78" width="168" height="24" rx="6" fill="#161d2e" stroke="#232c44"/>
+  <text x="800" y="94" class="m" font-size="10" fill="#93a0ba" text-anchor="middle">Modbus RTU / TCP</text>
+  <rect x="716" y="106" width="168" height="24" rx="6" fill="#161d2e" stroke="#232c44"/>
+  <text x="800" y="122" class="m" font-size="10" fill="#93a0ba" text-anchor="middle">CAN/J1939 · OBD-II</text>
+  <rect x="716" y="134" width="168" height="24" rx="6" fill="#161d2e" stroke="#232c44"/>
+  <text x="800" y="150" class="m" font-size="10" fill="#93a0ba" text-anchor="middle">BLE 5.2 · LoRa · 1-Wire</text>
+
+  <path d="M 222 62 C 290 62, 300 62, 356 62" fill="none" stroke="#7c5cff" stroke-width="2.5" marker-end="url(#cgA)"/>
+  <text x="288" y="50" class="m" font-size="10" fill="#7c5cff" text-anchor="middle">BIND</text>
+  <text x="288" y="80" class="m" font-size="9" fill="#93a0ba" text-anchor="middle">challenge-response</text>
+
+  <path d="M 562 62 C 620 62, 640 62, 696 62" fill="none" stroke="#38e0b0" stroke-width="2.5" marker-end="url(#cgB)"/>
+  <text x="630" y="50" class="m" font-size="10" fill="#38e0b0" text-anchor="middle">REACH</text>
+  <text x="630" y="80" class="m" font-size="9" fill="#93a0ba" text-anchor="middle">zero integration</text>
+
+  <path d="M 222 110 C 290 110, 300 100, 356 92" fill="none" stroke="#7c5cff" stroke-width="1.8" stroke-dasharray="5 4" marker-end="url(#cgA)"/>
+  <text x="288" y="128" class="m" font-size="9" fill="#7c5cff" text-anchor="middle">read req · write req (gated)</text>
+  <path d="M 562 110 C 620 110, 640 118, 696 124" fill="none" stroke="#38e0b0" stroke-width="1.8" stroke-dasharray="5 4" marker-end="url(#cgB)"/>
+  <text x="630" y="140" class="m" font-size="9" fill="#38e0b0" text-anchor="middle">telemetry · fault codes</text>
+  <path d="M 356 130 C 300 138, 290 130, 224 124" fill="none" stroke="#38e0b0" stroke-width="1.8" stroke-dasharray="5 4" marker-end="url(#cgB)"/>
+  <text x="288" y="152" class="m" font-size="9" fill="#38e0b0" text-anchor="middle">readings return · signed output</text>
+
+  <rect x="20" y="190" width="880" height="180" rx="12" fill="#111623" stroke="#232c44"/>
+  <text x="460" y="218" class="m" font-size="11" fill="#7c5cff" text-anchor="middle" letter-spacing="2">THREE DISCIPLINES OF THE CONNECT</text>
+
+  <rect x="40" y="236" width="270" height="116" rx="10" fill="#161d2e" stroke="#7c5cff" stroke-opacity="0.5"/>
+  <text x="175" y="262" class="t" font-size="12.5" font-weight="700" fill="#e8edf7" text-anchor="middle">Reads — safe by default</text>
+  <text x="175" y="284" class="t" font-size="10.5" fill="#93a0ba" text-anchor="middle">fault codes · hour meters · sensor values</text>
+  <text x="175" y="302" class="t" font-size="10.5" fill="#93a0ba" text-anchor="middle">no approval needed · everything timestamped</text>
+  <text x="175" y="326" class="m" font-size="9.5" fill="#38e0b0" text-anchor="middle">mhs/&lt;deck&gt;/device/&lt;dev&gt;/read</text>
+
+  <rect x="326" y="236" width="270" height="116" rx="10" fill="#161d2e" stroke="#ffb454" stroke-opacity="0.5"/>
+  <text x="461" y="262" class="t" font-size="12.5" font-weight="700" fill="#e8edf7" text-anchor="middle">Writes — gated by button</text>
+  <text x="461" y="284" class="t" font-size="10.5" fill="#93a0ba" text-anchor="middle">resets · calibrations · actuator tests</text>
+  <text x="461" y="302" class="t" font-size="10.5" fill="#ffb454" text-anchor="middle">no software authorization path · human key only</text>
+  <text x="461" y="326" class="m" font-size="9.5" fill="#38e0b0" text-anchor="middle">gate/request → gate/decision</text>
+
+  <rect x="612" y="236" width="270" height="116" rx="10" fill="#161d2e" stroke="#ff6b81" stroke-opacity="0.5"/>
+  <text x="747" y="262" class="t" font-size="12.5" font-weight="700" fill="#e8edf7" text-anchor="middle">Never — defeat an interlock</text>
+  <text x="747" y="284" class="t" font-size="10.5" fill="#93a0ba" text-anchor="middle">safety limits · e-stops · guards</text>
+  <text x="747" y="302" class="t" font-size="10.5" fill="#93a0ba" text-anchor="middle">stated in plain-language MHS safety labels</text>
+  <text x="747" y="326" class="m" font-size="9.5" fill="#ff6b81" text-anchor="middle">never written, period</text>
+</svg>

--- a/docs/hardware-bindings/assets/mandatory-auth-gate.svg
+++ b/docs/hardware-bindings/assets/mandatory-auth-gate.svg
@@ -1,0 +1,85 @@
+<svg viewBox="0 0 960 520" width="960" height="520" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Mandatory authorization gate — models come in, raw data never leaves">
+      <defs>
+        <marker id="arrT" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#38e0b0"/></marker>
+        <marker id="arrP" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#7c5cff"/></marker>
+      </defs>
+      <style>.t{font-family:'Segoe UI',system-ui,-apple-system,sans-serif}.m{font-family:'Cascadia Code',Consolas,'Courier New',monospace}</style>
+
+      <path d="M 400 110 C 360 35, 240 35, 152 62" fill="none" stroke="#7c5cff" stroke-width="2" marker-end="url(#arrP)"/>
+      <text x="275" y="18" class="m" font-size="11" fill="#7c5cff" text-anchor="middle">signed inference output</text>
+      <text x="275" y="34" class="t" font-size="10" fill="#93a0ba" text-anchor="middle">the model leaves with conclusions, not data</text>
+
+      <rect x="20" y="55" width="250" height="345" rx="12" fill="#111623" stroke="#232c44"/>
+      <text x="145" y="79" class="m" font-size="11" fill="#7c5cff" text-anchor="middle" letter-spacing="2">EXTERNAL MODELS</text>
+      <text x="145" y="97" class="t" font-size="10.5" fill="#93a0ba" text-anchor="middle">external models · bring-your-own (BYOM)</text>
+      <rect x="42" y="112" width="206" height="58" rx="8" fill="#161d2e" stroke="#232c44"/>
+      <text x="145" y="137" class="t" font-size="13" font-weight="700" fill="#e8edf7" text-anchor="middle">insurer · underwriting model</text>
+      <text x="145" y="155" class="t" font-size="10" fill="#93a0ba" text-anchor="middle">risk evaluation</text>
+      <rect x="42" y="182" width="206" height="58" rx="8" fill="#161d2e" stroke="#232c44"/>
+      <text x="145" y="207" class="t" font-size="13" font-weight="700" fill="#e8edf7" text-anchor="middle">third-party · evaluation models</text>
+      <text x="145" y="225" class="t" font-size="10" fill="#93a0ba" text-anchor="middle">health / safety / maintenance</text>
+      <rect x="42" y="262" width="206" height="46" rx="8" fill="none" stroke="#ff6b81" stroke-dasharray="4 3" opacity="0.6"/>
+      <text x="145" y="283" class="t" font-size="11.5" font-weight="700" fill="#ff6b81" text-anchor="middle">✗ direct API call</text>
+      <text x="145" y="299" class="t" font-size="9.5" fill="#ff6b81" opacity="0.75" text-anchor="middle">no consent card, no call</text>
+      <rect x="42" y="320" width="206" height="46" rx="8" fill="none" stroke="#ff6b81" stroke-dasharray="4 3" opacity="0.6"/>
+      <text x="145" y="341" class="t" font-size="11.5" font-weight="700" fill="#ff6b81" text-anchor="middle">✗ unreviewed model</text>
+      <text x="145" y="357" class="t" font-size="9.5" fill="#ff6b81" opacity="0.75" text-anchor="middle">rejected at onboarding</text>
+
+      <rect x="330" y="55" width="300" height="345" rx="12" fill="#111623" stroke="#232c44"/>
+      <text x="480" y="79" class="m" font-size="11" fill="#7c5cff" text-anchor="middle" letter-spacing="2">MANDATORY AUTH GATE</text>
+      <text x="480" y="97" class="t" font-size="10.5" fill="#93a0ba" text-anchor="middle">mandatory authorization gate · hardware-enforced</text>
+      <rect x="355" y="112" width="250" height="228" rx="10" fill="#161d2e" stroke="#7c5cff" stroke-width="2"/>
+      <rect x="355" y="112" width="10" height="228" rx="3" fill="#7c5cff" opacity="0.3"/>
+      <rect x="595" y="112" width="10" height="228" rx="3" fill="#7c5cff" opacity="0.3"/>
+      <circle cx="480" cy="152" r="24" fill="#141026" stroke="#38e0b0" stroke-width="2"/>
+      <path d="M 469 152 L 477 160 L 492 144" fill="none" stroke="#38e0b0" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="480" y="196" class="t" font-size="12" font-weight="700" fill="#38e0b0" text-anchor="middle">physical Approve button</text>
+      <line x1="375" y1="208" x2="585" y2="208" stroke="#232c44"/>
+      <rect x="380" y="218" width="200" height="62" rx="8" fill="#0d1420" stroke="#38e0b0" stroke-opacity="0.45"/>
+      <text x="480" y="242" class="t" font-size="12.5" font-weight="700" fill="#e8edf7" text-anchor="middle">sandbox — isolated execution</text>
+      <text x="480" y="260" class="t" font-size="10.5" fill="#93a0ba" text-anchor="middle">consented fields only · overreach rejected</text>
+      <text x="480" y="302" class="t" font-size="12" font-weight="700" fill="#ff6b81" text-anchor="middle">no consent card → call rejected</text>
+      <text x="480" y="320" class="t" font-size="10.5" fill="#93a0ba" text-anchor="middle">no bypass · no direct path · hardware-level</text>
+      <text x="480" y="336" class="t" font-size="10.5" fill="#ffb454" text-anchor="middle">revocation → next call fails immediately</text>
+      <text x="480" y="368" class="t" font-size="10" fill="#93a0ba" opacity="0.75" text-anchor="middle">authorization checks run inside the secure element, not bypassable software</text>
+
+      <rect x="690" y="55" width="250" height="345" rx="12" fill="#111623" stroke="#232c44"/>
+      <text x="815" y="79" class="m" font-size="11" fill="#7c5cff" text-anchor="middle" letter-spacing="2">LOCAL DATA</text>
+      <text x="815" y="97" class="t" font-size="10.5" fill="#93a0ba" text-anchor="middle">local data · raw never leaves</text>
+      <rect x="712" y="112" width="206" height="70" rx="8" fill="#161d2e" stroke="#7c5cff" stroke-width="1.5"/>
+      <rect x="726" y="126" width="28" height="28" rx="3" fill="none" stroke="#7c5cff" stroke-width="1.5"/>
+      <rect x="733" y="129" width="14" height="9" fill="#7c5cff" opacity="0.55"/>
+      <rect x="733" y="144" width="14" height="6" fill="none" stroke="#7c5cff" stroke-width="1" opacity="0.5"/>
+      <text x="766" y="138" class="t" font-size="13" font-weight="700" fill="#e8edf7">privacy cartridge</text>
+      <text x="766" y="155" class="t" font-size="10" fill="#93a0ba">AES-256 · key lives in the cartridge</text>
+      <rect x="712" y="196" width="206" height="74" rx="8" fill="#161d2e" stroke="#232c44"/>
+      <rect x="724" y="216" width="16" height="20" rx="2" fill="none" stroke="#7c5cff" opacity="0.5"/>
+      <rect x="732" y="212" width="16" height="20" rx="2" fill="none" stroke="#7c5cff" opacity="0.7"/>
+      <rect x="740" y="208" width="16" height="20" rx="2" fill="#141026" stroke="#7c5cff"/>
+      <text x="766" y="218" class="t" font-size="12.5" font-weight="700" fill="#e8edf7">consent cards</text>
+      <text x="766" y="235" class="t" font-size="10" fill="#93a0ba">which data · which institution · how long</text>
+      <text x="766" y="251" class="t" font-size="10" fill="#38e0b0">button-activated · revocable anytime</text>
+      <rect x="712" y="284" width="206" height="62" rx="8" fill="#161d2e" stroke="#232c44"/>
+      <rect x="726" y="298" width="26" height="26" rx="3" fill="none" stroke="#38e0b0" stroke-width="1.5"/>
+      <rect x="732" y="304" width="14" height="14" fill="none" stroke="#38e0b0" opacity="0.5"/>
+      <text x="766" y="310" class="t" font-size="12.5" font-weight="700" fill="#e8edf7">local model</text>
+      <text x="766" y="327" class="t" font-size="10" fill="#93a0ba">digests · risk tiers</text>
+      <text x="815" y="372" class="t" font-size="10" fill="#93a0ba" opacity="0.75" text-anchor="middle">raw data and intermediate features stay local</text>
+
+      <line x1="248" y1="141" x2="347" y2="141" stroke="#38e0b0" stroke-width="2" marker-end="url(#arrT)"/>
+      <line x1="248" y1="211" x2="347" y2="211" stroke="#38e0b0" stroke-width="2" marker-end="url(#arrT)"/>
+      <text x="301" y="172" class="t" font-size="11" font-weight="700" fill="#38e0b0" text-anchor="middle">post-compliance</text>
+      <text x="301" y="187" class="t" font-size="9.5" fill="#38e0b0" opacity="0.8" text-anchor="middle">onboarding-reviewed</text>
+      <line x1="609" y1="247" x2="706" y2="247" stroke="#38e0b0" stroke-width="2" marker-end="url(#arrT)"/>
+      <text x="657" y="234" class="t" font-size="10.5" font-weight="700" fill="#38e0b0" text-anchor="middle">consented fields only</text>
+      <text x="657" y="264" class="t" font-size="9.5" fill="#38e0b0" opacity="0.8" text-anchor="middle">nothing beyond the card</text>
+
+      <line x1="110" y1="428" x2="850" y2="428" stroke="#ff6b81" stroke-width="1.5" stroke-dasharray="6 5" opacity="0.55"/>
+      <line x1="470" y1="418" x2="490" y2="438" stroke="#ff6b81" stroke-width="3" stroke-linecap="round"/>
+      <line x1="490" y1="418" x2="470" y2="438" stroke="#ff6b81" stroke-width="3" stroke-linecap="round"/>
+      <text x="480" y="452" class="t" font-size="11" fill="#ff6b81" text-anchor="middle">no direct path · no bypass · no API around — this architecture has no such route</text>
+
+      <rect x="20" y="464" width="920" height="46" rx="10" fill="#0d1420" stroke="#232c44"/>
+      <text x="480" y="483" class="m" font-size="11" fill="#93a0ba" text-anchor="middle">audit · one record per call — which model · read what · when · under which consent card</text>
+      <text x="480" y="500" class="m" font-size="10" fill="#ffb454" text-anchor="middle">revocation · withdraw consent → the model's next call fails immediately</text>
+</svg>

--- a/docs/hardware-bindings/openworker-deck.md
+++ b/docs/hardware-bindings/openworker-deck.md
@@ -27,6 +27,8 @@ This document defines how an OpenWorker agent binds to and operates a Deck.
 Product specifications live in the upstream repository; this binding covers the
 integration surface only.
 
+![The agent's hardware connect — agent binds the gateway, the gateway reaches field devices](assets/agent-gateway-connect.svg)
+
 ## 1. Discovery and registration
 
 The Deck registers itself and each bridged device as an MHS-compatible node:
@@ -117,7 +119,46 @@ Four contactless modalities work on any machine with power: vibration
 and acoustic (MEMS mic). These feed anomaly detection and risk prediction on
 the local model — the agent reads the derived risk briefs, not raw streams.
 
-## 8. Status
+## 8. Product editions
+
+One binding, four form factors — an agent that binds one Deck can operate any
+edition; the topic tree and disciplines are identical:
+
+| Edition | Form factor | Where it lives |
+|---|---|---|
+| Desktop | 4″ console, Approve/Deny permission card, status ring | On the desk, next to the agent's host |
+| Industrial | 35 mm DIN-rail, RS-485/CAN terminal blocks, RJ45, LoRa antenna, passive heatsink, wide-temp | Inside the cabinet, on the rail |
+| Socket | Smart-plug with pass-through outlet, built-in current sensing | In the wall outlet — zero-wiring entry; the appliance plugs into it |
+| Pendant | Screenless guardian tag, GNSS + barometer + nano-SIM | On the person — tracks and check-ins flow up through any nearby Deck |
+
+## 9. Protocol support
+
+Every protocol maps onto the same standard MHS read/write interface — the agent
+never learns a vendor SDK:
+
+| Link | Reaches | Typical equipment |
+|---|---|---|
+| Modbus RTU (RS-485 multi-drop) | PLCs, VFDs, meters, controllers | Compressors, sterilizers, pump stations |
+| Modbus TCP (Ethernet) | Panel PCs, gateways, SCADA-adjacent devices | Machine tools, energy meters |
+| CAN 2.0B / J1939 | Vehicle and heavy-equipment buses | Trucks, gensets, ag machinery |
+| OBD-II | Passenger-vehicle diagnostics | Fleet vans, work trucks |
+| BLE 5.2 | Sensors, health devices, wearables | Blood-pressure cuffs, tag buttons, env pods |
+| LoRa | Long-range, low-power telemetry | Barns, tanks, remote sites |
+| 1-Wire | Cheap temperature chains | Cold storage, server rooms |
+
+## 10. Compute and storage
+
+Two planes, deliberately separated — compute stays in the base, data travels
+in the cartridge:
+
+- **Compute plane** — dual-core Cortex-A7 + 0.5 TOPS NPU: the local model,
+  anomaly detection, feature learning, and the MQTT broker run on the device.
+- **Storage plane** — 8 GB eMMC buffer plus a removable hardware-encrypted
+  cartridge (AES-256, key born in the cartridge, never leaves). Pulling the
+  cartridge removes the archive physically; compute keeps running and syncs
+  on re-insert.
+
+## 11. Status
 
 Design-stage hardware; EVT-phase target specs. Firmware is open source (MIT).
 MHS is a research preview — this binding tracks the spec as it stabilizes and

--- a/docs/hardware-bindings/openworker-deck.md
+++ b/docs/hardware-bindings/openworker-deck.md
@@ -1,0 +1,116 @@
+---
+name: openworker-deck
+type: hardware-binding
+standard: Model Hardware Standard (MHS)
+status: design-stage (EVT target specs)
+upstream: https://github.com/Hdhaidong/openworker-deck
+license: firmware MIT
+---
+
+# Hardware binding: OpenWorker Deck
+
+An MHS-compatible hardware companion that binds an OpenWorker coworker to the
+physical world. Two roles in one device:
+
+1. **Desk console** — a 4″ screen mirroring the coworker's live todo list and
+   progress, with a physical Approve/Deny permission card and a status ring
+   (idle / thinking / needs-you). When the agent requests a permission in
+   `interactive` mode, the desk rings instead of a chat bubble.
+2. **Device gateway** — an industrial + wireless gateway speaking Modbus
+   RTU/TCP, CAN 2.0B/J1939, OBD-II, BLE 5.2 and LoRa, registering itself and
+   every bridged device on the network following the MHS pattern.
+
+This document defines how an OpenWorker agent binds to and operates a Deck.
+Product specifications live in the upstream repository; this binding covers the
+integration surface only.
+
+## 1. Discovery and registration
+
+The Deck registers itself and each bridged device as an MHS-compatible node:
+
+- Standard read/write interface per device class
+- Natural-language safety labels auto-generated from device metadata
+- Device registry entries persist locally; re-discovery is idempotent
+
+An OpenWorker agent discovers the Deck like any other MHS node — no
+vendor-specific client. Any MHS-compatible agent (OpenWorker, Claude, or
+others) can bind; the Deck is agent-agnostic.
+
+## 2. Binding protocol
+
+| Layer | Mechanism |
+|---|---|
+| Transport | Built-in MQTT broker (3.1.1 / 5.0), LWT presence, topic tree per MHS↔topic mapping |
+| Security | TLS 1.3; cartridge challenge-response — the agent must satisfy a hardware-anchored challenge before write access |
+| Presence | LWT marks the agent offline on the network layer; the console reflects it on the status ring |
+| Time | Fleet time sync across multiple Decks for correlated telemetry |
+
+Topic tree sketch:
+
+```
+mhs/<deck-id>/console/todo          # agent publishes live todo list
+mhs/<deck-id>/console/progress      # agent publishes progress panel state
+mhs/<deck-id>/gate/request          # agent requests a permission
+mhs/<deck-id>/gate/decision         # Deck publishes Approve/Deny (human-pressed)
+mhs/<deck-id>/device/<dev>/read     # telemetry reads (safe by default)
+mhs/<deck-id>/device/<dev>/write    # actuation, calibration, resets (gated)
+mhs/<deck-id>/audit                 # per-call audit stream
+```
+
+## 3. Read/write discipline
+
+- **Reads are safe by default.** Fault codes, hour meters, cycle counts, sensor
+  readings, error history — no approval needed. Every reading is timestamped
+  and names its source device.
+- **Writes are gated.** Resets, calibration values, actuation tests: the agent
+  publishes to `gate/request` stating what it commands, what the machine will
+  physically do, and what could go wrong. The human presses Approve or Deny on
+  the physical card. No software path grants a write.
+- **Never write to defeat an interlock, guard, or limit** — the Deck's safety
+  labels carry this in plain language per MHS.
+
+## 4. The physical permission gate
+
+When the bound agent enters `interactive` mode and requests a permission:
+
+1. The Deck rings the desk — a physical card with Approve / Deny buttons.
+2. The request and its context are displayed on the console.
+3. The human's button press is the only path to a grant. The decision is
+   published to `gate/decision` and logged to the audit stream.
+4. Authorization is per-action, not per-session — a grant does not carry over.
+
+## 5. Privacy model
+
+- The agent's private data (telemetry, logs, history) is computed on the Deck's
+  local model and stays on the device by default. Offline is the resting state.
+- History archives to a removable hardware-encrypted cartridge (AES-256, key
+  lives in the cartridge). Pulling the cartridge removes the data physically;
+  compute continues with telemetry buffering to eMMC and syncs on re-insert.
+- The optional fleet bridge is opt-in and labeled.
+
+## 6. Audit
+
+Every model call and every write generates an audit record: who called, what
+was read or written, when, and under which authorization. The audit stream is
+available to the bound agent for review but is append-only — entries cannot
+be rewritten from the agent side.
+
+## 7. Sensing modalities (for agents without diagnostic ports)
+
+Four contactless modalities work on any machine with power: vibration
+(3-axis accelerometer), thermal (IR thermopile), current signature (CT clamp),
+and acoustic (MEMS mic). These feed anomaly detection and risk prediction on
+the local model — the agent reads the derived risk briefs, not raw streams.
+
+## 8. Status
+
+Design-stage hardware; EVT-phase target specs. Firmware is open source (MIT).
+MHS is a research preview — this binding tracks the spec as it stabilizes and
+degrades gracefully: no registration found means the normal case, and the
+agent falls back to its other paths.
+
+Product documentation, industrial design renders, and specification tables:
+[github.com/Hdhaidong/openworker-deck](https://github.com/Hdhaidong/openworker-deck)
+
+Independent community project — not affiliated with, endorsed by, or sponsored
+by Andrew Ng, deeplearning.ai, or the OpenWorker project.

--- a/docs/hardware-bindings/openworker-deck.md
+++ b/docs/hardware-bindings/openworker-deck.md
@@ -9,8 +9,11 @@ license: firmware MIT
 
 # Hardware binding: OpenWorker Deck
 
-An MHS-compatible hardware companion that binds an OpenWorker coworker to the
-physical world. Two roles in one device:
+**The agent's hardware connect.** The agent thinks — the Deck connects. An
+MHS-compatible physical gateway that binds an OpenWorker coworker to the
+physical world: one connect, two directions (the agent reaches down to
+machines; telemetry and fault codes flow back up), all writes passing a
+human-pressed button. Two roles in one device:
 
 1. **Desk console** — a 4″ screen mirroring the coworker's live todo list and
    progress, with a physical Approve/Deny permission card and a status ring
@@ -37,6 +40,9 @@ vendor-specific client. Any MHS-compatible agent (OpenWorker, Claude, or
 others) can bind; the Deck is agent-agnostic.
 
 ## 2. Binding protocol
+
+The connect itself — transport, security, and the topic tree that carries
+both directions:
 
 | Layer | Mechanism |
 |---|---|

--- a/docs/hardware-bindings/openworker-deck.md
+++ b/docs/hardware-bindings/openworker-deck.md
@@ -79,6 +79,15 @@ When the bound agent enters `interactive` mode and requests a permission:
    published to `gate/decision` and logged to the audit stream.
 4. Authorization is per-action, not per-session — a grant does not carry over.
 
+The same gate hardware also enforces **model-call authorization**. External
+models (an institution's own, reviewed at onboarding — BYOM) run in a sandbox
+and may only read the fields a consent card declares; they leave with signed
+inference outputs, never raw data. No consent card, no call — there is no
+bypass path and no direct API in the architecture, and a revocation cuts the
+model's next call immediately.
+
+![Mandatory authorization gate — models come in, raw data never leaves](assets/mandatory-auth-gate.svg)
+
 ## 5. Privacy model
 
 - The agent's private data (telemetry, logs, history) is computed on the Deck's


### PR DESCRIPTION
## Summary

* Adds `docs/hardware-bindings/openworker-deck.md` — an integration spec for binding an OpenWorker coworker to the OpenWorker Deck, an MHS-compatible hardware gateway: **the agent's hardware connect**

* Covers the integration surface only: discovery/registration, the MQTT topic tree (transport, security, both directions), read/write discipline, the physical permission gate, model-call authorization, privacy model, and audit stream

* Adds `docs/hardware-bindings/assets/mandatory-auth-gate.svg` — an architecture diagram of the mandatory authorization gate (models → hardware gate → local data, signed-output return path, blocked direct paths, audit strip)

* Proposes a `docs/hardware-bindings/` convention for MHS-compatible companion hardware — this is the first entry

## What the Deck is

Two roles in one device: a desk console that mirrors the coworker's live todo list on a 4″ screen with physical Approve/Deny permission buttons, and an industrial + wireless gateway (Modbus RTU/TCP, CAN/J1939, OBD-II, BLE 5.2, LoRa) that registers bridged devices on the network following the MHS pattern. Agent-agnostic — any MHS-compatible agent can bind. One connect, two directions: the agent reaches down to machines; telemetry and fault codes flow back up.

Companion to #593 (Hardware Repair Companion), whose `hardware-link` skill describes the agent side of the same MHS pattern; this spec describes the hardware side.

## Read/write discipline (short version)

* **Reads are safe by default** — fault codes, hour meters, sensor values; no approval needed, everything timestamped

* **Writes pass a human-pressed button** — resets, calibrations, actuator tests; no software authorization path exists

* **Never defeats an interlock** — safety limits, e-stops, protective stops are never written, in plain-language MHS safety labels

## Boundaries

* Integration spec only — product documentation, renders and specification tables stay in the [product repository](https://github.com/Hdhaidong/openworker-deck)

* Design-stage hardware, EVT target specs; firmware MIT, open source

* MHS is a research preview — the binding degrades gracefully and tracks the spec as it stabilizes

* Independent community project, not affiliated with or endorsed by the OpenWorker project

## Test plan

* [x] Markdown renders correctly on GitHub

* [x] SVG diagram renders on GitHub (relative path `assets/mandatory-auth-gate.svg`)

* [ ] Topic tree sketch is consistent with the MHS↔topic mapping described in #593's `hardware-link` skill

* [ ] Read/write discipline wording matches MHS plain-language safety label conventions