### PR TITLE
Fix accidental send when confirming IME composition

### DIFF
--- a/surfaces/gui/src/components/Composer.skills.test.tsx
+++ b/surfaces/gui/src/components/Composer.skills.test.tsx
@@ -47,6 +47,31 @@ afterEach(() => {
 });
 
 describe("Composer / skills popup", () => {
+  it("does not send when Enter confirms IME composition", async () => {
+    stubFetch();
+    const p = props();
+    render(<Composer {...p} />);
+    fireEvent.change(box(), { target: { value: "你好" } });
+
+    fireEvent.keyDown(box(), { key: "Enter", isComposing: true });
+    expect(p.onSend).not.toHaveBeenCalled();
+    expect((box() as HTMLTextAreaElement).value).toBe("你好");
+
+    fireEvent.keyDown(box(), { key: "Enter" });
+    await waitFor(() => expect(p.onSend).toHaveBeenCalledWith("你好", [], undefined));
+  });
+
+  it("does not send for WebKit's legacy IME key code", () => {
+    stubFetch();
+    const p = props();
+    render(<Composer {...p} />);
+    fireEvent.change(box(), { target: { value: "你好" } });
+
+    fireEvent.keyDown(box(), { key: "Enter", keyCode: 229 });
+    expect(p.onSend).not.toHaveBeenCalled();
+    expect((box() as HTMLTextAreaElement).value).toBe("你好");
+  });
+
   it("opens on a leading '/' and lists only enabled skills from the effective menu", async () => {
     stubFetch();
     render(<Composer {...props()} />);

--- a/surfaces/gui/src/components/Composer.tsx
+++ b/surfaces/gui/src/components/Composer.tsx
@@ -402,6 +402,11 @@ export function Composer(props: Props) {
   };
 
   const onKey = (e: React.KeyboardEvent) => {
+    // Enter confirms the active IME candidate before it means "send". WebKit may
+    // report the composition keydown with the legacy 229 key code, so keep that
+    // fallback alongside the standards-based isComposing flag.
+    if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+
     if (slashQuery !== null) {
       if (e.key === "ArrowDown") {
         e.preventDefault();


### PR DESCRIPTION
> Restores #575. GitHub automatically closed the original PR when its source fork was temporarily made private. This replacement preserves the original change.

## Summary

- ignore composer key events while an IME composition is active
- include the WebKit/Safari `keyCode === 229` compatibility fallback
- add regressions for standards-based composition and the WebKit fallback

This prevents Enter from submitting a message when it is only confirming Chinese, Japanese, or Korean input. The guard runs before slash-command keyboard handling so composition confirmation cannot accidentally select or submit a command either.

## Tests

- `npm test -- --run src/components/Composer.skills.test.tsx`
- `NODE_OPTIONS=--localstorage-file=/tmp/openworker-ime-pr-vitest-storage npm test` (136 passed)
- `npm run build`
