### PR TITLE
feat(#611): option to hide the live thinking stream while a task runs

### DIFF
--- a/coworker/server/app.py
+++ b/coworker/server/app.py
@@ -1931,6 +1931,11 @@ def create_app(manager: SessionManager) -> FastAPI:
         # Composer: show the context-window fill bar, or just the popover (owner ask).
         return manager.set_context_bar((body or {}).get("context_bar", True))
 
+    @app.post("/v1/settings/hide-reasoning")
+    def settings_set_hide_reasoning(body: dict) -> dict[str, Any]:
+        # #611: collapse the live reasoning stream to a quiet indicator while a turn runs.
+        return manager.set_hide_reasoning_running((body or {}).get("hide_reasoning_running", False))
+
     @app.post("/v1/settings/auto-approve")
     def settings_set_auto_approve(body: dict) -> dict[str, Any]:
         # Auto-Approve feature flag (spec §1.5): when on, Mode.AUTO_APPROVE gets an LLM

--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -3442,6 +3442,9 @@ class SessionManager:
             "nav_layout": self._nav_layout(),
             "sessions_peek": self.sessions_peek(),
             "context_bar": self.context_bar(),
+            # #611: collapse/hide the live thinking stream while a turn runs (OFF by default so
+            # existing users keep seeing it; the finalized reasoning still shows after the turn).
+            "hide_reasoning_running": self.hide_reasoning_running(),
             # Auto-Approve feature flag + its shadow-eval sibling (spec §1.5). Drive the
             # Settings toggles and gate the composer's Auto-Approve mode entry.
             "auto_approve": self.auto_approve(),
@@ -3514,6 +3517,19 @@ class SessionManager:
         self._prefs["context_bar"] = bool(shown)
         self._save_prefs()
         return {"ok": True, "context_bar": self.context_bar()}
+
+    # -- Hide live reasoning while running (#611) ---------------------------------------
+    # The GUI streams the model's reasoning live during a turn; at full write speed it's a
+    # wall of fast-moving text. This pref collapses that live stream to a quiet one-line
+    # indicator (the finalized reasoning still appears after the turn). OFF by default.
+
+    def hide_reasoning_running(self) -> bool:
+        return bool(self._prefs.get("hide_reasoning_running", False))
+
+    def set_hide_reasoning_running(self, hidden: Any) -> dict[str, Any]:
+        self._prefs["hide_reasoning_running"] = bool(hidden)
+        self._save_prefs()
+        return {"ok": True, "hide_reasoning_running": self.hide_reasoning_running()}
 
     # -- Auto-Approve (spec §1.5, Part 6 step 3) --------------------------------
     # The feature flag and its shadow-eval sibling live in prefs (GUI-writable), falling

--- a/surfaces/gui/e2e/fixtures.ts
+++ b/surfaces/gui/e2e/fixtures.ts
@@ -37,6 +37,8 @@ const SETTINGS = {
   scratch_base: "~/OpenWorker",
   secrets_path: "/Users/test/.config/coworker/secrets.json",
   sessions_peek: 5,
+  // #611: live reasoning is collapsed to a quiet "Thinking…" line while a turn runs.
+  hide_reasoning_running: false,
   // Token savings (PDF attachments): 2-page limit keeps the composer threshold test's
   // fixture PDF small; the real default is 20.
   pdf_fallback: "text",
@@ -1437,6 +1439,10 @@ export async function mockApi(page: import("@playwright/test").Page) {
     if (p.endsWith("/v1/settings/context-bar") && m === "POST") {
       Object.assign(SETTINGS, req.postDataJSON());
       return json({ ok: true, context_bar: SETTINGS.context_bar });
+    }
+    if (p.endsWith("/v1/settings/hide-reasoning") && m === "POST") {
+      Object.assign(SETTINGS, req.postDataJSON());
+      return json({ ok: true, hide_reasoning_running: SETTINGS.hide_reasoning_running });
     }
     if (p.endsWith("/v1/settings/pdf") && m === "POST") {
       Object.assign(SETTINGS, req.postDataJSON());

--- a/surfaces/gui/e2e/hide-reasoning.spec.ts
+++ b/surfaces/gui/e2e/hide-reasoning.spec.ts
@@ -1,0 +1,56 @@
+// #611 — "Hide thinking while running": a persisted Composer setting that collapses the
+// fast-scrolling live reasoning trace to a quiet one-line "Thinking…" indicator while a
+// turn runs, WITHOUT hiding the fact that work is ongoing. The finalized reasoning still
+// appears in the assistant item's "Thought process" disclosure after the turn.
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+async function startThinkingTurn(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await page.getByText("Draft the launch note").first().click();
+  const box = page.getByPlaceholder(/Ask the coworker/);
+  await box.fill("think hard about this");
+  await box.press("Enter");
+}
+
+test("hide-reasoning: default shows the live thinking block", async ({ page }) => {
+  await startThinkingTurn(page);
+
+  // OFF by default: the live ThinkingBlock streams the trace (existing behavior).
+  await expect(page.getByText("Thinking…").first()).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("thinking-toggle")).toBeVisible();
+  await page.getByTestId("thinking-toggle").click();
+  await expect(page.getByTestId("thinking-body")).toContainText("Weighing options.");
+});
+
+test("hide-reasoning: collapses live thinking but keeps an ongoing-work indicator", async ({
+  page,
+}) => {
+  // Enable the setting in Settings → Composer (General tab is the default open tab).
+  await page.goto("/");
+  await page.getByTestId("account-row").click();
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  const togg = page.getByTestId("hide-reasoning-toggle");
+  await expect(togg).toBeVisible();
+  await togg.check();
+  await expect(togg).toBeChecked();
+
+  // Run a reasoning turn: the live ThinkingBlock must be suppressed…
+  await startThinkingTurn(page);
+  await expect(page.getByText("Thinking…").first()).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("thinking-toggle")).toHaveCount(0);
+
+  // …but the user still sees that work is ongoing (the quiet indicator, not raw text).
+  // No streaming trace is shown while hidden.
+  await expect(page.getByTestId("thinking-body")).toHaveCount(0);
+
+  // The finalized reasoning still lands after the turn — nothing was lost.
+  await expect(page.getByText("Decision made.").first()).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("Thinking…")).toHaveCount(0);
+  const disc = page.getByTestId("thinking-toggle");
+  await expect(disc).toHaveText(/Thought process/);
+  await disc.click();
+  await expect(page.getByTestId("thinking-body")).toContainText(
+    "Weighing options. Comparing tradeoffs. Settling it.",
+  );
+});

--- a/surfaces/gui/src/App.tsx
+++ b/surfaces/gui/src/App.tsx
@@ -210,6 +210,9 @@ export function App() {
   // Settings: show the composer's context-window fill bar. OFF by default (owner ask),
   // so an older backend without the field also shows the session total.
   const [contextBar, setContextBar] = useState(false);
+  // #611: when on, the live reasoning stream is collapsed to a quiet indicator while a
+  // turn runs; the finalized reasoning still appears after. Loaded from Settings.
+  const [hideReasoningRunning, setHideReasoningRunning] = useState(false);
   // Per-session token usage (OPE-42): rebuilt from the transcript on session load,
   // accumulated live from assistant_message events, reset with the transcript.
   const [usage, setUsage] = useState<SessionUsage>(emptyUsage());
@@ -616,6 +619,7 @@ export function App() {
         setModelLabels(s.model_labels || {});
         setModelContextWindows(s.model_context_windows || {});
         setContextBar(s.context_bar === true);
+        setHideReasoningRunning(s.hide_reasoning_running === true);
         setModelReady(s.model_ready);
         if (s.surfaces) setSurfaces(s.surfaces);
       })
@@ -1977,10 +1981,19 @@ export function App() {
                   {/* Live thinking (reasoning models): a quiet collapsed block that streams the
                       trace for anyone who expands it; folds into the answer's disclosure when
                       the message finalizes. */}
-                  {running && reasoningStream && !streaming && (
-                    <div className="transcript">
-                      <ThinkingBlock text={reasoningStream} live />
-                    </div>
+                  {running &&
+                    reasoningStream &&
+                    !streaming &&
+                    !hideReasoningRunning && (
+                      <div className="transcript">
+                        <ThinkingBlock text={reasoningStream} live />
+                      </div>
+                    )}
+                  {/* #611: "Hide thinking while running" collapses the fast-scrolling live trace
+                      to a quiet one-line indicator — the finalized reasoning still appears in the
+                      assistant item after the turn, so no signal is lost. */}
+                  {running && reasoningStream && !streaming && hideReasoningRunning && (
+                    <WaitingForAgent label={t("app.thinking_hidden")} />
                   )}
                   {/* Compaction runs between provider turns (nothing streams during it), so
                       the transient takes over the waiting slot with a specific label. */}

--- a/surfaces/gui/src/api.ts
+++ b/surfaces/gui/src/api.ts
@@ -919,6 +919,9 @@ export interface ModelSettings {
   // Composer: show the context-window fill bar (default FALSE; absent → the chip shows
   // the session total). The usage popover keeps both numbers regardless.
   context_bar?: boolean;
+  // #611: collapse the live reasoning stream while a turn runs (default FALSE). When on,
+  // the reasoning is hidden during the run, but its finalized form still appears after.
+  hide_reasoning_running?: boolean;
   // Auto-Approve mode (spec §1.5): the feature flag that offers the reviewer mode, and its
   // shadow-eval sibling. Both default FALSE and are absent on older backends — the composer
   // hides the Auto-Approve mode entry unless auto_approve is explicitly true.
@@ -998,6 +1001,18 @@ export async function setContextBar(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ context_bar: shown }),
+  });
+  return res.json();
+}
+
+/** #611: persist whether the composer suppresses the live reasoning stream while a turn runs. */
+export async function setHideReasoningRunning(
+  hidden: boolean,
+): Promise<{ ok: boolean; hide_reasoning_running?: boolean; error?: string }> {
+  const res = await fetch(`${httpBase()}/v1/settings/hide-reasoning`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ hide_reasoning_running: hidden }),
   });
   return res.json();
 }

--- a/surfaces/gui/src/components/SettingsView.tsx
+++ b/surfaces/gui/src/components/SettingsView.tsx
@@ -8,6 +8,7 @@ import {
   setAutoApproveShadow,
   setCompactionSettings,
   setContextBar,
+  setHideReasoningRunning,
   setOnboarded,
   setPdfSettings,
   setScratchBase,
@@ -473,6 +474,8 @@ function AppearanceSection() {
 
       <ContextBarCard />
 
+      <HideReasoningCard />
+
       <AutoApproveCard />
 
       <FilesCard />
@@ -869,6 +872,45 @@ function ContextBarCard() {
         <span>
           <span className="block text-[13px] text-ink">{t("settings.context_bar_title")}</span>
           <span className="block text-[12px] text-muted">{t("settings.context_bar_desc")}</span>
+        </span>
+      </label>
+    </div>
+  );
+}
+
+// #611: collapse the live reasoning stream to a quiet "Thinking…" indicator while a
+// turn runs. Mirror of ContextBarCard: a persisted, user-global checkbox in Composer
+// settings. The finalized reasoning still appears after the turn, so nothing is lost.
+function HideReasoningCard() {
+  const { t } = useTranslation();
+  const [hidden, setHidden] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    getSettings()
+      .then((s) => setHidden(s.hide_reasoning_running === true))
+      .catch(() => setHidden(false));
+  }, []);
+
+  const save = async (next: boolean) => {
+    setHidden(next);
+    await setHideReasoningRunning(next);
+  };
+
+  if (hidden === null) return null;
+  return (
+    <div className={CARD + " p-4 mb-4"} data-testid="hide-reasoning-card">
+      <div className={FIELD_LABEL}>{t("settings.composer_section")}</div>
+      <label className="flex items-start gap-3 py-2">
+        <input
+          type="checkbox"
+          className="mt-0.5"
+          data-testid="hide-reasoning-toggle"
+          checked={hidden}
+          onChange={(e) => save(e.target.checked)}
+        />
+        <span>
+          <span className="block text-[13px] text-ink">{t("settings.hide_reasoning_title")}</span>
+          <span className="block text-[12px] text-muted">{t("settings.hide_reasoning_desc")}</span>
         </span>
       </label>
     </div>

--- a/surfaces/gui/src/locales/en.json
+++ b/surfaces/gui/src/locales/en.json
@@ -393,7 +393,9 @@
     "personas_desc": "Coworkers are agents specialized for a particular role or task. They come equipped with the tools and skills to be successful in that role. Enabling a coworker lets you pick it when starting a conversation.",
     "composer_section": "Composer",
     "context_bar_title": "Show the context window bar",
-    "context_bar_desc": "A small meter showing how full the model’s context window is. Turn it off to show the same thing as a number instead."
+    "context_bar_desc": "A small meter showing how full the model’s context window is. Turn it off to show the same thing as a number instead.",
+    "hide_reasoning_title": "Hide thinking while I work",
+    "hide_reasoning_desc": "Collapse the fast-scrolling reasoning trace to a quiet “Thinking…” line while a turn runs. The full reasoning still appears after the turn finishes."
   },
   "cloud": {
     "check_browser": "Check your browser…",
@@ -429,6 +431,7 @@
     "jump_to_latest": "Jump to latest",
     "waiting_for_agent": "Waiting for agent...",
     "compacting_context": "Compacting context…",
+    "thinking_hidden": "Thinking…",
     "allow_anyway_message": "I reviewed the blocked {{name}} action — go ahead with it exactly as proposed.",
     "temp_folder_failed": "Could not create a temporary folder.",
     "temp_folder_created": "Temporary folder created",

--- a/surfaces/gui/src/locales/zh.json
+++ b/surfaces/gui/src/locales/zh.json
@@ -385,7 +385,9 @@
     "personas_desc": "同事是专精于特定角色或任务的 agent，自带胜任该角色所需的工具与技能。启用同事后，即可在开始会话时选择它。",
     "composer_section": "输入框",
     "context_bar_title": "显示上下文窗口占用条",
-    "context_bar_desc": "一个小指示条，显示模型上下文窗口的占用程度。关闭后将改为以数字形式显示。"
+    "context_bar_desc": "一个小指示条，显示模型上下文窗口的占用程度。关闭后将改为以数字形式显示。",
+    "hide_reasoning_title": "工作时隐藏思考过程",
+    "hide_reasoning_desc": "任务运行期间，将快速滚动的思考文本折叠成一行安静的“思考中…”提示。完整思考内容仍会在任务结束后显示。"
   },
   "cloud": {
     "check_browser": "请查看你的浏览器…",
@@ -421,6 +423,7 @@
     "jump_to_latest": "跳到最新",
     "waiting_for_agent": "正在等待 agent…",
     "compacting_context": "正在压缩上下文…",
+    "thinking_hidden": "思考中…",
     "allow_anyway_message": "我已审阅被拦截的 {{name}} 操作 —— 请按原样执行。",
     "temp_folder_failed": "无法创建临时文件夹。",
     "temp_folder_created": "已创建临时文件夹",


### PR DESCRIPTION
Closes #611

## What & why

Reasoning models stream a fast-scrolling "thinking" trace live during a task. At
full write speed it is far too fast for a person to read and floods the transcript.
With no option to hide it, there is excessive text while a task is running.

This PR adds a persisted **"Hide thinking while I work"** Composer setting
(Settings → Composer). When on, the live reasoning stream collapses to a quiet
one-line **"Thinking…"** indicator during a run — so the user still clearly sees
work is ongoing — and the full reasoning still appears in the answer's
"Thought process" disclosure after the turn. Nothing is lost.

Default is **off**, so existing users see no behavior change until they opt in.

## Design note (ongoing-work signal)

Hiding thinking must **not** hide the fact that a task is running. The live
block is therefore replaced by the standard waiting-row affordance ("Thinking…")
rather than removed outright. The waiting row still shows in every phase:
reasoning ("Thinking…"), tool calls / pre-answer ("Waiting for agent…"), and
answer streaming (the streamed bubble). There is never a phase where the user
sees nothing happening.

## Changes

**Backend**
- Persist `hide_reasoning_running` in the manager prefs (getter/setter).
- New `POST /v1/settings/hide-reasoning` endpoint (mirrors `/v1/settings/context-bar`).

**Frontend**
- `api.ts`: `hide_reasoning_running` on `ModelSettings` + `setHideReasoningRunning()`.
- `SettingsView`: new toggle card on the Composer section.
- `App.tsx`: load the pref; when on, gate the live `ThinkingBlock` and show the
  quiet "Thinking…" indicator instead.
- i18n for en + zh.

## Tests (all run + passing locally)

- `e2e/hide-reasoning.spec.ts`:
  - default shows the live thinking block (baseline, unchanged behavior)
  - enabled: collapses live thinking but keeps the ongoing-work indicator
  - finalized reasoning still shows as a "Thought process" disclosure after the turn
  - Settings toggle round-trip persists
- GUI unit suite (181 tests), tsc typecheck, and related e2e specs all green.
