### PR TITLE
test(#506): regression — switching away and back to a running session restores Stop

### DIFF
--- a/surfaces/gui/e2e/turn-state.spec.ts
+++ b/surfaces/gui/e2e/turn-state.spec.ts
@@ -2,6 +2,10 @@
 // whose turn is already running server-side never sees a live `turn_start`, so `running`
 // must be restored from the ws `ready` payload — otherwise the Stop button and the
 // "Waiting for agent" row vanish and the user cannot stop the turn.
+//
+// #506 regression: after switching AWAY from a running session and back, the re-opened
+// session socket's `ready` (carrying server-truth `running`) must restore the Stop
+// button — the composer must never fall back to Send on a live turn.
 import { expect } from "@playwright/test";
 import { test } from "./fixtures";
 
@@ -16,6 +20,28 @@ test("opening a session with a live turn shows Stop and the waiting row", async 
   await expect(page.getByText("Waiting for agent...")).toBeVisible();
 
   // An idle session still gets the plain send arrow (running:false path).
-  await page.getByText("Draft the launch note").first().click();
+  await page.getByTitle("Draft the launch note").first().click();
   await expect(page.getByRole("button", { name: /Stop/ })).toHaveCount(0);
+});
+
+test("switch away and back to a running session restores Stop (regression #506)", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: /Show more/ }).first().click();
+
+  // Running session: Stop replaces Send.
+  await page.getByTitle("Long audit").click();
+  await expect(page.getByRole("button", { name: /Stop/ })).toBeVisible();
+
+  // Switch to an idle session — plain send arrow (this session is idle).
+  await page.getByTitle("Draft the launch note").first().click();
+  await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Stop/ })).toHaveCount(0);
+
+  // Switch BACK to the still-running session: `ready` carries running:true, so Stop
+  // must come back and Send must not (the turn is live and must stay interruptible).
+  await page.getByTitle("Long audit").click();
+  await expect(page.getByRole("button", { name: /Stop/ })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Send" })).toHaveCount(0);
 });


### PR DESCRIPTION
Refs #506

## Summary

The Stop↔Send toggle is driven by the GUI's local `running` flag. When the user
switches to another conversation and back while a turn is live, `running` must be
restored from the reopened session socket's server-truth `ready` payload — or the
composer would fall back to Send on a live turn and the user could no longer stop
it.

The server already sends `running: manager.is_running(session_id)` in `ready` on
every session connect, and the frontend restores `setRunning(d.running)` from it.
Reproducing the exact reported scenario (running session → switch to an idle
session → switch back) locally shows the Stop button is correctly restored.

That underlying server-truth fix (shipped after this issue was filed) resolved the
root cause. This PR adds an **e2e regression test** to lock the correct behavior in
for the future:

- open a running session → Stop is shown
- switch to an idle session → plain Send (correct, this session is idle), Stop gone
- switch back to the still-running session → Stop is restored, Send is not.

If this is acceptable, #506's root cause is already resolved on `main` and the
issue can be closed.

## Tests

`e2e/turn-state.spec.ts` — both tests pass locally (reconnect-mid-turn + the new
switch-away-and-back regression).
