### PR TITLE
fix(#607): open chat links in the user's browser

### DIFF
--- a/surfaces/gui/src-tauri/Cargo.lock
+++ b/surfaces/gui/src-tauri/Cargo.lock
@@ -1937,6 +1937,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,6 +2684,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "open"
+version = "5.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c603ab8300cf18bc3b14146b19fe3dfcc4843ae5a400cd0e7a30b95aa366634"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +2711,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
+ "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "uuid",
@@ -4073,6 +4104,28 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d60366174b745b4ef5824b8bbc1c457fd08f0ce101ff643c0a49181a9f4e91"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows 0.61.3",
+ "zbus",
 ]
 
 [[package]]

--- a/surfaces/gui/src-tauri/Cargo.toml
+++ b/surfaces/gui/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-dialog = "2"
+tauri-plugin-opener = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"

--- a/surfaces/gui/src-tauri/capabilities/default.json
+++ b/surfaces/gui/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:window:allow-set-focus",
     "core:window:allow-unminimize",
     "dialog:default",
+    "opener:default",
     "autostart:default"
   ]
 }

--- a/surfaces/gui/src-tauri/src/lib.rs
+++ b/surfaces/gui/src-tauri/src/lib.rs
@@ -717,6 +717,9 @@ pub fn run() {
             show_main(app);
         }))
         .plugin(tauri_plugin_dialog::init())
+        // Opens external http(s) URLs / files in the user's default browser (fixes #227, #607):
+        // the SPA routes transcript/provider links through openExternal() -> __TAURI__.opener.
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,

--- a/surfaces/gui/src/components/Markdown.test.tsx
+++ b/surfaces/gui/src/components/Markdown.test.tsx
@@ -1,8 +1,15 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { Markdown, OPEN_ARTIFACT_EVENT, OPEN_BOARD_EVENT } from "./Markdown";
+import { openExternal } from "../tauri";
 
 afterEach(cleanup);
+
+vi.mock("../tauri", () => ({ openExternal: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(openExternal).mockClear();
+});
 
 // §34 (UX-016): [Title](artifact:path) renders as a chip that opens the artifact viewer via
 // a window event; ordinary links keep the open-externally treatment.
@@ -28,6 +35,25 @@ describe("Markdown artifact links", () => {
     const a = container.querySelector("a")!;
     expect(a.getAttribute("target")).toBe("_blank");
     expect(a.getAttribute("href")).toBe("https://example.com");
+  });
+
+  // #607: in the desktop Tauri webview a plain target="_blank" never opens the OS browser, so a
+  // left-click on an external link must be routed through openExternal() (which uses the opener
+  // plugin in the packaged app and window.open in the browser).
+  it("routes a left-click on an external link through openExternal and prevents default", () => {
+    render(<Markdown text="see [the docs](https://example.com)" />);
+    const a = screen.getByText("the docs").closest("a")!;
+    fireEvent.click(a, { defaultPrevented: false });
+    expect(openExternal).toHaveBeenCalledTimes(1);
+    expect(openExternal).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("does not route artifact: or board: links through openExternal", () => {
+    render(
+      <Markdown text="see [the docs](https://example.com) and [file](artifact:reports/a.pdf)" />,
+    );
+    fireEvent.click(screen.getByTestId("artifact-chip"));
+    expect(openExternal).not.toHaveBeenCalled();
   });
 
   it("chip title falls back to the filename when the link text is empty", () => {

--- a/surfaces/gui/src/components/Markdown.tsx
+++ b/surfaces/gui/src/components/Markdown.tsx
@@ -2,6 +2,7 @@ import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import { useTranslation } from "react-i18next";
 import remarkGfm from "remark-gfm";
 import { Icon } from "./Icon";
+import { openExternal } from "../tauri";
 
 // §34 (UX-016): the agent ends a deliverable turn with plain markdown —
 // [Title](artifact:relative/path) — and the renderer turns it into a chip that opens the
@@ -76,8 +77,22 @@ export function Markdown({ text }: { text: string }) {
               const label = Array.isArray(children) ? children.join("") : String(children ?? "");
               return <BoardChip label={label} />;
             }
+            // #607: plain `target="_blank"` no-ops in the desktop Tauri webview (window.open is
+            // not wired to the OS browser). Route left-clicks through openExternal() so links in
+            // chat messages open in the user's browser in BOTH the packaged app (via the opener
+            // plugin) and the browser build (window.open fallback). Keep the real href + target
+            // so the URL stays copyable/semantic and Ctrl/Cmd+click still works.
             return (
-              <a href={href} {...props} target="_blank" rel="noreferrer">
+              <a
+                href={href}
+                {...props}
+                target="_blank"
+                rel="noreferrer"
+                onClick={(e) => {
+                  e.preventDefault();
+                  if (href) openExternal(href);
+                }}
+              >
                 {children}
               </a>
             );


### PR DESCRIPTION
Closes #607

## Problem
Clicking a Markdown link in chat (e.g. the GitHub links shared in a chat turn) does nothing in the desktop app: the link never opens a page in your local browser. The chat renderer wrote plain `<a target="_blank" rel="noreferrer">` tags. In the Tauri webview `target="_blank"`/`window.open` are no-ops without an `opener` plugin wired in, so the click is silently swallowed. It only appears to work because the same code works in the `vite` dev browser, which is why the bug slips through.

## Fix
- **Frontend** (`Markdown.tsx`): external links now route through Tauri's `openExternal` on click (`onClick` + `preventDefault`), while keeping the `href`/`target="_blank"` fallback.
- **Backend** (`src-tauri`): add and register `tauri-plugin-opener` and grant the `opener:default` capability so links open in the OS default browser.

## Tests
- `Markdown.test.tsx`: added tests asserting an external-link click calls `openExternal` and prevents default navigation (6 tests pass).
- Full frontend unit suite: 185 tests pass.
- `cargo check --locked` in `src-tauri` compiles clean with the opener plugin.

## Verification notes
Tested locally: `npx vitest run`, `tsc --noEmit`, and `cargo check` all green.
