### PR TITLE
fix(codex-auth): let the sign-in callback bind somewhere a container can reach

### DIFF
--- a/coworker/providers/codex_auth.py
+++ b/coworker/providers/codex_auth.py
@@ -27,6 +27,7 @@ import base64
 import hashlib
 import json
 import logging
+import os
 import secrets as pysecrets
 import time
 import uuid
@@ -42,6 +43,13 @@ TOKEN_URL = AUTH_ISSUER + "/oauth/token"
 CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CALLBACK_PORT = 1455
 CALLBACK_PATH = "/auth/callback"
+# Where the callback server listens. Loopback is right for a desktop install — the
+# browser completing the flow is on the same machine. It is wrong for a server one:
+# a container publishes a port to its external interface, and a listener bound to
+# the container's own loopback never sees that traffic, so the redirect lands on a
+# closed port and the sign-in can never finish. Overridable for exactly that case;
+# the redirect below is unaffected, since it describes where the BROWSER goes.
+CALLBACK_HOST_ENV = "COWORKER_OAUTH_CALLBACK_HOST"
 # Registered redirect for CLIENT_ID, verbatim — host and port are not ours to choose.
 REDIRECT_URI = f"http://localhost:{CALLBACK_PORT}{CALLBACK_PATH}"
 SCOPE = "openid profile email offline_access"
@@ -65,6 +73,15 @@ PLAN_LIMIT_ERROR = (
     "5 hours) is used up. Wait for it to reset, upgrade the plan, or switch to an "
     "API-key provider."
 )
+def callback_host() -> str:
+    """Bind address for the loopback callback server (see CALLBACK_HOST_ENV).
+
+    Read per flow, not at import, so a deployment can set it without re-importing —
+    and so tests can exercise both without module surgery.
+    """
+    return os.environ.get(CALLBACK_HOST_ENV) or "127.0.0.1"
+
+
 PORT_BUSY_ERROR = (
     f"Port {CALLBACK_PORT} is already in use — the OpenAI Codex CLI is the usual "
     "holder. Quit it and start the sign-in again."
@@ -361,7 +378,7 @@ async def _start_callback_server(
                 pass
 
     try:
-        server = await asyncio.start_server(handle, "127.0.0.1", CALLBACK_PORT)
+        server = await asyncio.start_server(handle, callback_host(), CALLBACK_PORT)
     except OSError as exc:
         raise CodexAuthError(PORT_BUSY_ERROR) from exc
     return server, future

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -120,6 +120,59 @@ async def _hit_callback(query: str) -> str:
     return data.decode()
 
 
+def test_callback_host_defaults_to_loopback(monkeypatch):
+    monkeypatch.delenv(codex_auth.CALLBACK_HOST_ENV, raising=False)
+    assert codex_auth.callback_host() == "127.0.0.1"
+    # Empty is not a bind address — a blank env var must not become "listen
+    # everywhere", which is the one mistake here that widens exposure silently.
+    monkeypatch.setenv(codex_auth.CALLBACK_HOST_ENV, "")
+    assert codex_auth.callback_host() == "127.0.0.1"
+
+
+class _FakeServer:
+    sockets: tuple = ()
+
+    def close(self):
+        pass
+
+    async def wait_closed(self):
+        pass
+
+
+async def _bind_host_used(monkeypatch) -> str:
+    """The address `_start_callback_server` actually asks asyncio to listen on.
+
+    Asserted through the call rather than by binding for real: the port is fixed at
+    1455, so a machine running the Codex CLI (its usual holder) or a container
+    publishing that port would otherwise fail this test for unrelated reasons.
+    """
+    seen: dict = {}
+
+    async def fake_start_server(handler, host, port):
+        seen.update(host=host, port=port)
+        return _FakeServer()
+
+    monkeypatch.setattr(codex_auth.asyncio, "start_server", fake_start_server)
+    server, future = await codex_auth._start_callback_server("state-1")
+    future.cancel()
+    assert seen["port"] == codex_auth.CALLBACK_PORT
+    return seen["host"]
+
+
+async def test_callback_server_binds_loopback_by_default(monkeypatch):
+    monkeypatch.delenv(codex_auth.CALLBACK_HOST_ENV, raising=False)
+    assert await _bind_host_used(monkeypatch) == "127.0.0.1"
+
+
+async def test_callback_server_honours_the_bind_override(monkeypatch):
+    """A container publishes a port to its external interface; a server bound to the
+    container's own loopback never sees that traffic, so the redirect lands on a closed
+    port. The registered redirect URI is unaffected — it says where the BROWSER goes."""
+    monkeypatch.setenv(codex_auth.CALLBACK_HOST_ENV, "0.0.0.0")
+    assert await _bind_host_used(monkeypatch) == "0.0.0.0"
+    assert codex_auth.REDIRECT_URI == "http://localhost:1455/auth/callback"
+
+
 async def test_sign_in_full_flow(tmp_path, monkeypatch):
     secrets = SecretStore(tmp_path / "s.json")
     opened: dict = {}


### PR DESCRIPTION
## The bug

`_start_callback_server` binds the sign-in callback to `127.0.0.1`:

```python
server = await asyncio.start_server(handle, "127.0.0.1", CALLBACK_PORT)
```

On a desktop install that's exactly right — the browser completing the flow is on the
same machine. On a server install it cannot work. A container publishes a port to the
container's **external** interface; a listener on the container's own loopback never
sees that traffic. So the browser is redirected to `http://localhost:1455/auth/callback`,
hits a closed port, and the flow sits until `FLOW_TIMEOUT_SECONDS` (300s) gives up.

The effect: ChatGPT-subscription sign-in cannot be completed in any containerized
deployment — including the `docker/` recipe in this repo. There's no error to read
either; the browser shows a connection failure and the app just waits.

## Reproduction

```bash
# in any container that publishes 1455 (docker run -p 1455:1455 …)
curl -s -X POST -H "X-OpenWorker-Token: $TOKEN" localhost:8765/v1/providers/openai-codex/signin
curl -sv "http://localhost:1455/auth/callback?code=x&state=y"   # connection refused
```

With `COWORKER_OAUTH_CALLBACK_HOST=0.0.0.0` the same request reaches the handler and
gets its "Nothing waiting for this sign-in" 400 — i.e. the server is now reachable, and
the real redirect completes.

We hit this running the engine headless on a Raspberry Pi and have been working around
it with a small TCP forwarder inside the image, which is a silly thing for a deployment
to have to carry.

## The change

- `COWORKER_OAUTH_CALLBACK_HOST`, read per flow (not at import), default `127.0.0.1`.
- An empty value falls back to loopback rather than becoming "listen everywhere" — the
  one mistake here that widens exposure silently.
- `REDIRECT_URI` is untouched. It describes where the *browser* goes, so the registered
  redirect for `CLIENT_ID` stays valid and nothing needs re-registering.

Nothing changes for desktop users unless they set the variable.

## On the security of the non-default path

Binding beyond loopback exposes the callback endpoint for the ~2 minutes a flow is
live. The existing handler already defends the part that matters: `state` is compared
with `compare_digest`, and a mismatch answers 400 **without** consuming the flow, so a
stray hit can't resolve or cancel a sign-in. Opting in is a deployment's decision, which
is why it's an env var and not a new default.

## Tests

`test_callback_host_defaults_to_loopback`, `test_callback_server_binds_loopback_by_default`,
`test_callback_server_honours_the_bind_override` — the last fails against `main`.

They assert the address through the `start_server` call rather than by binding for real,
deliberately: the port is fixed at 1455, so a machine running the Codex CLI (the usual
holder, per `PORT_BUSY_ERROR`) or a container publishing that port fails a real bind for
unrelated reasons. Worth noting the existing sign-in tests do bind it, and on such a
machine they block for the full 300s flow timeout rather than failing fast.