### PR TITLE
fix(server): auto-title sessions in the user's language

### DIFF
--- a/coworker/server/manager.py
+++ b/coworker/server/manager.py
@@ -5211,13 +5211,20 @@ class SessionManager:
         ]
 
     # -- LLM auto-titles (FB-010) -------------------------------------------------
+    # The title must speak the user's language: with no language pinned, an English
+    # instruction ("4-5 word title") yields English titles for Chinese/Japanese/…
+    # sessions. Same-language also relaxes the word count to a length that is natural
+    # for the opener's script (CJK titles are a few characters, not 4-5 "words").
     _AUTOTITLE_PROMPT = (
         "You title chat sessions. Given the user's opening message(s) — and, when "
-        "present, the assistant's first reply for context — reply with ONLY a 4-5 word "
-        "title for the session, named after what the session is actually about — no "
-        "quotes or punctuation wrapping it. If there is no topic at all ("
-        '"hey", "how are you", "hi there" and a generic reply), reply with exactly: '
-        "small-talk"
+        "present, the assistant's first reply for context — reply with ONLY a short "
+        "title for the session, named after what the session is actually about. "
+        "Write the title in the same language as the user's opening message "
+        "(4-5 words for English; the natural equivalent brevity for other "
+        "languages) — no quotes or punctuation wrapping it. If there is no topic "
+        "at all ("
+        '"hey", "how are you", "hi there" and a generic reply), reply with '
+        "exactly: small-talk"
     )
 
     def _maybe_autotitle(self, session_id: str) -> None:

--- a/tests/test_autotitle.py
+++ b/tests/test_autotitle.py
@@ -173,3 +173,38 @@ def test_turn_start_titles_before_the_turn_completes(tmp_path):
         assert mgr._autotitle_attempts[sid] == 1
 
     asyncio.run(go())
+
+
+async def test_title_call_pins_the_opener_language(tmp_path):
+    # With no language pinned in the titling instruction, an English system prompt
+    # ("4-5 word title") biases the model toward English titles even for non-English
+    # sessions. The prompt must tell the model to match the opener's language.
+    mgr, provider = _mgr(tmp_path, [_text("好的")], ["日本行程规划"])
+    await _turn(mgr, "lang1", "帮我规划一下日本的旅行")
+
+    system = provider.title_calls[0][0]["content"]
+    assert "same language as the user's opening message" in system
+
+
+async def test_non_english_opener_keeps_non_english_title(tmp_path):
+    # End to end: a CJK title survives the sanitizer (whitespace collapse and quote
+    # strip don't touch CJK) and the 80-char absurdity cap, and is stored verbatim.
+    mgr, _ = _mgr(tmp_path, [_text("好的，我来帮你安排")], ["日本行程规划"])
+    await _turn(mgr, "lang2", "帮我规划一下日本的旅行")
+    assert mgr.session_store.load("lang2").title == "日本行程规划"
+
+
+async def test_non_english_small_talk_still_hits_the_sentinel(tmp_path):
+    # The sentinel is a fixed English token regardless of the session's language;
+    # normalization must keep catching it after the prompt rewording.
+    mgr, provider = _mgr(
+        tmp_path,
+        [_text("你好呀"), _text("在的")],
+        ["small-talk", "季度汇报整理"],
+    )
+    await _turn(mgr, "lang3", "你好")
+    assert mgr.session_store.title_state("lang3")["auto_title"] is None
+
+    await _turn(mgr, "lang3", "帮我整理季度汇报")
+    assert len(provider.title_calls) == 2
+    assert mgr.session_store.load("lang3").title == "季度汇报整理"


### PR DESCRIPTION
## Problem

Session auto-titles come out in English even when the conversation is entirely in another language. The titling prompt (`_AUTOTITLE_PROMPT`) is written in English, asks for a **`4-5 word`** title, and never pins an output language — so the model defaults to English for zh/ja/ko/… sessions. The word count itself is also English-scale: a natural Chinese title is a few characters, not 4-5 words.

## Change

One prompt rewording, no behavior plumbing touched:

- The title must be written **in the same language as the user's opening message**.
- The 4-5 word count becomes an English-scale hint, with "the natural equivalent brevity for other languages" elsewhere.
- The `small-talk` sentinel stays the fixed English token it always was (the existing normalization already tolerates casing/punctuation riffs), so sentinel detection and the single-retry flow are unchanged.

## Tests

Three additions to `tests/test_autotitle.py` (suite: 11 passed):

1. `test_title_call_pins_the_opener_language` — regression-guards the same-language instruction in the title call's system prompt.
2. `test_non_english_opener_keeps_non_english_title` — end to end: a CJK title survives the sanitizer (whitespace/quote handling) and the 80-char cap, stored verbatim.
3. `test_non_english_small_talk_still_hits_the_sentinel` — a non-English small-talk opener still hits the sentinel and earns its single retry.

The prompt keeps the "You title chat sessions" opening, so the title-call recognizer in `tests/test_server.py` needed no change.

`tests/test_ui_refresh_e2e.py` fails identically on clean `main` in this environment (needs built GUI assets) — unaffected by this change.

## Context

Follows the i18n line of #127 (GUI localization) and #468 (output-language control): user-visible generated text should speak the user's language.